### PR TITLE
docs: add grain statements to measure and clinical safety model yml files

### DIFF
--- a/models/olids/reporting/clinical_safety/fct_clinical_safety_valproate_pregnancy.yml
+++ b/models/olids/reporting/clinical_safety/fct_clinical_safety_valproate_pregnancy.yml
@@ -3,6 +3,8 @@ models:
   - name: fct_clinical_safety_valproate_pregnancy
     description: 'Clinical safety alert identifying individuals of child-bearing age with recent valproate prescriptions.
 
+      One row per person of child-bearing age with valproate prescription within 6 months.
+
       Safety Concern: Valproate has teratogenic effects and requires monitoring in pregnancy or potential pregnancy.
 
       Criteria:

--- a/models/olids/reporting/measures/fct_person_bp_control.yml
+++ b/models/olids/reporting/measures/fct_person_bp_control.yml
@@ -3,6 +3,8 @@ models:
   - name: fct_person_bp_control
     description: 'Blood pressure control assessment using NICE NG136 guidelines with patient-specific targets.
 
+      One row per person that has a blood pressure recording.
+
       Treatment Targets:
 
       • Standard (under 80): <140/90 mmHg

--- a/models/olids/reporting/measures/fct_person_diabetes_triple_target.yml
+++ b/models/olids/reporting/measures/fct_person_diabetes_triple_target.yml
@@ -3,6 +3,8 @@ models:
   - name: fct_person_diabetes_triple_target
     description: 'Diabetes triple target achievement tracking for clinical quality monitoring.
 
+      One row per person on diabetes register.
+
       Target Criteria:
 
       • HbA1c ≤58 mmol/mol (QOF standard for glycaemic control)


### PR DESCRIPTION
## Summary
Adds explicit grain statements to 3 model yml descriptions to improve documentation clarity and consistency.

## Changes
- **fct_person_bp_control.yml**: Added "One row per person that has a blood pressure recording"
- **fct_person_diabetes_triple_target.yml**: Added "One row per person on diabetes register"
- **fct_clinical_safety_valproate_pregnancy.yml**: Added "One row per person of child-bearing age with valproate prescription within 6 months"

## Context
Audit of QOF registers and measure models showed these 3 models were missing explicit grain statements. All other QOF registers (21/21) and intermediate models (10/10) already have grain statements.

Closes #80