### PR TITLE
Fix invalid Jinja syntax in staging model generation

### DIFF
--- a/models/commissioning/staging/stg_epd_pc_activesubmission.sql
+++ b/models/commissioning/staging/stg_epd_pc_activesubmission.sql
@@ -1,8 +1,6 @@
 -- Staging model for epd_primary_care.ActiveSubmission
 -- Source: "DATA_LAKE"."EPD_PRIMARY_CARE"
-{% if source.get('description') %}
 -- Description: Primary care medications and prescribing data
-{% endif %}
 
 select
     "UniqSubmissionId" as uniqsubmissionid

--- a/models/commissioning/staging/stg_epd_pc_meds.sql
+++ b/models/commissioning/staging/stg_epd_pc_meds.sql
@@ -1,8 +1,6 @@
 -- Staging model for epd_primary_care.Meds
 -- Source: "DATA_LAKE"."EPD_PRIMARY_CARE"
-{% if source.get('description') %}
 -- Description: Primary care medications and prescribing data
-{% endif %}
 
 select
     "AgeBands" as agebands,

--- a/models/commissioning/staging/stg_epd_pc_medsheader.sql
+++ b/models/commissioning/staging/stg_epd_pc_medsheader.sql
@@ -1,8 +1,6 @@
 -- Staging model for epd_primary_care.MedsHeader
 -- Source: "DATA_LAKE"."EPD_PRIMARY_CARE"
-{% if source.get('description') %}
 -- Description: Primary care medications and prescribing data
-{% endif %}
 
 select
     "DatSerVer" as datserver,

--- a/models/commissioning/staging/stg_sus_apc_customerrfa.sql
+++ b/models/commissioning/staging/stg_sus_apc_customerrfa.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.CustomerRfa
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "PRIMARYKEY_ID" as primarykey_id,

--- a/models/commissioning/staging/stg_sus_apc_episodes_derived.sql
+++ b/models/commissioning/staging/stg_sus_apc_episodes_derived.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.episodes.derived
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "dmicICBResidenceSubmitted" as dmicicbresidencesubmitted,

--- a/models/commissioning/staging/stg_sus_apc_insertdeletelog.sql
+++ b/models/commissioning/staging/stg_sus_apc_insertdeletelog.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.InsertDeleteLog
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "PRIMARYKEY_ID" as primarykey_id,

--- a/models/commissioning/staging/stg_sus_apc_spell.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "spell.patient.registration_derived.responsible_ccg_from_pds" as spell_patient_registration_derived_responsible_ccg_from_pds,

--- a/models/commissioning/staging/stg_sus_apc_spell_commissioning_grouping_unbundled_hrg.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_commissioning_grouping_unbundled_hrg.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.commissioning.grouping.unbundled_hrg
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_commissioning_service_agreements.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_commissioning_service_agreements.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.commissioning.service_agreements
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "commissioner_assignment_period_end_date" as commissioner_assignment_period_end_date,

--- a/models/commissioning/staging/stg_sus_apc_spell_commissioning_tariff_calculation_exclusion_reasons.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_commissioning_tariff_calculation_exclusion_reasons.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.commissioning.tariff_calculation.exclusion_reasons
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.critical_care_consolidated
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated_allocated_episodes.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated_allocated_episodes.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.critical_care_consolidated.allocated_episodes
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated_allocated_episodes_daily_activities.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated_allocated_episodes_daily_activities.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.critical_care_consolidated.allocated_episodes.daily_activities
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated_allocated_episodes_daily_activities_codes.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated_allocated_episodes_daily_activities_codes.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.critical_care_consolidated.allocated_episodes.daily_activities.codes
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "DAILY_ACTIVITIES_ID" as daily_activities_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated_allocated_episodes_daily_activities_high_cost_drugs.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated_allocated_episodes_daily_activities_high_cost_drugs.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.critical_care_consolidated.allocated_episodes.daily_activities.high_cost_drugs
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated_allocated_episodes_daily_activities_organ_systems_supported.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_critical_care_consolidated_allocated_episodes_daily_activities_organ_systems_supported.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.critical_care_consolidated.allocated_episodes.daily_activities.organ_systems_supported
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_derived.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_derived.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.derived
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "dmicSubICBResidenceSubmitted" as dmicsubicbresidencesubmitted,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "commissioning.grouping.code_cleaning_applied" as commissioning_grouping_code_cleaning_applied,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_births.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_births.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.births
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_care_location.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_care_location.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.care_location
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "end_date" as end_date,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_care_professionals.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_care_professionals.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.care_professionals
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "professional_registration_identifier" as professional_registration_identifier,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_coded_scored_assessments.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_coded_scored_assessments.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.clinical_coding.coded_scored_assessments
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_comorbidities.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_comorbidities.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.clinical_coding.comorbidities
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_diagnosis_icd.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_diagnosis_icd.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.clinical_coding.diagnosis.icd
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "present_on_admission" as present_on_admission,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_diagnosis_read.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_diagnosis_read.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.clinical_coding.diagnosis.read
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_diagnosis_snomed.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_diagnosis_snomed.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.clinical_coding.diagnosis.snomed
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_findings.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_findings.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.clinical_coding.findings
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_fit_notes.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_fit_notes.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.clinical_coding.fit_notes
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_observations.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_observations.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.clinical_coding.observations
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_procedure_opcs.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_procedure_opcs.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.clinical_coding.procedure.opcs
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "dmicImportLogId" as dmicimportlogid,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_procedure_snomed.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_clinical_coding_procedure_snomed.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.clinical_coding.procedure.snomed
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_commissioning_grouping_unbundled_hrg.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_commissioning_grouping_unbundled_hrg.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.commissioning.grouping.unbundled_hrg
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_commissioning_service_agreements.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_commissioning_service_agreements.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.commissioning.service_agreements
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "commissioner_assignment_period_end_date" as commissioner_assignment_period_end_date,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_commissioning_tariff_calculation_exclusion_reasons.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_commissioning_tariff_calculation_exclusion_reasons.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.commissioning.tariff_calculation.exclusion_reasons
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_critical_care_submitted.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_critical_care_submitted.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.critical_care_submitted
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_critical_care_submitted_daily_activities.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_critical_care_submitted_daily_activities.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.critical_care_submitted.daily_activities
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_critical_care_submitted_daily_activities_codes.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_critical_care_submitted_daily_activities_codes.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.critical_care_submitted.daily_activities.codes
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_critical_care_submitted_daily_activities_high_cost_drugs.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_critical_care_submitted_daily_activities_high_cost_drugs.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.critical_care_submitted.daily_activities.high_cost_drugs
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_critical_care_submitted_daily_activities_organ_systems_supported.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_critical_care_submitted_daily_activities_organ_systems_supported.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.critical_care_submitted.daily_activities.organ_systems_supported
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_home_leave.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_home_leave.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.home_leave
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_patient_overseas_visitor.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_patient_overseas_visitor.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.patient.overseas_visitor
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_patient_overseas_visitor_charging_category.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_patient_overseas_visitor_charging_category.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.patient.overseas_visitor_charging_category
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_patient_social_and_personal_circumstances.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_patient_social_and_personal_circumstances.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.patient.social_and_personal_circumstances
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_apc_spell_episodes_system_transaction_cds_copy_recipients.sql
+++ b/models/commissioning/staging/stg_sus_apc_spell_episodes_system_transaction_cds_copy_recipients.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.spell.episodes.system.transaction.cds_copy_recipients
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "EPISODES_ID" as episodes_id,

--- a/models/commissioning/staging/stg_sus_apc_system_transaction_cds_recipients.sql
+++ b/models/commissioning/staging/stg_sus_apc_system_transaction_cds_recipients.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_apc.system.transaction.cds_recipients
 -- Source: "DATA_LAKE"."SUS_UNIFIED_APC"
-{% if source.get('description') %}
 -- Description: SUS admitted patient care episodes and procedures
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_op_appointment.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_op_appointment_care_professionals.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_care_professionals.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.care_professionals
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "professional_registration_identifier" as professional_registration_identifier,

--- a/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_coded_scored_assessments.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_coded_scored_assessments.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.clinical_coding.coded_scored_assessments
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_comorbidities.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_comorbidities.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.clinical_coding.comorbidities
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_diagnosis_icd.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_diagnosis_icd.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.clinical_coding.diagnosis.icd
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "code" as code,

--- a/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_diagnosis_read.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_diagnosis_read.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.clinical_coding.diagnosis.read
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_diagnosis_snomed.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_diagnosis_snomed.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.clinical_coding.diagnosis.snomed
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_findings.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_findings.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.clinical_coding.findings
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_fit_notes.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_fit_notes.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.clinical_coding.fit_notes
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_observations.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_observations.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.clinical_coding.observations
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_procedure_opcs.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_procedure_opcs.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.clinical_coding.procedure.opcs
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "dmicImportLogId" as dmicimportlogid,

--- a/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_procedure_snomed.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_clinical_coding_procedure_snomed.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.clinical_coding.procedure.snomed
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_op_appointment_commissioning_grouping_unbundled_hrg.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_commissioning_grouping_unbundled_hrg.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.commissioning.grouping.unbundled_hrg
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "multiple_applies" as multiple_applies,

--- a/models/commissioning/staging/stg_sus_op_appointment_commissioning_service_agreements.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_commissioning_service_agreements.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.commissioning.service_agreements
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "service_code" as service_code,

--- a/models/commissioning/staging/stg_sus_op_appointment_commissioning_tariff_calculation_exclusion_reasons.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_commissioning_tariff_calculation_exclusion_reasons.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.commissioning.tariff_calculation.exclusion_reasons
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "EXCLUSION_REASONS_ID" as exclusion_reasons_id,

--- a/models/commissioning/staging/stg_sus_op_appointment_patient_social_and_personal_circumstances.sql
+++ b/models/commissioning/staging/stg_sus_op_appointment_patient_social_and_personal_circumstances.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.appointment.patient.social_and_personal_circumstances
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "ROWNUMBER_ID" as rownumber_id,

--- a/models/commissioning/staging/stg_sus_op_customerrfa.sql
+++ b/models/commissioning/staging/stg_sus_op_customerrfa.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.CustomerRFA
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "dmicDerivedCCGofResidence" as dmicderivedccgofresidence,

--- a/models/commissioning/staging/stg_sus_op_derived.sql
+++ b/models/commissioning/staging/stg_sus_op_derived.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.derived
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "PRIMARYKEY_ID" as primarykey_id,

--- a/models/commissioning/staging/stg_sus_op_insertdeletelog.sql
+++ b/models/commissioning/staging/stg_sus_op_insertdeletelog.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.InsertDeleteLog
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "PRIMARYKEY_ID" as primarykey_id,

--- a/models/commissioning/staging/stg_sus_op_system_transaction_cds_copy_recipients.sql
+++ b/models/commissioning/staging/stg_sus_op_system_transaction_cds_copy_recipients.sql
@@ -1,8 +1,6 @@
 -- Staging model for sus_op.system.transaction.cds_copy_recipients
 -- Source: "DATA_LAKE"."SUS_UNIFIED_OP"
-{% if source.get('description') %}
 -- Description: SUS outpatient appointments and activity
-{% endif %}
 
 select
     "CDS_COPY_RECIPIENTS_ID" as cds_copy_recipients_id,

--- a/models/commissioning/staging/stg_wl_wl_asicasras_data.sql
+++ b/models/commissioning/staging/stg_wl_wl_asicasras_data.sql
@@ -1,8 +1,6 @@
 -- Staging model for wl.WL_AsiCasRas_Data
 -- Source: "DATA_LAKE"."WL"
-{% if source.get('description') %}
 -- Description: Waiting lists and patient pathway data
-{% endif %}
 
 select
     "DATE_AND_TIME_DATA_SET_CREATED" as date_and_time_data_set_created,

--- a/models/commissioning/staging/stg_wl_wl_clockstarts_data.sql
+++ b/models/commissioning/staging/stg_wl_wl_clockstarts_data.sql
@@ -1,8 +1,6 @@
 -- Staging model for wl.WL_ClockStarts_Data
 -- Source: "DATA_LAKE"."WL"
-{% if source.get('description') %}
 -- Description: Waiting lists and patient pathway data
-{% endif %}
 
 select
     "DATE_AND_TIME_DATA_SET_CREATED" as date_and_time_data_set_created,

--- a/models/commissioning/staging/stg_wl_wl_clockstops_data.sql
+++ b/models/commissioning/staging/stg_wl_wl_clockstops_data.sql
@@ -1,8 +1,6 @@
 -- Staging model for wl.WL_ClockStops_Data
 -- Source: "DATA_LAKE"."WL"
-{% if source.get('description') %}
 -- Description: Waiting lists and patient pathway data
-{% endif %}
 
 select
     "DATE_AND_TIME_DATA_SET_CREATED" as date_and_time_data_set_created,

--- a/models/commissioning/staging/stg_wl_wl_diagnostics_data.sql
+++ b/models/commissioning/staging/stg_wl_wl_diagnostics_data.sql
@@ -1,8 +1,6 @@
 -- Staging model for wl.WL_Diagnostics_Data
 -- Source: "DATA_LAKE"."WL"
-{% if source.get('description') %}
 -- Description: Waiting lists and patient pathway data
-{% endif %}
 
 select
     "DATE_AND_TIME_DATA_SET_CREATED" as date_and_time_data_set_created,

--- a/models/commissioning/staging/stg_wl_wl_openpathways_data.sql
+++ b/models/commissioning/staging/stg_wl_wl_openpathways_data.sql
@@ -1,8 +1,6 @@
 -- Staging model for wl.WL_OpenPathways_Data
 -- Source: "DATA_LAKE"."WL"
-{% if source.get('description') %}
 -- Description: Waiting lists and patient pathway data
-{% endif %}
 
 select
     "DATE_AND_TIME_DATA_SET_CREATED" as date_and_time_data_set_created,

--- a/models/commissioning/staging/stg_wl_wl_pifu_data.sql
+++ b/models/commissioning/staging/stg_wl_wl_pifu_data.sql
@@ -1,8 +1,6 @@
 -- Staging model for wl.WL_PIFU_Data
 -- Source: "DATA_LAKE"."WL"
-{% if source.get('description') %}
 -- Description: Waiting lists and patient pathway data
-{% endif %}
 
 select
     "DATE_AND_TIME_DATA_SET_CREATED" as date_and_time_data_set_created,

--- a/models/commissioning/staging/stg_wl_wl_submissionlog_data.sql
+++ b/models/commissioning/staging/stg_wl_wl_submissionlog_data.sql
@@ -1,8 +1,6 @@
 -- Staging model for wl.WL_SubmissionLog_Data
 -- Source: "DATA_LAKE"."WL"
-{% if source.get('description') %}
 -- Description: Waiting lists and patient pathway data
-{% endif %}
 
 select
     "derSubmissionID" as dersubmissionid,

--- a/models/shared/staging/stg_dictionary_activitylocationtype.sql
+++ b/models/shared/staging/stg_dictionary_activitylocationtype.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ActivityLocationType
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ActivityLocationTypeID" as sk_activitylocationtypeid,

--- a/models/shared/staging/stg_dictionary_admincategories.sql
+++ b/models/shared/staging/stg_dictionary_admincategories.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.AdminCategories
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_AdminCategoryID" as sk_admincategoryid,

--- a/models/shared/staging/stg_dictionary_age.sql
+++ b/models/shared/staging/stg_dictionary_age.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Age
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_AgeID" as sk_ageid,

--- a/models/shared/staging/stg_dictionary_ageband.sql
+++ b/models/shared/staging/stg_dictionary_ageband.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.AgeBand
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_AgeBandID" as sk_agebandid,

--- a/models/shared/staging/stg_dictionary_ageband_agebandgp_lookup.sql
+++ b/models/shared/staging/stg_dictionary_ageband_agebandgp_lookup.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.AgeBand_AgeBandGP_Lookup
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_AgeBandID" as sk_agebandid,

--- a/models/shared/staging/stg_dictionary_ageband_gp.sql
+++ b/models/shared/staging/stg_dictionary_ageband_gp.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.AgeBand_GP
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_AgeBandGPID" as sk_agebandgpid,

--- a/models/shared/staging/stg_dictionary_allspgs.sql
+++ b/models/shared/staging/stg_dictionary_allspgs.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.AllSPGs
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ServiceProviderGroupID" as sk_serviceprovidergroupid,

--- a/models/shared/staging/stg_dictionary_bnf_chapter.sql
+++ b/models/shared/staging/stg_dictionary_bnf_chapter.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.BNF_Chapter
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_BNFChapterID" as sk_bnfchapterid,

--- a/models/shared/staging/stg_dictionary_bnf_hierarchy.sql
+++ b/models/shared/staging/stg_dictionary_bnf_hierarchy.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.BNF_Hierarchy
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_BNFID" as sk_bnfid,

--- a/models/shared/staging/stg_dictionary_bnf_substance_product_presentation.sql
+++ b/models/shared/staging/stg_dictionary_bnf_substance_product_presentation.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.BNF_Substance_Product_Presentation
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_BNFID" as sk_bnfid,

--- a/models/shared/staging/stg_dictionary_carersupportindicator.sql
+++ b/models/shared/staging/stg_dictionary_carersupportindicator.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.CarerSupportIndicator
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_CarerSupportIndicatorID" as sk_carersupportindicatorid,

--- a/models/shared/staging/stg_dictionary_ccgbypractice.sql
+++ b/models/shared/staging/stg_dictionary_ccgbypractice.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.CCGByPractice
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ServiceProviderID" as sk_serviceproviderid,

--- a/models/shared/staging/stg_dictionary_ccgbypracticenational.sql
+++ b/models/shared/staging/stg_dictionary_ccgbypracticenational.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.CCGByPracticeNational
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ServiceProviderID" as sk_serviceproviderid,

--- a/models/shared/staging/stg_dictionary_commissioner.sql
+++ b/models/shared/staging/stg_dictionary_commissioner.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Commissioner
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_CommissionerID" as sk_commissionerid,

--- a/models/shared/staging/stg_dictionary_commissionermatrix.sql
+++ b/models/shared/staging/stg_dictionary_commissionermatrix.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.CommissionerMatrix
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_CommissionerID" as sk_commissionerid,

--- a/models/shared/staging/stg_dictionary_commissionermatrixnational.sql
+++ b/models/shared/staging/stg_dictionary_commissionermatrixnational.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.CommissionerMatrixNational
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_CommissionerID" as sk_commissionerid,

--- a/models/shared/staging/stg_dictionary_commissionerpctccg.sql
+++ b/models/shared/staging/stg_dictionary_commissionerpctccg.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.CommissionerPCTCCG
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_CommissionerID_PCT" as sk_commissionerid_pct,

--- a/models/shared/staging/stg_dictionary_commissioninglocation.sql
+++ b/models/shared/staging/stg_dictionary_commissioninglocation.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.CommissioningLocation
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_CCGLocationId" as sk_ccglocationid,

--- a/models/shared/staging/stg_dictionary_consultant.sql
+++ b/models/shared/staging/stg_dictionary_consultant.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Consultant
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ConsultantID" as sk_consultantid,

--- a/models/shared/staging/stg_dictionary_consultantprovider.sql
+++ b/models/shared/staging/stg_dictionary_consultantprovider.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ConsultantProvider
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ConsultantID" as sk_consultantid,

--- a/models/shared/staging/stg_dictionary_costband.sql
+++ b/models/shared/staging/stg_dictionary_costband.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.CostBand
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_CostBandID" as sk_costbandid,

--- a/models/shared/staging/stg_dictionary_datebankholiday.sql
+++ b/models/shared/staging/stg_dictionary_datebankholiday.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.DateBankHoliday
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_Date" as sk_date,

--- a/models/shared/staging/stg_dictionary_dates.sql
+++ b/models/shared/staging/stg_dictionary_dates.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Dates
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_Date" as sk_date,

--- a/models/shared/staging/stg_dictionary_dates_month_year.sql
+++ b/models/shared/staging/stg_dictionary_dates_month_year.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Dates_Month_Year
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_YearMonth" as sk_yearmonth,

--- a/models/shared/staging/stg_dictionary_datetimes.sql
+++ b/models/shared/staging/stg_dictionary_datetimes.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.DateTimes
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_DateTime" as sk_datetime,

--- a/models/shared/staging/stg_dictionary_diagnosis.sql
+++ b/models/shared/staging/stg_dictionary_diagnosis.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Diagnosis
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_DiagnosisID" as sk_diagnosisid,

--- a/models/shared/staging/stg_dictionary_electoralward.sql
+++ b/models/shared/staging/stg_dictionary_electoralward.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ElectoralWard
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ElectoralWardID" as sk_electoralwardid,

--- a/models/shared/staging/stg_dictionary_ethnicity.sql
+++ b/models/shared/staging/stg_dictionary_ethnicity.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Ethnicity
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_EthnicityID" as sk_ethnicityid,

--- a/models/shared/staging/stg_dictionary_ethnicity2.sql
+++ b/models/shared/staging/stg_dictionary_ethnicity2.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Ethnicity2
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_EthnicityID" as sk_ethnicityid,

--- a/models/shared/staging/stg_dictionary_ethnicitycode.sql
+++ b/models/shared/staging/stg_dictionary_ethnicitycode.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.EthnicityCode
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_EthnicityID" as sk_ethnicityid,

--- a/models/shared/staging/stg_dictionary_f_alevel.sql
+++ b/models/shared/staging/stg_dictionary_f_alevel.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.F&ALevel
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_LevelID" as sk_levelid,

--- a/models/shared/staging/stg_dictionary_f_amapping.sql
+++ b/models/shared/staging/stg_dictionary_f_amapping.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.F&AMapping
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_PODID" as sk_podid,

--- a/models/shared/staging/stg_dictionary_f_aparentchild.sql
+++ b/models/shared/staging/stg_dictionary_f_aparentchild.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.F&AParentChild
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_PARENT_PODID" as sk_parent_podid,

--- a/models/shared/staging/stg_dictionary_gender.sql
+++ b/models/shared/staging/stg_dictionary_gender.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Gender
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_GenderID" as sk_genderid,

--- a/models/shared/staging/stg_dictionary_gp.sql
+++ b/models/shared/staging/stg_dictionary_gp.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.GP
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_GPID" as sk_gpid,

--- a/models/shared/staging/stg_dictionary_hrg.sql
+++ b/models/shared/staging/stg_dictionary_hrg.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.HRG
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_HRGID" as sk_hrgid,

--- a/models/shared/staging/stg_dictionary_hrgtrimpoint.sql
+++ b/models/shared/staging/stg_dictionary_hrgtrimpoint.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.HRGTrimPoint
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_HRGID" as sk_hrgid,

--- a/models/shared/staging/stg_dictionary_hrgtrimpoint_pivoted.sql
+++ b/models/shared/staging/stg_dictionary_hrgtrimpoint_pivoted.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.HRGTrimPoint_Pivoted
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_HRGID" as sk_hrgid,

--- a/models/shared/staging/stg_dictionary_language.sql
+++ b/models/shared/staging/stg_dictionary_language.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Language
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_LanguageID" as sk_languageid,

--- a/models/shared/staging/stg_dictionary_maincommissionerprovider.sql
+++ b/models/shared/staging/stg_dictionary_maincommissionerprovider.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.MainCommissionerProvider
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID_Commissioner" as sk_organisationid_commissioner,

--- a/models/shared/staging/stg_dictionary_onsareacollections.sql
+++ b/models/shared/staging/stg_dictionary_onsareacollections.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ONSAreaCollections
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_AreaCollectionID" as sk_areacollectionid,

--- a/models/shared/staging/stg_dictionary_onscodeequivalent.sql
+++ b/models/shared/staging/stg_dictionary_onscodeequivalent.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ONSCodeEquivalent
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "Geography_Code" as geography_code,

--- a/models/shared/staging/stg_dictionary_operationstatus.sql
+++ b/models/shared/staging/stg_dictionary_operationstatus.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OperationStatus
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OperationStatusID" as sk_operationstatusid,

--- a/models/shared/staging/stg_dictionary_organisation.sql
+++ b/models/shared/staging/stg_dictionary_organisation.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Organisation
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID" as sk_organisationid,

--- a/models/shared/staging/stg_dictionary_organisationdescendent.sql
+++ b/models/shared/staging/stg_dictionary_organisationdescendent.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationDescendent
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID_Root" as sk_organisationid_root,

--- a/models/shared/staging/stg_dictionary_organisationformername.sql
+++ b/models/shared/staging/stg_dictionary_organisationformername.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationFormerName
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID" as sk_organisationid,

--- a/models/shared/staging/stg_dictionary_organisationhierarchypractice.sql
+++ b/models/shared/staging/stg_dictionary_organisationhierarchypractice.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationHierarchyPractice
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID" as sk_organisationid,

--- a/models/shared/staging/stg_dictionary_organisationlookup.sql
+++ b/models/shared/staging/stg_dictionary_organisationlookup.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationLookup
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID" as sk_organisationid,

--- a/models/shared/staging/stg_dictionary_organisationmatrixcommissioner.sql
+++ b/models/shared/staging/stg_dictionary_organisationmatrixcommissioner.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationMatrixCommissioner
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID_Commissioner" as sk_organisationid_commissioner,

--- a/models/shared/staging/stg_dictionary_organisationmatrixcommissionerview.sql
+++ b/models/shared/staging/stg_dictionary_organisationmatrixcommissionerview.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationMatrixCommissionerView
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID_Commissioner" as sk_organisationid_commissioner,

--- a/models/shared/staging/stg_dictionary_organisationmatrixpractice.sql
+++ b/models/shared/staging/stg_dictionary_organisationmatrixpractice.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationMatrixPractice
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID_Practice" as sk_organisationid_practice,

--- a/models/shared/staging/stg_dictionary_organisationmatrixpracticeview.sql
+++ b/models/shared/staging/stg_dictionary_organisationmatrixpracticeview.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationMatrixPracticeView
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID_Practice" as sk_organisationid_practice,

--- a/models/shared/staging/stg_dictionary_organisationonscode.sql
+++ b/models/shared/staging/stg_dictionary_organisationonscode.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationONSCode
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID" as sk_organisationid,

--- a/models/shared/staging/stg_dictionary_organisationrelationship.sql
+++ b/models/shared/staging/stg_dictionary_organisationrelationship.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationRelationship
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID" as sk_organisationid,

--- a/models/shared/staging/stg_dictionary_organisationrelationshiptype.sql
+++ b/models/shared/staging/stg_dictionary_organisationrelationshiptype.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationRelationshipType
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "Code" as code,

--- a/models/shared/staging/stg_dictionary_organisationrole.sql
+++ b/models/shared/staging/stg_dictionary_organisationrole.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationRole
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID" as sk_organisationid,

--- a/models/shared/staging/stg_dictionary_organisationroletype.sql
+++ b/models/shared/staging/stg_dictionary_organisationroletype.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationRoleType
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "Code" as code,

--- a/models/shared/staging/stg_dictionary_organisationstatus.sql
+++ b/models/shared/staging/stg_dictionary_organisationstatus.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationStatus
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationStatusID" as sk_organisationstatusid,

--- a/models/shared/staging/stg_dictionary_organisationsuccessor.sql
+++ b/models/shared/staging/stg_dictionary_organisationsuccessor.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationSuccessor
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationID" as sk_organisationid,

--- a/models/shared/staging/stg_dictionary_organisationtype.sql
+++ b/models/shared/staging/stg_dictionary_organisationtype.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OrganisationType
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OrganisationTypeID" as sk_organisationtypeid,

--- a/models/shared/staging/stg_dictionary_outputarea.sql
+++ b/models/shared/staging/stg_dictionary_outputarea.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OutputArea
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OutputAreaID" as sk_outputareaid,

--- a/models/shared/staging/stg_dictionary_overseasvisitorstatusclassification.sql
+++ b/models/shared/staging/stg_dictionary_overseasvisitorstatusclassification.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.OverseasVisitorStatusClassification
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_OverseasVisitorStatusClassificationID" as sk_overseasvisitorstatusclassificationid,

--- a/models/shared/staging/stg_dictionary_partialpostcode.sql
+++ b/models/shared/staging/stg_dictionary_partialpostcode.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.PartialPostcode
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_PartialPostcode" as sk_partialpostcode,

--- a/models/shared/staging/stg_dictionary_patientclassification.sql
+++ b/models/shared/staging/stg_dictionary_patientclassification.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.PatientClassification
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_PatientClassificationID" as sk_patientclassificationid,

--- a/models/shared/staging/stg_dictionary_podcommissioners.sql
+++ b/models/shared/staging/stg_dictionary_podcommissioners.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.PODCommissioners
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_CommissionerID" as sk_commissionerid,

--- a/models/shared/staging/stg_dictionary_podgroups.sql
+++ b/models/shared/staging/stg_dictionary_podgroups.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.PODGroups
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_PodGroupID" as sk_podgroupid,

--- a/models/shared/staging/stg_dictionary_podteams.sql
+++ b/models/shared/staging/stg_dictionary_podteams.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.PODTeams
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_PODTeamID" as sk_podteamid,

--- a/models/shared/staging/stg_dictionary_postcode.sql
+++ b/models/shared/staging/stg_dictionary_postcode.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Postcode
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_PostcodeID" as sk_postcodeid,

--- a/models/shared/staging/stg_dictionary_postcoderegions.sql
+++ b/models/shared/staging/stg_dictionary_postcoderegions.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.PostcodeRegions
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "OSNorthing" as osnorthing,

--- a/models/shared/staging/stg_dictionary_practicematrix.sql
+++ b/models/shared/staging/stg_dictionary_practicematrix.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.PracticeMatrix
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ServiceProviderID" as sk_serviceproviderid,

--- a/models/shared/staging/stg_dictionary_practicematrixnational.sql
+++ b/models/shared/staging/stg_dictionary_practicematrixnational.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.PracticeMatrixNational
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ServiceProviderID" as sk_serviceproviderid,

--- a/models/shared/staging/stg_dictionary_prescribingsetting.sql
+++ b/models/shared/staging/stg_dictionary_prescribingsetting.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.PrescribingSetting
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_PrescribingSettingID" as sk_prescribingsettingid,

--- a/models/shared/staging/stg_dictionary_procedure.sql
+++ b/models/shared/staging/stg_dictionary_procedure.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Procedure
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ProcedureCode" as sk_procedurecode,

--- a/models/shared/staging/stg_dictionary_readcodes.sql
+++ b/models/shared/staging/stg_dictionary_readcodes.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ReadCodes
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ReadCodeID" as sk_readcodeid,

--- a/models/shared/staging/stg_dictionary_residentialinstitute.sql
+++ b/models/shared/staging/stg_dictionary_residentialinstitute.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ResidentialInstitute
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ResidentialInstituteID" as sk_residentialinstituteid,

--- a/models/shared/staging/stg_dictionary_rttperiodstatus.sql
+++ b/models/shared/staging/stg_dictionary_rttperiodstatus.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.RTTPeriodStatus
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_RTTPeriodStatusID" as sk_rttperiodstatusid,

--- a/models/shared/staging/stg_dictionary_serviceprovider.sql
+++ b/models/shared/staging/stg_dictionary_serviceprovider.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ServiceProvider
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ServiceProviderID" as sk_serviceproviderid,

--- a/models/shared/staging/stg_dictionary_serviceprovidergroup.sql
+++ b/models/shared/staging/stg_dictionary_serviceprovidergroup.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ServiceProviderGroup
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ServiceProviderGroupID" as sk_serviceprovidergroupid,

--- a/models/shared/staging/stg_dictionary_serviceprovidergroupnational.sql
+++ b/models/shared/staging/stg_dictionary_serviceprovidergroupnational.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ServiceProviderGroupNational
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ServiceProviderGroupID" as sk_serviceprovidergroupid,

--- a/models/shared/staging/stg_dictionary_serviceproviderhierarchy.sql
+++ b/models/shared/staging/stg_dictionary_serviceproviderhierarchy.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ServiceProviderHierarchy
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ServiceProviderGroupID" as sk_serviceprovidergroupid,

--- a/models/shared/staging/stg_dictionary_serviceprovidertypes.sql
+++ b/models/shared/staging/stg_dictionary_serviceprovidertypes.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.ServiceProviderTypes
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_ServiceProviderTypeID" as sk_serviceprovidertypeid,

--- a/models/shared/staging/stg_dictionary_slam_podgroup.sql
+++ b/models/shared/staging/stg_dictionary_slam_podgroup.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.SLAM_PODGroup
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_SLAMPODGroupID" as sk_slampodgroupid,

--- a/models/shared/staging/stg_dictionary_specialties.sql
+++ b/models/shared/staging/stg_dictionary_specialties.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Specialties
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_SpecialtyID" as sk_specialtyid,

--- a/models/shared/staging/stg_dictionary_staff.sql
+++ b/models/shared/staging/stg_dictionary_staff.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Staff
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_StaffID" as sk_staffid,

--- a/models/shared/staging/stg_dictionary_stp.sql
+++ b/models/shared/staging/stg_dictionary_stp.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.STP
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_STPID" as sk_stpid,

--- a/models/shared/staging/stg_dictionary_stpbycommissioner.sql
+++ b/models/shared/staging/stg_dictionary_stpbycommissioner.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.STPByCommissioner
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_CommissionerID" as sk_commissionerid,

--- a/models/shared/staging/stg_dictionary_stpcommissioner.sql
+++ b/models/shared/staging/stg_dictionary_stpcommissioner.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.STPCommissioner
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_STPID" as sk_stpid,

--- a/models/shared/staging/stg_dictionary_sustarifftypes.sql
+++ b/models/shared/staging/stg_dictionary_sustarifftypes.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.SUSTariffTypes
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_TariffTypeID" as sk_tarifftypeid,

--- a/models/shared/staging/stg_dictionary_times.sql
+++ b/models/shared/staging/stg_dictionary_times.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Times
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_Time" as sk_time,

--- a/models/shared/staging/stg_dictionary_unit.sql
+++ b/models/shared/staging/stg_dictionary_unit.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Unit
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_UnitID" as sk_unitid,

--- a/models/shared/staging/stg_dictionary_unitconversion.sql
+++ b/models/shared/staging/stg_dictionary_unitconversion.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.UnitConversion
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_UnitID_Source" as sk_unitid_source,

--- a/models/shared/staging/stg_dictionary_unitmapping.sql
+++ b/models/shared/staging/stg_dictionary_unitmapping.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.UnitMapping
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_UnitID" as sk_unitid,

--- a/models/shared/staging/stg_dictionary_urgent_emergency_care_activity_type.sql
+++ b/models/shared/staging/stg_dictionary_urgent_emergency_care_activity_type.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Urgent_Emergency_Care_Activity_Type
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_Urgent_Emergency_Care_Activity_Type_ID" as sk_urgent_emergency_care_activity_type_id,

--- a/models/shared/staging/stg_dictionary_wards.sql
+++ b/models/shared/staging/stg_dictionary_wards.sql
@@ -1,8 +1,6 @@
 -- Staging model for dictionary.Wards
 -- Source: "Dictionary"."dbo"
-{% if source.get('description') %}
 -- Description: Reference data including PDS and lookup tables
-{% endif %}
 
 select
     "SK_WardID" as sk_wardid,

--- a/scripts/sources/3_generate_staging_models.py
+++ b/scripts/sources/3_generate_staging_models.py
@@ -111,12 +111,14 @@ def main():
             
             column_list = ',\n    '.join(column_mappings)
             
+            # Add description if available
+            description_comment = ""
+            if source.get('description'):
+                description_comment = f"-- Description: {source.get('description')}\n"
+            
             model_sql = f"""-- Staging model for {source_name}.{table_name}
 -- Source: {source['database']}.{source['schema']}
-{{% if source.get('description') %}}
--- Description: {source.get('description')}
-{{% endif %}}
-
+{description_comment}
 select
     {column_list}
 from {{{{ source('{source_name}', '{table_name}') }}}}"""


### PR DESCRIPTION
## Summary
- Fixed invalid Jinja syntax in the staging model generation script that was causing compilation errors
- All 166 staging models were failing with: `'dbt.context.providers.RuntimeSourceResolver object' has no attribute 'get'`
- Regenerated all staging models with the corrected template

## Changes Made
- Updated `scripts/sources/3_generate_staging_models.py` to remove invalid Jinja `{% if source.get() %}` syntax
- Replaced with proper Python string formatting for conditional description comments
- Regenerated all 166 staging models (72 commissioning, 94 shared)

## Test Results
- ✅ `dbt run` now passes successfully for all models
- ✅ All staging models compile without errors

## Impact
This fix resolves the compilation errors that were preventing any dbt models from running.