### PR TITLE
fix: correct QOF cluster IDs for CHD and epilepsy registers

### DIFF
--- a/models/olids/modelling/diagnoses/qof/int_chd_diagnoses_all.sql
+++ b/models/olids/modelling/diagnoses/qof/int_chd_diagnoses_all.sql
@@ -34,7 +34,7 @@ SELECT
     -- CHD-specific flags (observation-level only)
     CASE WHEN obs.cluster_id = 'CHD_COD' THEN TRUE ELSE FALSE END AS is_diagnosis_code
 
-FROM ({{ get_observations("'CHD_COD'") }}) obs
+FROM ({{ get_observations("'CHD_COD'", source='PCD') }}) obs
 WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/olids/modelling/diagnoses/qof/int_epilepsy_diagnoses_all.sql
+++ b/models/olids/modelling/diagnoses/qof/int_epilepsy_diagnoses_all.sql
@@ -6,9 +6,9 @@
 
 /*
 All epilepsy diagnosis observations from clinical records.
-Uses QOF epilepsy cluster IDs:
+Uses QOF epilepsy cluster IDs per v50 business rules:
 - EPIL_COD: Epilepsy diagnoses
-- EPILDRUG_COD: Epilepsy drug codes
+- EPILRES_COD: Epilepsy resolved codes
 
 Clinical Purpose:
 - QOF epilepsy register data collection
@@ -36,16 +36,16 @@ SELECT
 
     -- Epilepsy-specific flags (observation-level only)
     CASE WHEN obs.cluster_id = 'EPIL_COD' THEN TRUE ELSE FALSE END AS is_diagnosis_code,
-    CASE WHEN obs.cluster_id = 'EPILDRUG_COD' THEN TRUE ELSE FALSE END AS is_resolved_code,
+    CASE WHEN obs.cluster_id = 'EPILRES_COD' THEN TRUE ELSE FALSE END AS is_resolved_code,
 
     -- Epilepsy observation type determination
     CASE
         WHEN obs.cluster_id = 'EPIL_COD' THEN 'Epilepsy Diagnosis'
-        WHEN obs.cluster_id = 'EPILDRUG_COD' THEN 'Epilepsy Drug'
+        WHEN obs.cluster_id = 'EPILRES_COD' THEN 'Epilepsy Resolved'
         ELSE 'Unknown'
     END AS epilepsy_observation_type
 
-FROM ({{ get_observations("'EPIL_COD', 'EPILDRUG_COD'", source='PCD') }}) obs
+FROM ({{ get_observations("'EPIL_COD', 'EPILRES_COD'", source='PCD') }}) obs
 WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/olids/modelling/diagnoses/qof/int_epilepsy_diagnoses_all.yml
+++ b/models/olids/modelling/diagnoses/qof/int_epilepsy_diagnoses_all.yml
@@ -3,7 +3,7 @@ models:
   - name: int_epilepsy_diagnoses_all
     description: 'Epilepsy diagnosis and resolution observations for QOF register management.
 
-      One row per observation using EPI_COD (diagnosis) and EPIRES_COD (resolution) clusters.'
+      One row per observation using EPIL_COD (diagnosis) and EPILRES_COD (resolution) clusters.'
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
@@ -21,17 +21,17 @@ models:
         description: 'Human-readable description of the clinical code'
 
       - name: source_cluster_id
-        description: 'QOF cluster identifier (EPIL_COD or EPILDRUG_COD)'
+        description: 'QOF cluster identifier (EPIL_COD or EPILRES_COD)'
 
       - name: is_diagnosis_code
         description: 'Flag indicating epilepsy diagnosis code (EPIL_COD cluster)'
 
       - name: is_resolved_code
-        description: 'Flag indicating epilepsy drug code (EPILDRUG_COD cluster)'
+        description: 'Flag indicating epilepsy resolved code (EPILRES_COD cluster)'
 
       - name: epilepsy_observation_type
-        description: 'Categorised epilepsy observation type (Epilepsy Diagnosis or Epilepsy Drug)'
+        description: 'Categorised epilepsy observation type (Epilepsy Diagnosis or Epilepsy Resolved)'
 
     tests:
       - cluster_ids_exist:
-          cluster_ids: EPIL_COD, EPILDRUG_COD
+          cluster_ids: EPIL_COD, EPILRES_COD


### PR DESCRIPTION
## Summary
- Add `source='PCD'` to CHD model to resolve cluster ID collision with UKHSA refsets
- Replace `EPILDRUG_COD` with `EPILRES_COD` in epilepsy model per QOF v50 business rules
- Update epilepsy YAML documentation and `cluster_ids_exist` test

## Changes
- **CHD**: Added PCD source filter to prevent collision with UKHSA CHD_COD cluster
- **Epilepsy**: Corrected cluster IDs from EPILDRUG_COD to EPILRES_COD for resolution codes
- **Documentation**: Updated YAML descriptions and test assertions

## Counts
Before change:
**CHD**: 126K records
**Epilepsy**: 7.3K records

After change:
**CHD**: 34K records (as expected)
**Epilepsy**: 7.2K records (slight reduction, good as exclusion criteria was wrong).

The counts for CHD now look correct, but for Epilepsy I suspect that healtheintent's logic was wrong. Need an extract against EMIS or QOF to confirm expected counts.

Resolves #55