### PR TITLE
fix: populate postcode_hash in historical demographics tables

### DIFF
--- a/models/olids/reporting/person_analytics/person_month_analysis_base.yml
+++ b/models/olids/reporting/person_analytics/person_month_analysis_base.yml
@@ -16,6 +16,10 @@ models:
 
       • UK financial year and quarter dimensions
 
+      Known Limitations:
+
+      • Address/geographic fields use current address for all historical months (address history dates not available)
+
       Purpose: Supports population health reporting and clinical quality indicators. Incremental processing handles new months whilst full refresh captures late-arriving data.'
     
     config:
@@ -167,7 +171,7 @@ models:
         description: PCN name including borough
         
       - name: post_code_hash
-        description: Hashed postcode for privacy
+        description: Hashed postcode for privacy (current address used for all months)
         
       - name: uprn_hash
         description: Hashed UPRN for privacy

--- a/models/olids/reporting/person_demographics/dim_person_demographics_historical.sql
+++ b/models/olids/reporting/person_demographics/dim_person_demographics_historical.sql
@@ -64,31 +64,30 @@ WITH person_months AS (
 ),
 
 monthly_addresses AS (
-    -- Get address and geography valid for each person-month using intermediate model with SCD2 logic
-    SELECT DISTINCT
+    -- Get current address for each person-month
+    -- NOTE: Uses current address for all historical months due to lack of address history dates
+    SELECT
         pm.analysis_month,
         pm.person_id,
-        pc.postcode_hash,
-        pc.primary_care_organisation as icb_code_resident,
-        pc.icb_resident,
-        pc.local_authority_code,
-        pc.local_authority_name,
-        pc.borough_resident,
-        pc.is_london_resident,
-        pc.london_classification,
-        pc.lsoa_code_21,
-        pc.lsoa_name_21,
-        pc.ward_code,
-        pc.ward_name,
-        pc.neighbourhood_resident,
-        pc.imd_decile_19,
-        pc.imd_quintile_19,
-        pc.imd_quintile_numeric_19
+        pg.postcode_hash,
+        pg.primary_care_organisation as icb_code_resident,
+        pg.icb_resident,
+        pg.local_authority_code,
+        pg.local_authority_name,
+        pg.borough_resident,
+        pg.is_london_resident,
+        pg.london_classification,
+        pg.lsoa_code_21,
+        pg.lsoa_name_21,
+        pg.ward_code,
+        pg.ward_name,
+        pg.neighbourhood_resident,
+        pg.imd_decile_19,
+        pg.imd_quintile_19,
+        pg.imd_quintile_numeric_19
     FROM person_months pm
-    LEFT JOIN {{ ref('int_person_geography') }} pc
-        ON pm.person_id = pc.person_id
-        AND pc.address_start_date <= pm.analysis_month
-        AND (pc.address_end_date IS NULL OR pc.address_end_date >= DATE_TRUNC('month', pm.analysis_month))
+    LEFT JOIN {{ ref('int_person_geography') }} pg
+        ON pm.person_id = pg.person_id
 ),
 
 monthly_ethnicity AS (

--- a/models/olids/reporting/person_demographics/dim_person_demographics_historical.yml
+++ b/models/olids/reporting/person_demographics/dim_person_demographics_historical.yml
@@ -15,7 +15,7 @@ models:
 
       • Practice registration status as of each month
 
-      • Ethnicity and address data as recorded by each month
+      • Ethnicity as recorded by each month
 
       • 5-year rolling history window for performance
 
@@ -26,6 +26,10 @@ models:
       • Excludes persons without any registration history
 
       • Maintains temporal accuracy for all demographic attributes
+
+      Known Limitations:
+
+      • Address/geographic fields use current address for all historical months (address history dates not available)
 
       For analysis queries using specific months.'
 
@@ -192,7 +196,7 @@ models:
         description: 'Practice neighbourhood classification'
 
       - name: postcode_hash
-        description: 'Patient residential address postcode hash for privacy protection (as of analysis month)'
+        description: 'Patient residential address postcode hash for privacy protection (current address used for all months)'
 
       - name: uprn_hash
         description: 'Patient address Unique Property Reference Number hash (placeholder for future use)'


### PR DESCRIPTION
## Summary

- Fixes NULL postcode_hash and geographic fields in dim_person_demographics_historical
- Updates monthly_addresses CTE to join int_person_geography without date filtering
- Documents limitation that historical months use current address

## Root Cause

The monthly_addresses CTE was attempting to filter int_person_geography by address_start_date and address_end_date, but int_person_geography only returns one row per person (current address). This caused the date filter to fail for historical months, resulting in NULL geographic fields.

## Solution

Simplified the join to match dim_person_demographics approach - join on person_id only to get current address for all months. Since address history dates aren't available in source data, this is the best available option.

## Known Limitation

Historical months now show current address rather than address at that point in time. This limitation is now documented in:
- dim_person_demographics_historical model and field descriptions
- person_month_analysis_base model and field descriptions