### PR TITLE
Implement Type 1 opt-out tagging and row access policy infrastructure

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -7,6 +7,7 @@ profile: 'ncl_analytics'
 # Display connection info when dbt runs start
 on-run-start:
   - "{{ log('🔗 DBT CONNECTION: Role=' ~ target.role ~ ', Warehouse=' ~ target.warehouse ~ ', Database=' ~ target.database ~ ', Schema=' ~ target.schema ~ ', Target=' ~ target.name, info=True) }}"
+  - "{{ ensure_governance_tags() }}"
 
 
 target-path: "target"
@@ -132,7 +133,9 @@ models:
         +materialized: table
         +database: "PUBLISHED_REPORTING__SECONDARY_USE"
         +schema: "OLIDS_PUBLISHED"
-        +post-hook: ["{{ add_model_comment() }}"]
+        +post-hook:
+          - "{{ add_model_comment() }}"
+          - "{{ apply_snowflake_tag_if_tagged('secondary_use_opt_out', 'DATA_CATEGORY', 'PRIMARY_CARE_SECONDARY_USE') }}"
     
     # Shared models (reference data, utilities)
     shared:

--- a/macros/apply_snowflake_tag_if_tagged.sql
+++ b/macros/apply_snowflake_tag_if_tagged.sql
@@ -1,0 +1,5 @@
+{% macro apply_snowflake_tag_if_tagged(dbt_tag, sf_tag_name, sf_tag_value) %}
+  {% if dbt_tag in config.get('tags', []) %}
+    ALTER {{ this }} SET TAG {{ sf_tag_name }} = '{{ sf_tag_value }}';
+  {% endif %}
+{% endmacro %}

--- a/macros/apply_snowflake_tag_if_tagged.sql
+++ b/macros/apply_snowflake_tag_if_tagged.sql
@@ -1,5 +1,10 @@
 {% macro apply_snowflake_tag_if_tagged(dbt_tag, sf_tag_name, sf_tag_value) %}
   {% if dbt_tag in config.get('tags', []) %}
-    ALTER {{ this }} SET TAG {{ sf_tag_name }} = '{{ sf_tag_value }}';
+    {% set object_type = config.get('materialized', 'table') %}
+    {% if object_type == 'view' %}
+      ALTER VIEW {{ this }} SET TAG {{ this.database }}.{{ this.schema }}.{{ sf_tag_name }} = '{{ sf_tag_value }}';
+    {% else %}
+      ALTER TABLE {{ this }} SET TAG {{ this.database }}.{{ this.schema }}.{{ sf_tag_name }} = '{{ sf_tag_value }}';
+    {% endif %}
   {% endif %}
 {% endmacro %}

--- a/macros/ensure_governance_tags.sql
+++ b/macros/ensure_governance_tags.sql
@@ -1,16 +1,22 @@
 {% macro ensure_governance_tags() %}
   {% if execute %}
-    {% set schemas = [] %}
+    {% set schema_keys = [] %}
     {% for node in graph.nodes.values() %}
       {% if node.resource_type in ['model', 'snapshot'] and 'secondary_use_opt_out' in node.tags %}
-        {% do schemas.append({'database': node.database, 'schema': node.schema}) %}
+        {% set key = node.database ~ '.' ~ node.schema %}
+        {% if key not in schema_keys %}
+          {% do schema_keys.append(key) %}
+        {% endif %}
       {% endif %}
     {% endfor %}
 
-    {% for item in schemas | unique %}
+    {% for key in schema_keys %}
+      {% set parts = key.split('.') %}
+      {% set database = parts[0] %}
+      {% set schema = parts[1] %}
       {% set sql %}
-        CREATE SCHEMA IF NOT EXISTS {{ item.database }}.{{ item.schema }};
-        CREATE TAG IF NOT EXISTS {{ item.database }}.{{ item.schema }}.DATA_CATEGORY;
+        CREATE SCHEMA IF NOT EXISTS {{ database }}.{{ schema }};
+        CREATE TAG IF NOT EXISTS {{ database }}.{{ schema }}.DATA_CATEGORY;
       {% endset %}
       {% do run_query(sql) %}
     {% endfor %}

--- a/macros/ensure_governance_tags.sql
+++ b/macros/ensure_governance_tags.sql
@@ -1,0 +1,18 @@
+{% macro ensure_governance_tags() %}
+  {% if execute %}
+    {% set schemas = [] %}
+    {% for node in graph.nodes.values() %}
+      {% if node.resource_type in ['model', 'snapshot'] and 'secondary_use_opt_out' in node.tags %}
+        {% do schemas.append({'database': node.database, 'schema': node.schema}) %}
+      {% endif %}
+    {% endfor %}
+
+    {% for item in schemas | unique %}
+      {% set sql %}
+        CREATE SCHEMA IF NOT EXISTS {{ item.database }}.{{ item.schema }};
+        CREATE TAG IF NOT EXISTS {{ item.database }}.{{ item.schema }}.DATA_CATEGORY;
+      {% endset %}
+      {% do run_query(sql) %}
+    {% endfor %}
+  {% endif %}
+{% endmacro %}

--- a/models/olids/modelling/person_attributes/int_opt_out_type_1_all.sql
+++ b/models/olids/modelling/person_attributes/int_opt_out_type_1_all.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+Type 1 opt-out observations (dissent from secondary use of primary care data).
+Uses cluster IDs: OPT_OUT_TYPE_1_DISSENT_WITHDRAWAL and OPT_OUT_TYPE_1_DISSENT.
+*/
+
+SELECT
+    obs.id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS code_description,
+    obs.cluster_id AS source_cluster_id,
+
+    CASE
+        WHEN obs.cluster_id = 'OPT_OUT_TYPE_1_DISSENT_WITHDRAWAL' THEN TRUE
+        ELSE FALSE
+    END AS is_withdrawal,
+
+    CASE
+        WHEN obs.cluster_id = 'OPT_OUT_TYPE_1_DISSENT' THEN TRUE
+        ELSE FALSE
+    END AS is_dissent
+
+FROM ({{ get_observations("'OPT_OUT_TYPE_1_DISSENT_WITHDRAWAL', 'OPT_OUT_TYPE_1_DISSENT'") }}) obs
+WHERE obs.clinical_effective_date IS NOT NULL
+ORDER BY person_id, clinical_effective_date DESC

--- a/models/olids/published_reporting_secondary_use/childhood_imms_person_level_adolescent_dm_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/childhood_imms_person_level_adolescent_dm_secondary_use.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        materialized='table',
+        alias='childhood_imms_person_level_adolescent_dm',
+        tags=['secondary_use_opt_out']
+    )
+}}
+
+/*
+Childhood Immunisations Person Level Adolescent - Secondary Use
+
+Secondary use version with opt-out filtering applied.
+Only includes patients allowed for secondary use via dim_person_secondary_use_allowed.
+
+See childhood_imms_person_level_adolescent_dm in published_reporting_direct_care for full documentation.
+*/
+
+SELECT base.*
+FROM {{ ref('childhood_imms_person_level_adolescent_dm') }} base
+INNER JOIN {{ ref('dim_person_secondary_use_allowed') }} allowed
+    ON base.person_id = allowed.person_id

--- a/models/olids/published_reporting_secondary_use/childhood_imms_person_level_child_dm_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/childhood_imms_person_level_child_dm_secondary_use.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        materialized='table',
+        alias='childhood_imms_person_level_child_dm',
+        tags=['secondary_use_opt_out']
+    )
+}}
+
+/*
+Childhood Immunisations Person Level Child - Secondary Use
+
+Secondary use version with opt-out filtering applied.
+Only includes patients allowed for secondary use via dim_person_secondary_use_allowed.
+
+See childhood_imms_person_level_child_dm in published_reporting_direct_care for full documentation.
+*/
+
+SELECT base.*
+FROM {{ ref('childhood_imms_person_level_child_dm') }} base
+INNER JOIN {{ ref('dim_person_secondary_use_allowed') }} allowed
+    ON base.person_id = allowed.person_id

--- a/models/olids/published_reporting_secondary_use/covid_flu_dashboard_base_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/covid_flu_dashboard_base_secondary_use.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        materialized='table',
+        alias='covid_flu_dashboard_base',
+        tags=['secondary_use_opt_out'],
+        cluster_by=['programme_type', 'campaign_id', 'practice_code', 'person_id']
+    )
+}}
+
+/*
+COVID and Flu Dashboard Base Table - Secondary Use
+
+Secondary use version with opt-out filtering applied.
+Only includes patients allowed for secondary use via dim_person_secondary_use_allowed.
+
+See covid_flu_dashboard_base in published_reporting_direct_care for full documentation.
+*/
+
+SELECT base.*
+FROM {{ ref('covid_flu_dashboard_base') }} base
+INNER JOIN {{ ref('dim_person_secondary_use_allowed') }} allowed
+    ON base.person_id = allowed.person_id

--- a/models/olids/published_reporting_secondary_use/ltc_lcs_cf_dashboard_base_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/ltc_lcs_cf_dashboard_base_secondary_use.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        materialized='table',
+        alias='ltc_lcs_cf_dashboard_base',
+        tags=['secondary_use_opt_out'],
+        cluster_by=['indicator_category', 'indicator_id']
+    )
+}}
+
+/*
+LTC/LCS Case Finding Dashboard Base Table - Secondary Use
+
+Secondary use version with opt-out filtering applied.
+Only includes patients allowed for secondary use via dim_person_secondary_use_allowed.
+
+See ltc_lcs_cf_dashboard_base in published_reporting_direct_care for full documentation.
+*/
+
+SELECT base.*
+FROM {{ ref('ltc_lcs_cf_dashboard_base') }} base
+INNER JOIN {{ ref('dim_person_secondary_use_allowed') }} allowed
+    ON base.person_id = allowed.person_id

--- a/models/olids/published_reporting_secondary_use/population_health_needs_base_readable_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/population_health_needs_base_readable_secondary_use.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        materialized='table',
+        alias='population_health_needs_base_readable',
+        tags=['secondary_use_opt_out']
+    )
+}}
+
+/*
+Population Health Needs Base Readable - Secondary Use
+
+Secondary use version with opt-out filtering applied.
+Only includes patients allowed for secondary use via dim_person_secondary_use_allowed.
+
+See population_health_needs_base_readable in published_reporting_direct_care for full documentation.
+*/
+
+SELECT base.*
+FROM {{ ref('population_health_needs_base_readable') }} base
+INNER JOIN {{ ref('dim_person_secondary_use_allowed') }} allowed
+    ON base.person_id = allowed.person_id

--- a/models/olids/published_reporting_secondary_use/population_health_needs_base_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/population_health_needs_base_secondary_use.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        materialized='table',
+        alias='population_health_needs_base',
+        tags=['secondary_use_opt_out']
+    )
+}}
+
+/*
+Population Health Needs Base - Secondary Use
+
+Secondary use version with opt-out filtering applied.
+Only includes patients allowed for secondary use via dim_person_secondary_use_allowed.
+
+See population_health_needs_base in published_reporting_direct_care for full documentation.
+*/
+
+SELECT base.*
+FROM {{ ref('population_health_needs_base') }} base
+INNER JOIN {{ ref('dim_person_secondary_use_allowed') }} allowed
+    ON base.person_id = allowed.person_id

--- a/models/olids/published_reporting_secondary_use/schema.yml
+++ b/models/olids/published_reporting_secondary_use/schema.yml
@@ -1,0 +1,38 @@
+version: 2
+
+models:
+  - name: covid_flu_dashboard_base_secondary_use
+    description: |
+      COVID and Flu Dashboard base table for secondary use.
+      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      See covid_flu_dashboard_base in published_reporting_direct_care for full details.
+
+  - name: ltc_lcs_cf_dashboard_base_secondary_use
+    description: |
+      LTC/LCS Case Finding Dashboard base table for secondary use.
+      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      See ltc_lcs_cf_dashboard_base in published_reporting_direct_care for full details.
+
+  - name: population_health_needs_base_secondary_use
+    description: |
+      Population health needs base table for secondary use.
+      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      See population_health_needs_base in published_reporting_direct_care for full details.
+
+  - name: population_health_needs_base_readable_secondary_use
+    description: |
+      Population health needs base readable table for secondary use.
+      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      See population_health_needs_base_readable in published_reporting_direct_care for full details.
+
+  - name: childhood_imms_person_level_child_dm_secondary_use
+    description: |
+      Childhood immunisations person-level data for children, for secondary use.
+      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      See childhood_imms_person_level_child_dm in published_reporting_direct_care for full details.
+
+  - name: childhood_imms_person_level_adolescent_dm_secondary_use
+    description: |
+      Childhood immunisations person-level data for adolescents, for secondary use.
+      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      See childhood_imms_person_level_adolescent_dm in published_reporting_direct_care for full details.

--- a/models/olids/reporting/person_status/dim_person_opt_out_type_1_status.sql
+++ b/models/olids/reporting/person_status/dim_person_opt_out_type_1_status.sql
@@ -21,13 +21,15 @@ WITH latest_opt_out_status AS (
         opt.source_cluster_id,
 
         CASE
-            WHEN opt.source_cluster_id IN ('OPT_OUT_TYPE_1_DISSENT', 'OPT_OUT_TYPE_1_DISSENT_WITHDRAWAL') THEN TRUE
+            WHEN opt.source_cluster_id = 'OPT_OUT_TYPE_1_DISSENT' THEN TRUE
+            WHEN opt.source_cluster_id = 'OPT_OUT_TYPE_1_DISSENT_WITHDRAWAL' THEN FALSE
             ELSE FALSE
         END AS is_opted_out,
 
         CASE
-            WHEN opt.source_cluster_id IN ('OPT_OUT_TYPE_1_DISSENT', 'OPT_OUT_TYPE_1_DISSENT_WITHDRAWAL') THEN 'Opted Out'
-            ELSE 'Not Opted Out'
+            WHEN opt.source_cluster_id = 'OPT_OUT_TYPE_1_DISSENT' THEN 'Opted Out'
+            WHEN opt.source_cluster_id = 'OPT_OUT_TYPE_1_DISSENT_WITHDRAWAL' THEN 'Withdrawal of Dissent'
+            ELSE 'Unknown'
         END AS opt_out_status
 
     FROM {{ ref('int_opt_out_type_1_all') }} opt
@@ -49,3 +51,4 @@ SELECT
     is_opted_out,
     opt_out_status
 FROM latest_opt_out_status
+WHERE is_opted_out = TRUE

--- a/models/olids/reporting/person_status/dim_person_opt_out_type_1_status.sql
+++ b/models/olids/reporting/person_status/dim_person_opt_out_type_1_status.sql
@@ -1,0 +1,51 @@
+{{
+    config(
+        materialized='table',
+        tags=['dimension', 'person', 'opt_out', 'gdpr'],
+        cluster_by=['person_id'])
+}}
+
+/*
+Type 1 opt-out status dimension.
+Holds latest Type 1 opt-out status (dissent from secondary use of primary care data).
+Only includes persons with Type 1 opt-out records.
+*/
+
+WITH latest_opt_out_status AS (
+    SELECT
+        opt.person_id,
+        pp.sk_patient_id,
+        opt.clinical_effective_date,
+        opt.concept_code,
+        opt.code_description,
+        opt.source_cluster_id,
+
+        CASE
+            WHEN opt.source_cluster_id IN ('OPT_OUT_TYPE_1_DISSENT', 'OPT_OUT_TYPE_1_DISSENT_WITHDRAWAL') THEN TRUE
+            ELSE FALSE
+        END AS is_opted_out,
+
+        CASE
+            WHEN opt.source_cluster_id IN ('OPT_OUT_TYPE_1_DISSENT', 'OPT_OUT_TYPE_1_DISSENT_WITHDRAWAL') THEN 'Opted Out'
+            ELSE 'Not Opted Out'
+        END AS opt_out_status
+
+    FROM {{ ref('int_opt_out_type_1_all') }} opt
+    JOIN {{ ref('int_patient_person_unique') }} pp
+        ON opt.person_id = pp.person_id
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY opt.person_id
+        ORDER BY opt.clinical_effective_date DESC, opt.id DESC
+    ) = 1
+)
+
+SELECT
+    person_id,
+    sk_patient_id,
+    clinical_effective_date AS latest_opt_out_date,
+    concept_code,
+    code_description,
+    source_cluster_id,
+    is_opted_out,
+    opt_out_status
+FROM latest_opt_out_status

--- a/models/olids/reporting/person_status/dim_person_secondary_use_allowed.sql
+++ b/models/olids/reporting/person_status/dim_person_secondary_use_allowed.sql
@@ -1,0 +1,31 @@
+{{
+    config(
+        materialized='table',
+        tags=['dimension', 'person', 'opt_out', 'gdpr'],
+        cluster_by=['person_id'])
+}}
+
+/*
+Persons allowed for secondary use.
+Central opt-out filter - excludes patients with active Type 1 opt-outs.
+All secondary use models should inner join to this to apply opt-out filtering.
+
+Future opt-outs can be added here (e.g., national data opt-out).
+*/
+
+WITH opted_out_type_1 AS (
+    SELECT person_id
+    FROM {{ ref('dim_person_opt_out_type_1_status') }}
+    WHERE is_opted_out = TRUE
+),
+
+all_persons AS (
+    SELECT DISTINCT person_id
+    FROM {{ ref('int_patient_person_unique') }}
+)
+
+SELECT
+    person_id,
+    TRUE AS is_allowed_secondary_use
+FROM all_persons
+WHERE person_id NOT IN (SELECT person_id FROM opted_out_type_1)


### PR DESCRIPTION
## Summary
Implements governance infrastructure for Type 1 opt-outs (dissent from secondary use of primary care data) using Snowflake tags and centralised filtering.

Closes #71

## Changes

### Core Models
- **int_opt_out_type_1_all**: Extracts Type 1 opt-out observations using clusters `OPT_OUT_TYPE_1_DISSENT_WITHDRAWAL` and `OPT_OUT_TYPE_1_DISSENT`
- **dim_person_opt_out_type_1_status**: Tracks current opt-out status per person, correctly handling withdrawal of dissent
- **dim_person_secondary_use_allowed**: Central opt-out filter - single source of truth for which patients are allowed in secondary use

### Secondary Use Models
Created filtered versions of published models in `published_reporting_secondary_use`:
- covid_flu_dashboard_base
- ltc_lcs_cf_dashboard_base  
- population_health_needs_base
- population_health_needs_base_readable
- childhood_imms_person_level_child_dm
- childhood_imms_person_level_adolescent_dm

All use `alias` to maintain same table names as direct care versions, and inner join to `dim_person_secondary_use_allowed` for filtering.

### Snowflake Tagging Infrastructure
- **ensure_governance_tags**: Macro to create `DATA_CATEGORY` tags in schemas containing tagged models
- **apply_snowflake_tag_if_tagged**: Post-hook macro to apply Snowflake tags based on dbt tags
- Models with `secondary_use_opt_out` dbt tag automatically get `DATA_CATEGORY = 'PRIMARY_CARE_SECONDARY_USE'` Snowflake tag
- Tag application prepared for future Row Access Policy implementation

## Implementation Notes
- Defense in depth: Models filter via inner join AND get tagged for future Row Access Policy
- Centralized opt-out logic in `dim_person_secondary_use_allowed` makes it easy to add national data opt-out later
- Aggregate models excluded for now (require filtering at intermediate layer)
-
## Test Plan
- [x] Models build successfully with opt-out filtering applied
- [x] Tags created in correct schemas