### PR TITLE
feat: add hypertensive range flag and fix BP filtering

### DIFF
--- a/models/olids/modelling/observations/int_blood_pressure_all.yml
+++ b/models/olids/modelling/observations/int_blood_pressure_all.yml
@@ -11,7 +11,9 @@ models:
 
       • Identifies clinical context (Home BP, ABPM)
 
-      • Applies plausible value filtering (Systolic: 40-350 mmHg, Diastolic: 20-200 mmHg)
+      • Filters invalid readings: requires both systolic and diastolic values with plausible ranges (Systolic: 40-350 mmHg, Diastolic: 20-200 mmHg)
+
+      • Flags hypertensive range: ≥140/90 mmHg (clinic) or ≥135/85 mmHg (home/ABPM)
 
       • Uses six BP cluster types: BP_COD, SYSBP_COD, DIASBP_COD, HOMEAMBBP_COD, ABPM_COD, HOMEBP_COD
 
@@ -38,23 +40,25 @@ models:
       - name: systolic_value
         description: Systolic blood pressure value in mmHg
         tests:
+          - not_null
           - dbt_utils.accepted_range:
               min_value: 40
               max_value: 350
               inclusive: true
-              where: "systolic_value IS NOT NULL"
       - name: diastolic_value
         description: Diastolic blood pressure value in mmHg
         tests:
+          - not_null
           - dbt_utils.accepted_range:
               min_value: 20
               max_value: 200
               inclusive: true
-              where: "diastolic_value IS NOT NULL"
       - name: is_home_bp_event
         description: 'Boolean flag indicating if any observation on this date was recorded as home blood pressure (HOMEBP_COD, HOMEAMBBP_COD)'
       - name: is_abpm_bp_event
         description: 'Boolean flag indicating if any observation on this date was recorded as ambulatory blood pressure monitoring (ABPM_COD)'
+      - name: is_hypertensive_range
+        description: 'Boolean flag for stage 1 hypertension threshold: ≥140/90 mmHg (clinic) or ≥135/85 mmHg (home/ABPM)'
       - name: result_unit_display
         description: 'Unit of measurement for blood pressure values (always mmHg)'
       - name: systolic_id

--- a/models/olids/modelling/observations/int_blood_pressure_latest.sql
+++ b/models/olids/modelling/observations/int_blood_pressure_latest.sql
@@ -14,6 +14,7 @@ SELECT
     diastolic_value,
     is_home_bp_event,
     is_abpm_bp_event,
+    is_hypertensive_range,
     -- Additional metadata for traceability
     result_unit_display,
     systolic_observation_id,

--- a/models/olids/modelling/observations/int_blood_pressure_latest.yml
+++ b/models/olids/modelling/observations/int_blood_pressure_latest.yml
@@ -1,4 +1,28 @@
 version: 2
 models:
   - name: int_blood_pressure_latest
-    description: Latest blood pressure event per person with paired systolic/diastolic values and clinical context flags (Home/ABPM). One row per person containing their most recent BP event.
+    description: 'Latest blood pressure event per person with paired systolic/diastolic values, clinical context flags (Home/ABPM), and hypertensive range indicator. One row per person containing their most recent BP event.'
+    columns:
+      - name: person_id
+        description: Person identifier
+        tests:
+          - not_null
+          - unique
+      - name: clinical_effective_date
+        description: Date of most recent blood pressure measurement
+        tests:
+          - not_null
+      - name: systolic_value
+        description: Systolic blood pressure value in mmHg
+        tests:
+          - not_null
+      - name: diastolic_value
+        description: Diastolic blood pressure value in mmHg
+        tests:
+          - not_null
+      - name: is_home_bp_event
+        description: 'Boolean flag indicating if this BP was recorded as home blood pressure'
+      - name: is_abpm_bp_event
+        description: 'Boolean flag indicating if this BP was recorded as ambulatory blood pressure monitoring'
+      - name: is_hypertensive_range
+        description: 'Boolean flag for stage 1 hypertension threshold: ≥140/90 mmHg (clinic) or ≥135/85 mmHg (home/ABPM)'


### PR DESCRIPTION
## Summary
- Add `is_hypertensive_range` flag to identify stage 1 hypertension thresholds
- Fix invalid BP filtering to require both systolic and diastolic values
- Update tests and documentation

## Changes
- **Hypertensive range flag**: ≥140/90 mmHg (clinic) or ≥135/85 mmHg (home/ABPM) per NICE guidance
- **Invalid BP filtering**: Now requires both systolic AND diastolic values (previously allowed partial readings)
- **Tests**: Added `not_null` tests for systolic and diastolic columns
- **Documentation**: Updated YAML with new flag and filtering behaviour

## Clinical Context
The thresholds match NICE hypertension guidelines for stage 1 hypertension diagnosis, with different thresholds for clinic vs home/ambulatory monitoring.

Resolves #52