### PR TITLE
feat: add centralised data refresh metadata tables

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -7,7 +7,7 @@ profile: 'ncl_analytics'
 # Display connection info when dbt runs start
 on-run-start:
   - "{{ log('🔗 DBT CONNECTION: Role=' ~ target.role ~ ', Warehouse=' ~ target.warehouse ~ ', Database=' ~ target.database ~ ', Schema=' ~ target.schema ~ ', Target=' ~ target.name, info=True) }}"
-  - "{{ ensure_governance_tags() }}"
+  - "{% if flags.WHICH in ['run', 'build'] %}{{ ensure_governance_tags() }}{% endif %}"
 
 
 target-path: "target"

--- a/models/olids/modelling/utilities/int_global_data_refresh_date.sql
+++ b/models/olids/modelling/utilities/int_global_data_refresh_date.sql
@@ -1,0 +1,38 @@
+{{
+    config(
+        materialized='table',
+        tags=['utility', 'refresh_date', 'daily']
+    )
+}}
+
+/*
+Global OLIDS Data Refresh Date
+
+Calculates the consensus date where at least 150 practices have uploaded data,
+excluding future dates. This filters out both stale practices and those entering
+incorrect future dates.
+
+Returns a single row with the most recent valid data refresh date.
+*/
+
+WITH practice_list AS (
+    SELECT DISTINCT practice_code
+    FROM {{ ref('dim_practice') }}
+),
+date_practice_counts AS (
+    SELECT
+        o.clinical_effective_date::date AS obs_date,
+        COUNT(DISTINCT o.record_owner_organisation_code) AS practice_count
+    FROM {{ ref('stg_olids_observation') }} o
+    INNER JOIN practice_list p
+        ON o.record_owner_organisation_code = p.practice_code
+    WHERE o.clinical_effective_date < CURRENT_DATE()
+    GROUP BY o.clinical_effective_date::date
+)
+
+SELECT
+    obs_date AS global_data_refresh_date
+FROM date_practice_counts
+WHERE practice_count >= 150
+ORDER BY obs_date DESC
+LIMIT 1

--- a/models/olids/modelling/utilities/int_global_data_refresh_date.yml
+++ b/models/olids/modelling/utilities/int_global_data_refresh_date.yml
@@ -1,0 +1,19 @@
+version: 2
+
+models:
+  - name: int_global_data_refresh_date
+    description: |
+      Global OLIDS data refresh date based on practice upload consensus.
+
+      Calculates the most recent date where at least 150 practices have uploaded observation data,
+      excluding future dates. This consensus approach filters out both stale practices and those
+      entering incorrect future dates, providing a reliable indicator of when most OLIDS data was
+      last refreshed.
+
+      Returns a single row with one column: global_data_refresh_date.
+
+    columns:
+      - name: global_data_refresh_date
+        description: Most recent date where ≥150 practices have uploaded data (excludes future dates)
+        tests:
+          - not_null

--- a/models/olids/published_reporting_direct_care/metadata_refresh_dates.sql
+++ b/models/olids/published_reporting_direct_care/metadata_refresh_dates.sql
@@ -1,0 +1,63 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+
+/*
+OLIDS Data Refresh Metadata
+
+Provides centralized refresh date information for OLIDS data and dashboard tables.
+
+Columns:
+- metric_type: Type of metric (global_data_refresh, table_refresh)
+- table_name: Name of dashboard table (NULL for global metrics)
+- refresh_date: Date when data was last refreshed
+- last_altered_timestamp: Timestamp when table was last modified (from Snowflake metadata)
+
+The global_data_refresh represents the consensus date where at least 150 practices
+have uploaded data, excluding future dates. This filters out both stale practices
+and those entering incorrect future dates.
+
+Table refresh dates are retrieved directly from Snowflake's INFORMATION_SCHEMA,
+ensuring accuracy regardless of partial dbt runs.
+*/
+
+WITH global_refresh AS (
+    SELECT
+        'global_data_refresh' AS metric_type,
+        NULL AS table_name,
+        global_data_refresh_date AS refresh_date,
+        NULL AS last_altered_timestamp
+    FROM {{ ref('int_global_data_refresh_date') }}
+),
+dashboard_tables AS (
+    SELECT
+        'table_refresh' AS metric_type,
+        table_name,
+        last_altered AS last_altered_timestamp
+    FROM {{ this.database }}.INFORMATION_SCHEMA.TABLES
+    WHERE table_schema = 'OLIDS_PUBLISHED'
+        AND table_name IN (
+            'COVID_FLU_DASHBOARD_BASE',
+            'LTC_LCS_CF_DASHBOARD_BASE',
+            'POPULATION_HEALTH_NEEDS_BASE',
+            'POPULATION_HEALTH_NEEDS_BASE_READABLE',
+            'POPULATION_HEALTH_NEEDS_DEMOGRAPHICS_LTCS',
+            'CHILDHOOD_IMMS_PERSON_LEVEL_CHILD_DM',
+            'CHILDHOOD_IMMS_PERSON_LEVEL_ADOLESCENT_DM'
+        )
+),
+table_refresh AS (
+    SELECT
+        metric_type,
+        table_name,
+        last_altered_timestamp::date AS refresh_date,
+        last_altered_timestamp
+    FROM dashboard_tables
+)
+
+SELECT * FROM global_refresh
+UNION ALL
+SELECT * FROM table_refresh
+ORDER BY metric_type, table_name

--- a/models/olids/published_reporting_direct_care/metadata_refresh_dates.sql
+++ b/models/olids/published_reporting_direct_care/metadata_refresh_dates.sql
@@ -32,8 +32,21 @@ WITH global_refresh AS (
         NULL AS schema_name,
         NULL AS table_name,
         global_data_refresh_date AS refresh_date,
-        NULL AS last_altered_timestamp
+        NULL AS last_altered_timestamp,
+        0 AS sort_order
     FROM {{ ref('int_global_data_refresh_date') }}
+),
+published_reporting_tables AS (
+    SELECT
+        'table_refresh' AS metric_type,
+        table_catalog AS database_name,
+        table_schema AS schema_name,
+        table_name,
+        last_altered AS last_altered_timestamp,
+        1 AS sort_order
+    FROM {{ this.database }}.INFORMATION_SCHEMA.TABLES
+    WHERE table_type = 'BASE TABLE'
+        AND table_name != 'METADATA_REFRESH_DATES'
 ),
 reporting_tables AS (
     SELECT
@@ -41,20 +54,21 @@ reporting_tables AS (
         table_catalog AS database_name,
         table_schema AS schema_name,
         table_name,
-        last_altered AS last_altered_timestamp
-    FROM {{ this.database }}.INFORMATION_SCHEMA.TABLES
+        last_altered AS last_altered_timestamp,
+        2 AS sort_order
+    FROM {{ this.database.replace('PUBLISHED_REPORTING__DIRECT_CARE', 'REPORTING') }}.INFORMATION_SCHEMA.TABLES
     WHERE table_type = 'BASE TABLE'
-        AND table_name != 'METADATA_REFRESH_DATES'
-
-    UNION ALL
-
+        AND table_schema LIKE 'OLIDS_%'
+),
+modelling_tables AS (
     SELECT
         'table_refresh' AS metric_type,
         table_catalog AS database_name,
         table_schema AS schema_name,
         table_name,
-        last_altered AS last_altered_timestamp
-    FROM {{ target.database.replace('PUBLISHED_REPORTING__DIRECT_CARE', 'REPORTING') }}.INFORMATION_SCHEMA.TABLES
+        last_altered AS last_altered_timestamp,
+        3 AS sort_order
+    FROM {{ this.database.replace('PUBLISHED_REPORTING__DIRECT_CARE', 'MODELLING') }}.INFORMATION_SCHEMA.TABLES
     WHERE table_type = 'BASE TABLE'
         AND table_schema LIKE 'OLIDS_%'
 ),
@@ -65,11 +79,55 @@ table_refresh AS (
         schema_name,
         table_name,
         last_altered_timestamp::date AS refresh_date,
-        last_altered_timestamp
+        last_altered_timestamp,
+        sort_order
+    FROM published_reporting_tables
+
+    UNION ALL
+
+    SELECT
+        metric_type,
+        database_name,
+        schema_name,
+        table_name,
+        last_altered_timestamp::date AS refresh_date,
+        last_altered_timestamp,
+        sort_order
     FROM reporting_tables
+
+    UNION ALL
+
+    SELECT
+        metric_type,
+        database_name,
+        schema_name,
+        table_name,
+        last_altered_timestamp::date AS refresh_date,
+        last_altered_timestamp,
+        sort_order
+    FROM modelling_tables
 )
 
-SELECT * FROM global_refresh
+SELECT
+    metric_type,
+    database_name,
+    schema_name,
+    table_name,
+    refresh_date,
+    last_altered_timestamp,
+    sort_order
+FROM global_refresh
+
 UNION ALL
-SELECT * FROM table_refresh
-ORDER BY metric_type, database_name, schema_name, table_name
+
+SELECT
+    metric_type,
+    database_name,
+    schema_name,
+    table_name,
+    refresh_date,
+    last_altered_timestamp,
+    sort_order
+FROM table_refresh
+
+ORDER BY sort_order, schema_name, table_name

--- a/models/olids/published_reporting_direct_care/metadata_refresh_dates.sql
+++ b/models/olids/published_reporting_direct_care/metadata_refresh_dates.sql
@@ -38,15 +38,8 @@ dashboard_tables AS (
         last_altered AS last_altered_timestamp
     FROM {{ this.database }}.INFORMATION_SCHEMA.TABLES
     WHERE table_schema = 'OLIDS_PUBLISHED'
-        AND table_name IN (
-            'COVID_FLU_DASHBOARD_BASE',
-            'LTC_LCS_CF_DASHBOARD_BASE',
-            'POPULATION_HEALTH_NEEDS_BASE',
-            'POPULATION_HEALTH_NEEDS_BASE_READABLE',
-            'POPULATION_HEALTH_NEEDS_DEMOGRAPHICS_LTCS',
-            'CHILDHOOD_IMMS_PERSON_LEVEL_CHILD_DM',
-            'CHILDHOOD_IMMS_PERSON_LEVEL_ADOLESCENT_DM'
-        )
+        AND table_type = 'BASE TABLE'
+        AND table_name != 'METADATA_REFRESH_DATES'
 ),
 table_refresh AS (
     SELECT

--- a/models/olids/published_reporting_direct_care/metadata_refresh_dates.yml
+++ b/models/olids/published_reporting_direct_care/metadata_refresh_dates.yml
@@ -1,0 +1,31 @@
+version: 2
+
+models:
+  - name: metadata_refresh_dates
+    description: |
+      Centralised metadata tracking for OLIDS data freshness and table update timestamps.
+
+      Provides two types of metrics:
+      - **Global data refresh**: Consensus date where ≥150 practices have uploaded data (excludes future dates and filters out stale practices)
+      - **Table refresh**: Last modified timestamps for all OLIDS tables in REPORTING and PUBLISHED_REPORTING databases
+
+      Table timestamps are retrieved from Snowflake's INFORMATION_SCHEMA, ensuring accuracy regardless of partial dbt runs.
+
+    columns:
+      - name: metric_type
+        description: Type of metric (global_data_refresh or table_refresh)
+
+      - name: database_name
+        description: Snowflake database name (NULL for global metrics)
+
+      - name: schema_name
+        description: Snowflake schema name (NULL for global metrics)
+
+      - name: table_name
+        description: Table name (NULL for global metrics)
+
+      - name: refresh_date
+        description: Date when data was last refreshed (date portion of last_altered_timestamp for tables)
+
+      - name: last_altered_timestamp
+        description: Timestamp when table was last modified (from Snowflake metadata, NULL for global metrics)

--- a/models/olids/published_reporting_secondary_use/metadata_refresh_dates_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/metadata_refresh_dates_secondary_use.sql
@@ -21,36 +21,94 @@ WITH global_refresh AS (
         NULL AS schema_name,
         NULL AS table_name,
         global_data_refresh_date AS refresh_date,
-        NULL AS last_altered_timestamp
+        NULL AS last_altered_timestamp,
+        0 AS sort_order
     FROM {{ ref('int_global_data_refresh_date') }}
 ),
-table_refresh AS (
+published_reporting_tables AS (
     SELECT
         'table_refresh' AS metric_type,
         table_catalog AS database_name,
         table_schema AS schema_name,
         table_name,
         last_altered::date AS refresh_date,
-        last_altered AS last_altered_timestamp
+        last_altered AS last_altered_timestamp,
+        1 AS sort_order
     FROM {{ this.database }}.INFORMATION_SCHEMA.TABLES
     WHERE table_type = 'BASE TABLE'
         AND table_name != 'METADATA_REFRESH_DATES'
-
-    UNION ALL
-
+),
+reporting_tables AS (
     SELECT
         'table_refresh' AS metric_type,
         table_catalog AS database_name,
         table_schema AS schema_name,
         table_name,
         last_altered::date AS refresh_date,
-        last_altered AS last_altered_timestamp
-    FROM {{ target.database.replace('PUBLISHED_REPORTING__SECONDARY_USE', 'REPORTING') }}.INFORMATION_SCHEMA.TABLES
+        last_altered AS last_altered_timestamp,
+        2 AS sort_order
+    FROM {{ this.database.replace('PUBLISHED_REPORTING__SECONDARY_USE', 'REPORTING') }}.INFORMATION_SCHEMA.TABLES
+    WHERE table_type = 'BASE TABLE'
+        AND table_schema LIKE 'OLIDS_%'
+),
+modelling_tables AS (
+    SELECT
+        'table_refresh' AS metric_type,
+        table_catalog AS database_name,
+        table_schema AS schema_name,
+        table_name,
+        last_altered::date AS refresh_date,
+        last_altered AS last_altered_timestamp,
+        3 AS sort_order
+    FROM {{ this.database.replace('PUBLISHED_REPORTING__SECONDARY_USE', 'MODELLING') }}.INFORMATION_SCHEMA.TABLES
     WHERE table_type = 'BASE TABLE'
         AND table_schema LIKE 'OLIDS_%'
 )
 
-SELECT * FROM global_refresh
+SELECT
+    metric_type,
+    database_name,
+    schema_name,
+    table_name,
+    refresh_date,
+    last_altered_timestamp,
+    sort_order
+FROM global_refresh
+
 UNION ALL
-SELECT * FROM table_refresh
-ORDER BY metric_type, database_name, schema_name, table_name
+
+SELECT
+    metric_type,
+    database_name,
+    schema_name,
+    table_name,
+    refresh_date,
+    last_altered_timestamp,
+    sort_order
+FROM published_reporting_tables
+
+UNION ALL
+
+SELECT
+    metric_type,
+    database_name,
+    schema_name,
+    table_name,
+    refresh_date,
+    last_altered_timestamp,
+    sort_order
+FROM reporting_tables
+
+UNION ALL
+
+SELECT
+    metric_type,
+    database_name,
+    schema_name,
+    table_name,
+    refresh_date,
+    last_altered_timestamp,
+    sort_order
+FROM modelling_tables
+
+ORDER BY sort_order, schema_name, table_name

--- a/models/olids/published_reporting_secondary_use/metadata_refresh_dates_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/metadata_refresh_dates_secondary_use.sql
@@ -8,7 +8,7 @@
 /*
 OLIDS Data Refresh Metadata - Secondary Use
 
-Provides centralized refresh date information for OLIDS data and dashboard tables
+Provides centralised refresh date information for OLIDS data and dashboard tables
 in the secondary use schema.
 
 See metadata_refresh_dates in published_reporting_direct_care for full documentation.
@@ -17,6 +17,8 @@ See metadata_refresh_dates in published_reporting_direct_care for full documenta
 WITH global_refresh AS (
     SELECT
         'global_data_refresh' AS metric_type,
+        NULL AS database_name,
+        NULL AS schema_name,
         NULL AS table_name,
         global_data_refresh_date AS refresh_date,
         NULL AS last_altered_timestamp
@@ -25,7 +27,9 @@ WITH global_refresh AS (
 table_refresh AS (
     SELECT
         'table_refresh' AS metric_type,
-        table_schema || '.' || table_name AS table_name,
+        table_catalog AS database_name,
+        table_schema AS schema_name,
+        table_name,
         last_altered::date AS refresh_date,
         last_altered AS last_altered_timestamp
     FROM {{ this.database }}.INFORMATION_SCHEMA.TABLES
@@ -36,7 +40,9 @@ table_refresh AS (
 
     SELECT
         'table_refresh' AS metric_type,
-        table_schema || '.' || table_name AS table_name,
+        table_catalog AS database_name,
+        table_schema AS schema_name,
+        table_name,
         last_altered::date AS refresh_date,
         last_altered AS last_altered_timestamp
     FROM {{ target.database.replace('PUBLISHED_REPORTING__SECONDARY_USE', 'REPORTING') }}.INFORMATION_SCHEMA.TABLES
@@ -47,4 +53,4 @@ table_refresh AS (
 SELECT * FROM global_refresh
 UNION ALL
 SELECT * FROM table_refresh
-ORDER BY metric_type, table_name
+ORDER BY metric_type, database_name, schema_name, table_name

--- a/models/olids/published_reporting_secondary_use/metadata_refresh_dates_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/metadata_refresh_dates_secondary_use.sql
@@ -25,13 +25,23 @@ WITH global_refresh AS (
 table_refresh AS (
     SELECT
         'table_refresh' AS metric_type,
-        table_name,
+        table_schema || '.' || table_name AS table_name,
         last_altered::date AS refresh_date,
         last_altered AS last_altered_timestamp
     FROM {{ this.database }}.INFORMATION_SCHEMA.TABLES
-    WHERE table_schema = 'OLIDS_PUBLISHED'
-        AND table_type = 'BASE TABLE'
+    WHERE table_type = 'BASE TABLE'
         AND table_name != 'METADATA_REFRESH_DATES'
+
+    UNION ALL
+
+    SELECT
+        'table_refresh' AS metric_type,
+        table_schema || '.' || table_name AS table_name,
+        last_altered::date AS refresh_date,
+        last_altered AS last_altered_timestamp
+    FROM {{ target.database.replace('PUBLISHED_REPORTING__SECONDARY_USE', 'REPORTING') }}.INFORMATION_SCHEMA.TABLES
+    WHERE table_type = 'BASE TABLE'
+        AND table_schema LIKE 'OLIDS_%'
 )
 
 SELECT * FROM global_refresh

--- a/models/olids/published_reporting_secondary_use/metadata_refresh_dates_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/metadata_refresh_dates_secondary_use.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='view',
+        alias='metadata_refresh_dates'
+    )
+}}
+
+/*
+OLIDS Data Refresh Metadata - Secondary Use
+
+Provides centralized refresh date information for OLIDS data and dashboard tables
+in the secondary use schema.
+
+See metadata_refresh_dates in published_reporting_direct_care for full documentation.
+*/
+
+WITH global_refresh AS (
+    SELECT
+        'global_data_refresh' AS metric_type,
+        NULL AS table_name,
+        global_data_refresh_date AS refresh_date,
+        NULL AS last_altered_timestamp
+    FROM {{ ref('int_global_data_refresh_date') }}
+),
+table_refresh AS (
+    SELECT
+        'table_refresh' AS metric_type,
+        table_name,
+        last_altered::date AS refresh_date,
+        last_altered AS last_altered_timestamp
+    FROM {{ this.database }}.INFORMATION_SCHEMA.TABLES
+    WHERE table_schema = 'OLIDS_PUBLISHED'
+        AND table_name IN (
+            'COVID_FLU_DASHBOARD_BASE',
+            'LTC_LCS_CF_DASHBOARD_BASE',
+            'POPULATION_HEALTH_NEEDS_BASE',
+            'POPULATION_HEALTH_NEEDS_BASE_READABLE',
+            'CHILDHOOD_IMMS_PERSON_LEVEL_CHILD_DM',
+            'CHILDHOOD_IMMS_PERSON_LEVEL_ADOLESCENT_DM'
+        )
+)
+
+SELECT * FROM global_refresh
+UNION ALL
+SELECT * FROM table_refresh
+ORDER BY metric_type, table_name

--- a/models/olids/published_reporting_secondary_use/metadata_refresh_dates_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/metadata_refresh_dates_secondary_use.sql
@@ -30,14 +30,8 @@ table_refresh AS (
         last_altered AS last_altered_timestamp
     FROM {{ this.database }}.INFORMATION_SCHEMA.TABLES
     WHERE table_schema = 'OLIDS_PUBLISHED'
-        AND table_name IN (
-            'COVID_FLU_DASHBOARD_BASE',
-            'LTC_LCS_CF_DASHBOARD_BASE',
-            'POPULATION_HEALTH_NEEDS_BASE',
-            'POPULATION_HEALTH_NEEDS_BASE_READABLE',
-            'CHILDHOOD_IMMS_PERSON_LEVEL_CHILD_DM',
-            'CHILDHOOD_IMMS_PERSON_LEVEL_ADOLESCENT_DM'
-        )
+        AND table_type = 'BASE TABLE'
+        AND table_name != 'METADATA_REFRESH_DATES'
 )
 
 SELECT * FROM global_refresh

--- a/models/olids/published_reporting_secondary_use/schema.yml
+++ b/models/olids/published_reporting_secondary_use/schema.yml
@@ -36,3 +36,15 @@ models:
       Childhood immunisations person-level data for adolescents, for secondary use.
       Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
       See childhood_imms_person_level_adolescent_dm in published_reporting_direct_care for full details.
+
+  - name: metadata_refresh_dates_secondary_use
+    description: |
+      Centralised metadata tracking for OLIDS data freshness and table update timestamps (secondary use).
+
+      Provides two types of metrics:
+      - **Global data refresh**: Consensus date where ≥150 practices have uploaded data (excludes future dates and filters out stale practices)
+      - **Table refresh**: Last modified timestamps for all OLIDS tables in REPORTING and PUBLISHED_REPORTING databases
+
+      Table timestamps are retrieved from Snowflake's INFORMATION_SCHEMA, ensuring accuracy regardless of partial dbt runs.
+
+      See metadata_refresh_dates in published_reporting_direct_care for column documentation.


### PR DESCRIPTION
## Summary

Implements centralized tracking of OLIDS data refresh dates and dashboard table update timestamps, addressing the need for a single source of truth for data freshness information.

## Changes

- **`int_global_data_refresh_date`**: Intermediate table that calculates the consensus date where ≥150 practices have uploaded data, excluding future dates (filters out both stale practices and incorrect future dates)
- **`metadata_refresh_dates`**: View in `published_reporting_direct_care` that combines:
  - Global data refresh date (from int model)
  - Individual dashboard table last modified timestamps (from INFORMATION_SCHEMA)
- **`metadata_refresh_dates_secondary_use`**: Equivalent view for secondary use schema

## Implementation Details

- Global refresh calculation is materialized once in `int_global_data_refresh_date` for performance
- Metadata views use `{{ this.database }}` for environment-aware querying (works in both dev and prod)
- Table timestamps are always current via live INFORMATION_SCHEMA queries
- No data duplication - views are lightweight

## Test Plan

- [x] Verify `int_global_data_refresh_date` builds successfully
- [x] Query `metadata_refresh_dates` in direct care schema shows global + table refresh dates
- [x] Query `metadata_refresh_dates` in secondary use schema shows global + table refresh dates
- [x] Verify works in both dev and prod environments

Closes #50