### PR TITLE
feat: add person pseudonym table with HxFlake transformation

### DIFF
--- a/models/olids/published_reporting_direct_care/person_pseudo.sql
+++ b/models/olids/published_reporting_direct_care/person_pseudo.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        materialized='view',
+        tags=['published', 'direct_care', 'person', 'pseudonym'])
+}}
+
+/*
+Published View: Person Pseudonym for Direct Care
+
+Provides pseudonymized hex keys for patient re-identification in direct care contexts.
+Built on dim_person_pseudo with HxFlake format transformation.
+
+Key Features:
+
+• One row per person_id
+
+• HxFlake format: XX-XXX-XXX (10 characters total)
+
+• Reversible transformation for re-identification
+
+• Direct care access layer
+
+Data Source: dim_person_pseudo
+*/
+
+SELECT
+    person_id,
+    sk_patient_id,
+    hx_flake
+FROM {{ ref('dim_person_pseudo') }}
+
+ORDER BY person_id

--- a/models/olids/published_reporting_direct_care/person_pseudo.yml
+++ b/models/olids/published_reporting_direct_care/person_pseudo.yml
@@ -1,0 +1,38 @@
+version: 2
+
+models:
+  - name: person_pseudo
+    description: 'Published View: Person Pseudonym for Direct Care
+
+      Provides pseudonymized hex keys for patient re-identification in direct care contexts.
+      Built on dim_person_pseudo with HxFlake format transformation.
+
+      Key Features:
+
+      • One row per person_id
+
+      • HxFlake format: XX-XXX-XXX (10 characters total)
+
+      • Reversible transformation for re-identification
+
+      • Direct care access layer
+
+      Data Source: dim_person_pseudo'
+
+    columns:
+      - name: person_id
+        description: 'Unique person identifier'
+        tests:
+          - not_null
+          - unique
+
+      - name: sk_patient_id
+        description: 'Surrogate key for patient record used in pseudonym generation'
+        tests:
+          - not_null
+
+      - name: hx_flake
+        description: 'Pseudonymized hex key in format XX-XXX-XXX for patient re-identification'
+        tests:
+          - not_null
+          - unique

--- a/models/olids/reporting/person_demographics/dim_person_pseudo.sql
+++ b/models/olids/reporting/person_demographics/dim_person_pseudo.sql
@@ -1,0 +1,89 @@
+{{
+    config(
+        materialized='table',
+        tags=['dimension', 'person', 'pseudonym'],
+        cluster_by=['person_id'])
+}}
+
+/*
+Person Pseudonym Dimension Table
+
+Provides pseudonymized hex keys for patient re-identification.
+Generates HxFlake format from sk_patient_id using standardized transformation.
+
+Key Features:
+
+• One row per person_id
+
+• HxFlake format: XX-XXX-XXX (10 characters total)
+
+• Reversible transformation for re-identification
+
+• Links to person and patient records
+
+Data Source: sk_patient_id from stg_olids_patient via person relationships
+*/
+
+SELECT
+    -- Core Identifiers
+    bd.person_id,
+    bd.sk_patient_id,
+
+    -- HxFlake Pseudonym Generation (exact formula match)
+LEFT(
+         SUBSTR(
+             TRIM(
+                 REVERSE(
+                     RIGHT(
+                         LPAD(
+                             TO_CHAR(bd.sk_patient_id, 'XXXXXXXXX'),
+                             9,
+                             0
+                         ),
+                         10
+                     )
+                 )
+             ) || '0000000000',
+             1,
+             2
+         ) || '-' || RPAD(
+             SUBSTR(
+                 TRIM(
+                     REVERSE(
+                         RIGHT(
+                             LPAD(
+                                 TO_CHAR(bd.sk_patient_id, 'XXXXXXXXX'),
+                                 9,
+                                 0
+                             ),
+                             10
+                         )
+                     )
+                 ) || '0000000000',
+                 3,
+                 4
+             ),
+             3,
+             '0'
+         ) || '-' || SUBSTR(
+             TRIM(
+                 REVERSE(
+                     RIGHT(
+                         LPAD(
+                             TO_CHAR(bd.sk_patient_id, 'XXXXXXXXX'),
+                             9,
+                             0
+                         ),
+                         10
+                     )
+                 )
+             ) || '0000000000',
+             6,
+             3
+         ) || '0000000000',
+         10
+     ) AS hx_flake
+
+FROM {{ ref('dim_person_birth_death') }} bd
+
+ORDER BY bd.person_id

--- a/models/olids/reporting/person_demographics/dim_person_pseudo.yml
+++ b/models/olids/reporting/person_demographics/dim_person_pseudo.yml
@@ -1,0 +1,38 @@
+version: 2
+
+models:
+  - name: dim_person_pseudo
+    description: 'Person Pseudonym Dimension Table
+
+      Provides pseudonymized hex keys for patient re-identification.
+      Generates HxFlake format from sk_patient_id using standardized transformation.
+
+      Key Features:
+
+      • One row per person_id
+
+      • HxFlake format: XX-XXX-XXX (10 characters total)
+
+      • Reversible transformation for re-identification
+
+      • Links to person and patient records
+
+      Data Source: sk_patient_id from stg_olids_patient via person relationships'
+
+    columns:
+      - name: person_id
+        description: 'Unique person identifier'
+        tests:
+          - not_null
+          - unique
+
+      - name: sk_patient_id
+        description: 'Primary surrogate key for patient record used in pseudonym generation'
+        tests:
+          - not_null
+
+      - name: hx_flake
+        description: 'Pseudonymized hex key in format XX-XXX-XXX for patient re-identification'
+        tests:
+          - not_null
+          - unique


### PR DESCRIPTION
## Summary
- Add `dim_person_pseudo` table implementing HxFlake pseudonym formula
- Add `person_pseudo` view in published direct care layer
- Enable patient re-identification using hex transformation of sk_patient_id

## Implementation Details
- Uses exact HxFlake formula with `TO_CHAR` hexadecimal formatting
- Sources from `dim_person_birth_death` for consistency with demographics tables
- Generates unique XX-XXX-XXX format pseudonym keys
- Includes comprehensive tests and documentation

## Test Results
- All uniqueness tests passing
- Formula generates distinct pseudonyms per person