### PR TITLE
fix: disable AWS metadata checks in start_dbt.ps1

### DIFF
--- a/start_dbt.ps1
+++ b/start_dbt.ps1
@@ -87,6 +87,9 @@ if ($LASTEXITCODE -eq 0) {
 }
 Write-Host ""
 
+# Disable AWS metadata service checks (prevents connection pool warnings on Azure)
+[System.Environment]::SetEnvironmentVariable('AWS_EC2_METADATA_DISABLED', 'true', 'Process')
+
 # Load project-specific environment variables
 Write-Host "Loading environment variables from .env..." -ForegroundColor Cyan
 


### PR DESCRIPTION
## Summary
- Disables AWS EC2 metadata service checks to prevent urllib3 connection pool warnings

## Problem
When running dbt on Azure, the snowflake-connector-python's boto3 dependency attempts to fetch AWS credentials from the metadata service at 169.254.169.254. These requests fail on non-AWS environments, filling the connection pool (size 10) and causing warnings.

## Solution
Sets `AWS_EC2_METADATA_DISABLED=true` in the start_dbt.ps1 script before loading environment variables, preventing boto3 from attempting these unnecessary checks.

## Test plan
- [x] Run `.\start_dbt.ps1` in a fresh shell
- [x] Verify dbt commands no longer show connection pool warnings