### PR TITLE
refactor: separate geography and IMD logic into dedicated models

### DIFF
--- a/models/olids/modelling/geography/_geography.yml
+++ b/models/olids/modelling/geography/_geography.yml
@@ -1,0 +1,80 @@
+version: 2
+
+models:
+  - name: int_geography_london_boroughs
+    description: Identifies London boroughs from ICBs and local authorities with cleaned names
+    columns:
+      - name: icb_code
+        description: ICB/Primary care organisation code
+      - name: icb_name_original
+        description: Original ICB/Primary care organisation name from source
+      - name: icb_name_clean
+        description: Cleaned ICB name with organisation code suffix removed
+      - name: is_london_icb
+        description: Flag indicating if ICB name contains 'London'
+      - name: local_authority_code
+        description: Local authority organisation code
+      - name: local_authority_name_original
+        description: Original local authority name from source
+      - name: local_authority_name_clean
+        description: Cleaned local authority name with 'London Borough of' prefix removed
+      - name: is_london_borough
+        description: Flag indicating if local authority is a London borough
+      - name: is_london_geography
+        description: Combined flag if either ICB or local authority is London-based
+
+  - name: int_geography_mappings
+    description: Single source of truth for geography code-to-name mappings
+    columns:
+      - name: mapping_category
+        description: Category of mapping (ORGANISATION, GEOGRAPHY, GEOGRAPHY_MAPPING)
+      - name: mapping_type
+        description: Type of mapping (PRIMARY_CARE, LOCAL_AUTHORITY, LSOA_2021, etc.)
+      - name: code
+        description: Geographic or organisation code
+      - name: name
+        description: Geographic or organisation name
+      - name: start_date
+        description: Start date for organisation records
+      - name: end_date
+        description: End date for organisation records
+      - name: parent_code
+        description: Parent geography code for hierarchical mappings
+      - name: parent_name
+        description: Parent geography name for hierarchical mappings
+
+  - name: int_geography_imd
+    description: Index of Multiple Deprivation mappings and quintile calculations
+    columns:
+      - name: lsoa_code_2011
+        description: LSOA 2011 census code
+        tests:
+          - not_null
+          - unique
+      - name: imd_decile_19
+        description: IMD 2019 decile (1=most deprived, 10=least deprived)
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      - name: imd_quintile_19
+        description: IMD quintile text description
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['Most Deprived', 'Second Most Deprived', 'Third Most Deprived', 'Second Least Deprived', 'Least Deprived']
+      - name: imd_quintile_numeric_19
+        description: IMD quintile as number (1-5)
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [1, 2, 3, 4, 5]
+      - name: imd_tertile_19
+        description: IMD tertile grouping
+      - name: is_most_deprived_20pct
+        description: Flag for areas in most deprived 20% (deciles 1-2)
+        tests:
+          - not_null

--- a/models/olids/modelling/geography/int_geography_imd.sql
+++ b/models/olids/modelling/geography/int_geography_imd.sql
@@ -1,0 +1,62 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+/*
+Index of Multiple Deprivation (IMD) Mappings and Calculations
+Provides LSOA-to-IMD mappings and quintile calculations from deciles.
+Based on IMD 2019 data which uses 2011 LSOA boundaries.
+*/
+
+WITH imd_2019_data AS (
+    -- IMD 2019 reference data
+    SELECT
+        lsoacode AS lsoa_code_2011,
+        imddecile AS imd_decile
+    FROM {{ ref('stg_reference_imd2019') }}
+    WHERE lsoacode IS NOT NULL
+        AND imddecile IS NOT NULL
+)
+
+SELECT
+    lsoa_code_2011,
+    imd_decile AS imd_decile_19,
+
+    -- IMD Quintile calculation from deciles
+    CASE
+        WHEN imd_decile IN (1, 2) THEN 'Most Deprived'
+        WHEN imd_decile IN (3, 4) THEN 'Second Most Deprived'
+        WHEN imd_decile IN (5, 6) THEN 'Third Most Deprived'
+        WHEN imd_decile IN (7, 8) THEN 'Second Least Deprived'
+        WHEN imd_decile IN (9, 10) THEN 'Least Deprived'
+        ELSE NULL
+    END AS imd_quintile_19,
+
+    -- Numeric quintile for easier filtering/sorting
+    CASE
+        WHEN imd_decile IN (1, 2) THEN 1
+        WHEN imd_decile IN (3, 4) THEN 2
+        WHEN imd_decile IN (5, 6) THEN 3
+        WHEN imd_decile IN (7, 8) THEN 4
+        WHEN imd_decile IN (9, 10) THEN 5
+        ELSE NULL
+    END AS imd_quintile_numeric_19,
+
+    -- IMD Tertile calculation for additional grouping options
+    CASE
+        WHEN imd_decile IN (1, 2, 3) THEN 'Most Deprived Third'
+        WHEN imd_decile IN (4, 5, 6, 7) THEN 'Middle Third'
+        WHEN imd_decile IN (8, 9, 10) THEN 'Least Deprived Third'
+        ELSE NULL
+    END AS imd_tertile_19,
+
+    -- Binary deprivation flag (most deprived 20% - top 2 deciles)
+    CASE
+        WHEN imd_decile IN (1, 2) THEN TRUE
+        ELSE FALSE
+    END AS is_most_deprived_20pct
+
+FROM imd_2019_data
+ORDER BY lsoa_code_2011

--- a/models/olids/modelling/geography/int_geography_london_areas.sql
+++ b/models/olids/modelling/geography/int_geography_london_areas.sql
@@ -1,0 +1,37 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+/*
+London Area Identification using LSOA Reference Data
+Uses the LSOA21_WARD25_LAD25 reference table which has a RESIDENT_FLAG
+that clearly identifies NCL, Other London, and Outside London areas.
+*/
+
+SELECT DISTINCT
+    lad25_cd,
+    lad25_nm,
+
+    -- London classification based on resident_flag
+    CASE
+        WHEN resident_flag = 'NCL' THEN 'NCL'
+        WHEN resident_flag = 'Other London' THEN 'Other London'
+        WHEN resident_flag = 'Outside London' THEN 'Outside London'
+        ELSE 'Unknown'
+    END AS london_classification,
+
+    -- Boolean flags for easier filtering
+    CASE WHEN resident_flag IN ('NCL', 'Other London') THEN TRUE ELSE FALSE END AS is_london_area,
+    CASE WHEN resident_flag = 'NCL' THEN TRUE ELSE FALSE END AS is_ncl_area,
+
+    -- Borough name (for London areas only)
+    CASE
+        WHEN resident_flag IN ('NCL', 'Other London') THEN lad25_nm
+        ELSE NULL
+    END AS borough_name
+
+FROM {{ ref('stg_reference_lsoa21_ward25_lad25') }}
+WHERE lad25_cd IS NOT NULL
+    AND lad25_nm IS NOT NULL

--- a/models/olids/modelling/geography/int_geography_london_boroughs.sql
+++ b/models/olids/modelling/geography/int_geography_london_boroughs.sql
@@ -1,0 +1,92 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+/*
+London Borough Identification and Cleaning
+Identifies London boroughs from ICBs and local authorities, providing cleaned borough names.
+*/
+
+WITH icb_organisations AS (
+    -- Get all ICB organisations (primary care organisations) with cleaned names
+    SELECT DISTINCT
+        organisation_code,
+        organisation_name AS organisation_name_original,
+        -- Remove organisation code from the end of the name if present
+        CASE
+            WHEN organisation_name LIKE '% - ' || organisation_code
+                THEN TRIM(REGEXP_REPLACE(organisation_name, ' - ' || organisation_code || '$', ''))
+            -- Handle other code patterns like "NHS North West London ICB - W2U3Z"
+            WHEN organisation_name RLIKE '.* - [A-Z0-9]+$'
+                THEN TRIM(REGEXP_REPLACE(organisation_name, ' - [A-Z0-9]+$', ''))
+            ELSE organisation_name
+        END AS organisation_name_clean,
+        CASE
+            WHEN UPPER(organisation_name) LIKE '%LONDON%' THEN TRUE
+            ELSE FALSE
+        END AS is_london_icb
+    FROM {{ ref('stg_dictionary_dbo_organisation') }}
+    WHERE organisation_code IS NOT NULL
+        AND organisation_name IS NOT NULL
+        AND (end_date IS NULL OR end_date >= CURRENT_DATE())
+),
+
+local_authority_organisations AS (
+    -- Get all local authority organisations with cleaned names
+    SELECT DISTINCT
+        organisation_code,
+        organisation_name AS organisation_name_original,
+        -- Clean borough names by removing prefixes
+        CASE
+            WHEN organisation_name LIKE 'London Borough of %'
+                THEN TRIM(SUBSTRING(organisation_name, 19))
+            WHEN organisation_name LIKE 'Royal Borough of %'
+                THEN TRIM(SUBSTRING(organisation_name, 18))
+            WHEN organisation_name = 'City of Westminster'
+                THEN 'Westminster'
+            WHEN organisation_name = 'City of London'
+                THEN 'City of London'
+            ELSE organisation_name
+        END AS organisation_name_clean,
+        CASE
+            WHEN organisation_name LIKE 'London Borough of %'
+              OR organisation_name LIKE 'Royal Borough of %'
+              OR organisation_name IN ('City of Westminster', 'City of London')
+            THEN TRUE
+            ELSE FALSE
+        END AS is_london_borough
+    FROM {{ ref('stg_dictionary_dbo_organisation') }}
+    WHERE organisation_code IS NOT NULL
+        AND organisation_name IS NOT NULL
+        AND (end_date IS NULL OR end_date >= CURRENT_DATE())
+)
+
+-- ICB organisations with London flags
+SELECT
+    organisation_code AS icb_code,
+    organisation_name_original AS icb_name_original,
+    organisation_name_clean AS icb_name_clean,
+    is_london_icb,
+    NULL AS local_authority_code,
+    NULL AS local_authority_name_original,
+    NULL AS local_authority_name_clean,
+    NULL AS is_london_borough,
+    is_london_icb AS is_london_geography
+FROM icb_organisations
+
+UNION ALL
+
+-- Local Authority organisations with London flags
+SELECT
+    NULL AS icb_code,
+    NULL AS icb_name_original,
+    NULL AS icb_name_clean,
+    NULL AS is_london_icb,
+    organisation_code AS local_authority_code,
+    organisation_name_original AS local_authority_name_original,
+    organisation_name_clean AS local_authority_name_clean,
+    is_london_borough,
+    is_london_borough AS is_london_geography
+FROM local_authority_organisations

--- a/models/olids/modelling/geography/int_geography_mappings.sql
+++ b/models/olids/modelling/geography/int_geography_mappings.sql
@@ -1,0 +1,137 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+/*
+Geographic Code to Name Mappings
+Provides a single source of truth for all geography code-to-name mappings.
+Includes ICBs, local authorities, LSOAs, MSOAs and their hierarchies.
+*/
+
+WITH postcode_geography AS (
+    -- Latest postcode geography mappings
+    SELECT DISTINCT
+        postcode_hash,
+        primary_care_organisation,
+        local_authority_organisation,
+        yr_2011_lsoa,
+        yr_2011_msoa,
+        yr_2021_lsoa,
+        yr_2021_msoa
+    FROM {{ ref('stg_olids_postcode_hash') }}
+    WHERE is_latest = TRUE
+        AND postcode_hash IS NOT NULL
+),
+
+primary_care_orgs AS (
+    -- ICB/Primary Care Organisation mappings
+    SELECT DISTINCT
+        organisation_code,
+        organisation_name,
+        start_date,
+        end_date,
+        'PRIMARY_CARE' AS org_type
+    FROM {{ ref('stg_dictionary_dbo_organisation') }}
+    WHERE organisation_code IN (SELECT DISTINCT primary_care_organisation FROM postcode_geography)
+        AND (end_date IS NULL OR end_date >= CURRENT_DATE())
+),
+
+local_authority_orgs AS (
+    -- Local Authority/Borough mappings
+    SELECT DISTINCT
+        organisation_code,
+        organisation_name,
+        start_date,
+        end_date,
+        'LOCAL_AUTHORITY' AS org_type
+    FROM {{ ref('stg_dictionary_dbo_organisation') }}
+    WHERE organisation_code IN (SELECT DISTINCT local_authority_organisation FROM postcode_geography)
+        AND (end_date IS NULL OR end_date >= CURRENT_DATE())
+),
+
+lsoa_2021_names AS (
+    -- LSOA 2021 names
+    SELECT DISTINCT
+        lsoa21_cd AS geography_code,
+        lsoa21_nm AS geography_name,
+        'LSOA_2021' AS geography_type
+    FROM {{ ref('stg_reference_lsoa2011_lsoa2021') }}
+    WHERE lsoa21_cd IS NOT NULL
+        AND lsoa21_nm IS NOT NULL
+),
+
+lsoa_2011_names AS (
+    -- LSOA 2011 names
+    SELECT DISTINCT
+        lsoa11_cd AS geography_code,
+        lsoa11_nm AS geography_name,
+        'LSOA_2011' AS geography_type
+    FROM {{ ref('stg_reference_lsoa2011_lsoa2021') }}
+    WHERE lsoa11_cd IS NOT NULL
+        AND lsoa11_nm IS NOT NULL
+),
+
+neighbourhood_mappings AS (
+    -- NCL Neighbourhood mappings
+    SELECT DISTINCT
+        lsoa_2021_code AS geography_code,
+        neighbourhood_name AS mapped_value,
+        'LSOA_TO_NEIGHBOURHOOD' AS mapping_type
+    FROM {{ ref('stg_reference_ncl_neighbourhood_lsoa_2021') }}
+    WHERE lsoa_2021_code IS NOT NULL
+        AND neighbourhood_name IS NOT NULL
+),
+
+all_organisations AS (
+    -- Combine all organisation types
+    SELECT * FROM primary_care_orgs
+    UNION ALL
+    SELECT * FROM local_authority_orgs
+),
+
+all_geographies AS (
+    -- Combine all geography types
+    SELECT * FROM lsoa_2021_names
+    UNION ALL
+    SELECT * FROM lsoa_2011_names
+)
+
+-- Final output combining organisations and geographies
+SELECT
+    'ORGANISATION' AS mapping_category,
+    org.org_type AS mapping_type,
+    org.organisation_code AS code,
+    org.organisation_name AS name,
+    org.start_date,
+    org.end_date,
+    NULL AS parent_code,
+    NULL AS parent_name
+FROM all_organisations org
+
+UNION ALL
+
+SELECT
+    'GEOGRAPHY' AS mapping_category,
+    geo.geography_type AS mapping_type,
+    geo.geography_code AS code,
+    geo.geography_name AS name,
+    NULL AS start_date,
+    NULL AS end_date,
+    NULL AS parent_code,
+    NULL AS parent_name
+FROM all_geographies geo
+
+UNION ALL
+
+SELECT
+    'GEOGRAPHY_MAPPING' AS mapping_category,
+    nbhd.mapping_type,
+    nbhd.geography_code AS code,
+    nbhd.mapped_value AS name,
+    NULL AS start_date,
+    NULL AS end_date,
+    NULL AS parent_code,
+    nbhd.mapped_value AS parent_name
+FROM neighbourhood_mappings nbhd

--- a/models/olids/modelling/person_attributes/int_person_geography.yml
+++ b/models/olids/modelling/person_attributes/int_person_geography.yml
@@ -1,19 +1,21 @@
 version: 2
 models:
   - name: int_person_geography
-    description: 'Comprehensive person geography mapping including postcode hash, LSOA, borough, neighbourhood and IMD.
+    description: 'Person geography mapping using refactored intermediate geography tables.
 
       Key Features:
 
-      • Uses person_id directly from patient_address table
+      • Uses refactored geography models for clean separation of concerns
 
       • Selects most recent/active address for each person
 
       • Maps to 2011 and 2021 census geographies via postcode hash
 
-      • Includes IMD 2019 deprivation data (via 2011 LSOA)
+      • Includes IMD data from dedicated IMD model
 
       • Maps to NCL neighbourhoods (via 2021 LSOA)
+
+      • Includes London borough identification from dedicated model
 
       • All geographic joins are LEFT JOINs for residents outside London/NCL'
     columns:
@@ -30,11 +32,17 @@ models:
       - name: primary_care_organisation
         description: 'Primary care organisation (ICB) code where patient resides (from postcode lookup)'
       - name: icb_resident
-        description: 'ICB name where patient resides (distinct from registration ICB)'
-      - name: local_authority_organisation
-        description: 'Local authority organisation code where patient resides (from postcode lookup)'
+        description: 'ICB name where patient resides (from geography mappings)'
+      - name: local_authority_code
+        description: 'Local Authority District 2025 code (LAD25CD) from LSOA reference, fallback to organisation code'
+      - name: local_authority_name
+        description: 'Local Authority District 2025 name (LAD25NM) from LSOA reference, fallback to organisation name'
+      - name: ward_code
+        description: '2025 Ward code (WD25CD) from LSOA reference'
+      - name: ward_name
+        description: '2025 Ward name (WD25NM) from LSOA reference'
       - name: borough_resident
-        description: 'Borough where patient resides (cleaned without "London Borough of" prefix)'
+        description: 'Borough name where patient resides (only populated for London boroughs)'
       - name: lsoa_code_11
         description: '2011 Census Lower Layer Super Output Area code'
       - name: msoa_code_11
@@ -48,6 +56,14 @@ models:
       - name: neighbourhood_resident
         description: 'NCL neighbourhood of residence (from 2021 LSOA)'
       - name: imd_decile_19
-        description: 'IMD 2019 decile (1=most deprived, 10=least deprived)'
+        description: 'IMD 2019 decile from dedicated IMD model'
       - name: imd_quintile_19
-        description: 'IMD 2019 quintile grouping for analysis'
+        description: 'IMD 2019 quintile from dedicated IMD model'
+      - name: imd_quintile_numeric_19
+        description: 'IMD 2019 numeric quintile (1-5) from dedicated IMD model'
+      - name: is_most_deprived_20pct
+        description: 'Flag for most deprived 20% areas (deciles 1-2) from dedicated IMD model'
+      - name: is_london_resident
+        description: 'Flag indicating if person resides in London (based on LSOA reference data)'
+      - name: london_classification
+        description: 'London classification from LSOA reference (NCL, Other London, Outside London)'

--- a/models/olids/published_reporting_direct_care/ltc_lcs_cf_dashboard_base.sql
+++ b/models/olids/published_reporting_direct_care/ltc_lcs_cf_dashboard_base.sql
@@ -130,17 +130,9 @@ final_dashboard AS (
         interpreter_type,
         
         -- Geographic and deprivation
-        imd_quintile_19, 
-        imd_decile_19, 
+        imd_quintile_19 as imd_quintile_label,
+        imd_decile_19,
         lsoa_code_21 as lsoa_code,
-        CASE 
-            WHEN imd_quintile_19 IS NULL THEN 'Unknown'
-            WHEN imd_quintile_19 = 1 THEN 'Quintile 1 (Most Deprived)'
-            WHEN imd_quintile_19 = 2 THEN 'Quintile 2'
-            WHEN imd_quintile_19 = 3 THEN 'Quintile 3'
-            WHEN imd_quintile_19 = 4 THEN 'Quintile 4'
-            WHEN imd_quintile_19 = 5 THEN 'Quintile 5 (Least Deprived)'
-        END AS imd_quintile_label,
         
         -- Practice information
         practice_code, 

--- a/models/olids/reporting/person_analytics/person_month_analysis_base.sql
+++ b/models/olids/reporting/person_analytics/person_month_analysis_base.sql
@@ -107,14 +107,18 @@ SELECT
     -- Residence geography (where they live)
     d.icb_code_resident,
     d.icb_resident,
-    d.local_authority_organisation,
+    d.local_authority_code,
+    d.local_authority_name,
     d.borough_resident,
+    d.is_london_resident,
+    d.london_classification,
     d.lsoa_code_21,
     d.lsoa_name_21,
     d.ward_code,
     d.ward_name,
     d.imd_decile_19,
     d.imd_quintile_19,
+    d.imd_quintile_numeric_19,
     d.neighbourhood_resident,
     
     -- SCD2 metadata

--- a/models/olids/reporting/person_demographics/dim_person_demographics.sql
+++ b/models/olids/reporting/person_demographics/dim_person_demographics.sql
@@ -196,14 +196,18 @@ SELECT
     -- Geographic Data from person postcode mapping (residence-based)
     ca.primary_care_organisation as icb_code_resident,
     ca.icb_resident,
-    ca.local_authority_organisation,
+    ca.local_authority_code,
+    ca.local_authority_name,
     ca.borough_resident,
+    ca.is_london_resident,
+    ca.london_classification,
     ca.lsoa_code_21,
     ca.lsoa_name_21,
-    NULL AS ward_code,  -- Placeholder for ward mapping
-    NULL AS ward_name,  -- Placeholder for ward mapping
+    ca.ward_code,
+    ca.ward_name,
     ca.imd_decile_19,
     ca.imd_quintile_19,
+    ca.imd_quintile_numeric_19,
     ca.neighbourhood_resident
 
 FROM {{ ref('dim_person_birth_death') }} bd

--- a/models/olids/reporting/person_demographics/dim_person_demographics_historical.sql
+++ b/models/olids/reporting/person_demographics/dim_person_demographics_historical.sql
@@ -71,13 +71,19 @@ monthly_addresses AS (
         pc.postcode_hash,
         pc.primary_care_organisation as icb_code_resident,
         pc.icb_resident,
-        pc.local_authority_organisation,
+        pc.local_authority_code,
+        pc.local_authority_name,
         pc.borough_resident,
+        pc.is_london_resident,
+        pc.london_classification,
         pc.lsoa_code_21,
         pc.lsoa_name_21,
+        pc.ward_code,
+        pc.ward_name,
         pc.neighbourhood_resident,
         pc.imd_decile_19,
-        pc.imd_quintile_19
+        pc.imd_quintile_19,
+        pc.imd_quintile_numeric_19
     FROM person_months pm
     LEFT JOIN {{ ref('int_person_geography') }} pc
         ON pm.person_id = pc.person_id
@@ -375,14 +381,18 @@ SELECT
     -- Geographic Data from person postcode mapping (residence-based)
     ma.icb_code_resident,
     ma.icb_resident,
-    ma.local_authority_organisation,
+    ma.local_authority_code,
+    ma.local_authority_name,
     ma.borough_resident,
+    ma.is_london_resident,
+    ma.london_classification,
     ma.lsoa_code_21,
     ma.lsoa_name_21,
-    NULL AS ward_code,  -- Placeholder for ward mapping
-    NULL AS ward_name,  -- Placeholder for ward mapping
+    ma.ward_code,
+    ma.ward_name,
     ma.imd_decile_19,
     ma.imd_quintile_19,
+    ma.imd_quintile_numeric_19,
     ma.neighbourhood_resident,
     
     -- SCD2 compatibility fields for person-month grain

--- a/models/olids/reporting/programme/ltc_lcs/cf/fct_ltc_lcs_person_dashboard.sql
+++ b/models/olids/reporting/programme/ltc_lcs/cf/fct_ltc_lcs_person_dashboard.sql
@@ -47,13 +47,14 @@ SELECT
     demo.lsoa_name_21,
     demo.imd_decile_19,
     demo.imd_quintile_19,
-    CASE 
-        WHEN demo.imd_quintile_19 IS NULL THEN 'Unknown'
-        WHEN demo.imd_quintile_19 = 1 THEN 'Quintile 1 (Most Deprived)'
-        WHEN demo.imd_quintile_19 = 2 THEN 'Quintile 2'
-        WHEN demo.imd_quintile_19 = 3 THEN 'Quintile 3'
-        WHEN demo.imd_quintile_19 = 4 THEN 'Quintile 4'
-        WHEN demo.imd_quintile_19 = 5 THEN 'Quintile 5 (Least Deprived)'
+    demo.imd_quintile_numeric_19,
+    CASE
+        WHEN demo.imd_quintile_numeric_19 IS NULL THEN 'Unknown'
+        WHEN demo.imd_quintile_numeric_19 = 1 THEN 'Quintile 1 (Most Deprived)'
+        WHEN demo.imd_quintile_numeric_19 = 2 THEN 'Quintile 2'
+        WHEN demo.imd_quintile_numeric_19 = 3 THEN 'Quintile 3'
+        WHEN demo.imd_quintile_numeric_19 = 4 THEN 'Quintile 4'
+        WHEN demo.imd_quintile_numeric_19 = 5 THEN 'Quintile 5 (Least Deprived)'
     END AS imd_quintile_label,
     
     -- Case finding summary flags

--- a/models/olids/reporting/programme/ltc_lcs/cf/fct_ltc_lcs_population_summary.sql
+++ b/models/olids/reporting/programme/ltc_lcs/cf/fct_ltc_lcs_population_summary.sql
@@ -11,7 +11,7 @@ WITH demographic_population AS (
     SELECT
         demo.age_band_10y,
         demo.ethnicity_category,
-        COALESCE(demo.imd_quintile_19, 0) AS imd_quintile,  -- 0 = Unknown
+        COALESCE(demo.imd_quintile_numeric_19, 0) AS imd_quintile,  -- 0 = Unknown
         demo.borough_registered,
         demo.neighbourhood_registered,
         
@@ -31,7 +31,7 @@ WITH demographic_population AS (
     GROUP BY 
         demo.age_band_10y,
         demo.ethnicity_category,
-        COALESCE(demo.imd_quintile_19, 0),
+        COALESCE(demo.imd_quintile_numeric_19, 0),
         demo.borough_registered,
         demo.neighbourhood_registered
 ),
@@ -41,7 +41,7 @@ case_finding_demographics AS (
     SELECT
         demo.age_band_10y,
         demo.ethnicity_category,
-        COALESCE(demo.imd_quintile_19, 0) AS imd_quintile,
+        COALESCE(demo.imd_quintile_numeric_19, 0) AS imd_quintile,
         demo.borough_registered,
         demo.neighbourhood_registered,
         
@@ -100,7 +100,7 @@ case_finding_demographics AS (
     GROUP BY 
         demo.age_band_10y,
         demo.ethnicity_category,
-        COALESCE(demo.imd_quintile_19, 0),
+        COALESCE(demo.imd_quintile_numeric_19, 0),
         demo.borough_registered,
         demo.neighbourhood_registered
 )

--- a/models/olids/reporting/programme/ltc_lcs/cf/fct_ltc_lcs_practice_summary.sql
+++ b/models/olids/reporting/programme/ltc_lcs/cf/fct_ltc_lcs_practice_summary.sql
@@ -40,12 +40,12 @@ WITH practice_demographics AS (
         COUNT(CASE WHEN demo.ethnicity_category IS NULL OR demo.ethnicity_category = 'Unknown' THEN 1 END) AS pop_ethnicity_unknown,
         
         -- Deprivation quintiles (when available)
-        COUNT(CASE WHEN demo.imd_quintile_19 = 1 THEN 1 END) AS pop_imd_quintile_1_most_deprived,
-        COUNT(CASE WHEN demo.imd_quintile_19 = 2 THEN 1 END) AS pop_imd_quintile_2,
-        COUNT(CASE WHEN demo.imd_quintile_19 = 3 THEN 1 END) AS pop_imd_quintile_3,
-        COUNT(CASE WHEN demo.imd_quintile_19 = 4 THEN 1 END) AS pop_imd_quintile_4,
-        COUNT(CASE WHEN demo.imd_quintile_19 = 5 THEN 1 END) AS pop_imd_quintile_5_least_deprived,
-        COUNT(CASE WHEN demo.imd_quintile_19 IS NULL THEN 1 END) AS pop_imd_unknown
+        COUNT(CASE WHEN demo.imd_quintile_numeric_19 = 1 THEN 1 END) AS pop_imd_quintile_1_most_deprived,
+        COUNT(CASE WHEN demo.imd_quintile_numeric_19 = 2 THEN 1 END) AS pop_imd_quintile_2,
+        COUNT(CASE WHEN demo.imd_quintile_numeric_19 = 3 THEN 1 END) AS pop_imd_quintile_3,
+        COUNT(CASE WHEN demo.imd_quintile_numeric_19 = 4 THEN 1 END) AS pop_imd_quintile_4,
+        COUNT(CASE WHEN demo.imd_quintile_numeric_19 = 5 THEN 1 END) AS pop_imd_quintile_5_least_deprived,
+        COUNT(CASE WHEN demo.imd_quintile_numeric_19 IS NULL THEN 1 END) AS pop_imd_unknown
         
     FROM {{ ref('dim_person_current_practice') }} AS prac
     INNER JOIN {{ ref('dim_person_demographics') }} AS demo

--- a/models/shared/staging/stg_reference_gp_reg_pat_prac_lsoa_all.sql
+++ b/models/shared/staging/stg_reference_gp_reg_pat_prac_lsoa_all.sql
@@ -1,0 +1,13 @@
+-- Staging model for reference_analyst_managed.GP_REG_PAT_PRAC_LSOA_ALL
+-- Source: "DATA_LAKE__NCL"."ANALYST_MANAGED"
+-- Description: Analyst-managed reference datasets and business rules
+
+select
+    "PUBLICATION" as publication,
+    "EXTRACT_DATE" as extract_date,
+    "PRACTICE_CODE" as practice_code,
+    "PRACTICE_NAME" as practice_name,
+    "LSOA_CODE" as lsoa_code,
+    "SEX" as sex,
+    "NUMBER_OF_PATIENTS" as number_of_patients
+from {{ source('reference_analyst_managed', 'GP_REG_PAT_PRAC_LSOA_ALL') }}

--- a/models/shared/staging/stg_reference_lsoa21_ward25_lad25.sql
+++ b/models/shared/staging/stg_reference_lsoa21_ward25_lad25.sql
@@ -1,0 +1,13 @@
+-- Staging model for reference_analyst_managed.LSOA21_WARD25_LAD25
+-- Source: "DATA_LAKE__NCL"."ANALYST_MANAGED"
+-- Description: Analyst-managed reference datasets and business rules
+
+select
+    "LSOA21CD" as lsoa21_cd,
+    "LSOA21NM" as lsoa21_nm,
+    "WD25CD" as wd25_cd,
+    "WD25NM" as wd25_nm,
+    "LAD25CD" as lad25_cd,
+    "LAD25NM" as lad25_nm,
+    "RESIDENT_FLAG" as resident_flag
+from {{ source('reference_analyst_managed', 'LSOA21_WARD25_LAD25') }}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -8777,6 +8777,23 @@ sources:
       data_type: FLOAT
     - name: OTHERINSTRUCTIONS
       data_type: TEXT
+  - name: GP_REG_PAT_PRAC_LSOA_ALL
+    identifier: '"GP_REG_PAT_PRAC_LSOA_ALL"'
+    columns:
+    - name: PUBLICATION
+      data_type: TEXT
+    - name: EXTRACT_DATE
+      data_type: DATE
+    - name: PRACTICE_CODE
+      data_type: TEXT
+    - name: PRACTICE_NAME
+      data_type: TEXT
+    - name: LSOA_CODE
+      data_type: TEXT
+    - name: SEX
+      data_type: TEXT
+    - name: NUMBER_OF_PATIENTS
+      data_type: NUMBER
   - name: IMD2019
     identifier: '"IMD2019"'
     columns:
@@ -8861,6 +8878,23 @@ sources:
       data_type: TEXT
     - name: OBJECTID
       data_type: NUMBER
+  - name: LSOA21_WARD25_LAD25
+    identifier: '"LSOA21_WARD25_LAD25"'
+    columns:
+    - name: LSOA21CD
+      data_type: TEXT
+    - name: LSOA21NM
+      data_type: TEXT
+    - name: WD25CD
+      data_type: TEXT
+    - name: WD25NM
+      data_type: TEXT
+    - name: LAD25CD
+      data_type: TEXT
+    - name: LAD25NM
+      data_type: TEXT
+    - name: RESIDENT_FLAG
+      data_type: TEXT
   - name: NCL_GP_PRACTICE_NEIGHBOURHOOD
     identifier: '"NCL_GP_PRACTICE_NEIGHBOURHOOD"'
     columns:


### PR DESCRIPTION
## Summary
- Creates new intermediate models for clean separation of concerns
- Fixes IMD aggregation errors and schema compatibility issues
- Updates downstream models to use new geography fields

## New Models
- `int_geography_london_boroughs`: London borough identification and name cleaning
- `int_geography_imd`: Dedicated IMD 2019 calculations with text/numeric quintiles  
- `int_geography_mappings`: Geographic code-to-name lookup table

## Test plan
- [x] All geography models compile and run successfully
- [x] Downstream models updated to use new field names
- [x] IMD aggregation errors resolved
- [ ] Full refresh needed for `person_month_analysis_base` incremental model