### PR TITLE
fix: use double underscore in database prefix for default database

### DIFF
--- a/macros/generate_database_name.sql
+++ b/macros/generate_database_name.sql
@@ -10,7 +10,7 @@
         {%- if database_prefix is none -%}
             {{ target.database }}
         {%- else -%}
-            {{ database_prefix }}_{{ target.database }}
+            {{ database_prefix }}__{{ target.database }}
         {%- endif -%}
     {%- else -%}
         {%- if database_prefix is none -%}


### PR DESCRIPTION
Fixes inconsistency in `generate_database_name` macro where default database used single underscore while custom databases used double underscore.

**Problem:**
- Default database: `DEV_MODELLING` (single underscore) ❌
- Custom databases: `DEV__REPORTING` (double underscore) ✓

This caused `dbt docs generate` to fail with:
```
Database 'DEV_MODELLING' does not exist or not authorized.
```

**Solution:**
Changed line 13 to use `__` (double underscore) consistently.

**Test:**
`dbt docs generate` now succeeds.