### PR TITLE
fix: resolve PIVOT model test failures

### DIFF
--- a/models/commissioning/reporting/person_level/fct_person_wl_current_count_provider.sql
+++ b/models/commissioning/reporting/person_level/fct_person_wl_current_count_provider.sql
@@ -19,6 +19,7 @@ WITH PROVIDER_COUNTS AS (
     provider_code,
     open_pathways
     FROM {{ ref('int_wl_current') }}
+    WHERE patient_id IS NOT NULL
 )
 SELECT
 *
@@ -26,9 +27,9 @@ FROM PROVIDER_COUNTS wl
 PIVOT
 (
     SUM(open_pathways) FOR provider_code IN (
-        SELECT DISTINCT 
-        provider_code 
+        SELECT DISTINCT
+        provider_code
         FROM DEV__MODELLING.LOOKUP_NCL.PROVIDER_SHORTHAND
         )
-        DEFAULT ON NULL (0)
+    DEFAULT ON NULL (0)
 ) AS pvt

--- a/models/commissioning/reporting/person_level/fct_person_wl_current_count_tfc.sql
+++ b/models/commissioning/reporting/person_level/fct_person_wl_current_count_tfc.sql
@@ -19,6 +19,7 @@ WITH TFC_COUNTS AS (
     tfc_code,
     open_pathways
     FROM {{ ref('int_wl_current') }}
+    WHERE patient_id IS NOT NULL
 )
 SELECT
 *
@@ -32,5 +33,5 @@ PIVOT
         WHERE
         "IsTreatmentFunction" = TRUE
         )
-        DEFAULT ON NULL (0)
+    DEFAULT ON NULL (0)
 ) AS pvt


### PR DESCRIPTION
## Issue
The waiting list PIVOT models were failing `not_null` tests on `patient_id`.

## Solution
- **Added NULL filter**: `WHERE patient_id IS NOT NULL` prevents NULL patient_ids from appearing in results

## Results
✅ Both models build successfully  
✅ All tests pass  


There is still this syntax warning, but it doesn't seem to affect the models functionality.

[{
	"resource": "/C:/Projects/dbt-ncl-analytics/models/commissioning/reporting/person_level/fct_person_wl_current_count_provider.sql",
	"owner": "_generated_diagnostic_collection_name_#11",
	"code": "0101",
	"severity": 8,
	"message": "dbt0101: missing ')' at 'DEFAULT'\n  --> models\\commissioning\\reporting\\person_level\\fct_person_wl_current_count_provider.sql:34:5 (target\\compiled\\models\\commissioning\\reporting\\person_level\\fct_person_wl_current_count_provider.sql:31:5)",
	"source": "dbt",
	"startLineNumber": 34,
	"startColumn": 5,
	"endLineNumber": 34,
	"endColumn": 5,
	"modelVersionId": 13
},{
	"resource": "/C:/Projects/dbt-ncl-analytics/models/commissioning/reporting/person_level/fct_person_wl_current_count_tfc.sql",
	"owner": "_generated_diagnostic_collection_name_#11",
	"code": "0101",
	"severity": 8,
	"message": "dbt0101: missing ')' at 'DEFAULT'\n  --> models\\commissioning\\reporting\\person_level\\fct_person_wl_current_count_tfc.sql:36:5 (target\\compiled\\models\\commissioning\\reporting\\person_level\\fct_person_wl_current_count_tfc.sql:33:5)",
	"source": "dbt",
	"startLineNumber": 36,
	"startColumn": 5,
	"endLineNumber": 36,
	"endColumn": 5,
	"modelVersionId": 8
}]