### PR TITLE
feat: add OLIDS warning to model comments and update timezone

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -71,6 +71,8 @@ models:
     
     # OLIDS analytics models
     olids:
+      +meta:
+        custom_message: "Includes OLIDS data - don't publish/share outputs without DAC approval"
       staging:
         +materialized: view
         +database: "MODELLING"

--- a/macros/generate_history_table_comment.sql
+++ b/macros/generate_history_table_comment.sql
@@ -1,12 +1,19 @@
 {% macro generate_history_table_comment(table_name, description) %}
   {%- if execute -%}
     {%- set current_user = target.user | default('SYSTEM') if (target.user and target.user.strip()) else 'SYSTEM' -%}
-    {%- set day = run_started_at.strftime('%d')|int -%}
+
+    {#- Convert UTC to Europe/London timezone -#}
+    {%- set pytz = modules.pytz -%}
+    {%- set london_tz = pytz.timezone('Europe/London') -%}
+    {%- set london_time = run_started_at.astimezone(london_tz) -%}
+
+    {%- set day = london_time.strftime('%d')|int -%}
     {%- set day_suffix = 'th' -%}
     {%- if day % 10 == 1 and day != 11 -%}{%- set day_suffix = 'st' -%}{%- endif -%}
     {%- if day % 10 == 2 and day != 12 -%}{%- set day_suffix = 'nd' -%}{%- endif -%}
     {%- if day % 10 == 3 and day != 13 -%}{%- set day_suffix = 'rd' -%}{%- endif -%}
-    {%- set run_timestamp = day|string + day_suffix + run_started_at.strftime(' %B %Y at %H:%M:%S UTC') -%}
+    {%- set tz_abbr = london_time.strftime('%Z') -%}
+    {%- set run_timestamp = day|string + day_suffix + london_time.strftime(' %B %Y at %H:%M:%S ') + tz_abbr -%}
     {%- set target_name = target.name | default('unknown') -%}
     
     {#- Reuse same format as generate_table_comment but adapt for history tables -#}

--- a/macros/generate_table_comment.sql
+++ b/macros/generate_table_comment.sql
@@ -2,20 +2,34 @@
   {%- if execute -%}
     {%- set model_description = model.description or "" -%}
     {%- set current_user = target.user | default('SYSTEM') -%}
-    {%- set day = run_started_at.strftime('%d')|int -%}
+
+    {#- Convert UTC to Europe/London timezone -#}
+    {%- set pytz = modules.pytz -%}
+    {%- set london_tz = pytz.timezone('Europe/London') -%}
+    {%- set london_time = run_started_at.astimezone(london_tz) -%}
+
+    {%- set day = london_time.strftime('%d')|int -%}
     {%- set day_suffix = 'th' -%}
     {%- if day % 10 == 1 and day != 11 -%}{%- set day_suffix = 'st' -%}{%- endif -%}
     {%- if day % 10 == 2 and day != 12 -%}{%- set day_suffix = 'nd' -%}{%- endif -%}
     {%- if day % 10 == 3 and day != 13 -%}{%- set day_suffix = 'rd' -%}{%- endif -%}
-    {%- set run_timestamp = day|string + day_suffix + run_started_at.strftime(' %B %Y at %H:%M:%S UTC') -%}
+    {%- set tz_abbr = london_time.strftime('%Z') -%}
+    {%- set run_timestamp = day|string + day_suffix + london_time.strftime(' %B %Y at %H:%M:%S ') + tz_abbr -%}
     {%- set target_name = target.name | default('unknown') -%}
-    
+
     {%- set github_base_url = "https://github.com/ncl-icb-analytics/dbt-ncl-analytics/blob/main/" -%}
     {%- set model_file_path = model.original_file_path | replace("\\", "/") -%}
     {%- set github_file_url = github_base_url + model_file_path -%}
-    
-    {%- if model_description -%}
-      {%- set clean_description = model.description | replace("'", "''") -%}
+
+    {#- Check for custom message in meta config -#}
+    {%- set model_meta = config.get('meta', {}) -%}
+    {%- set custom_message = model_meta.get('custom_message', '') -%}
+    {%- if custom_message -%}
+      {%- set custom_message = "⚠️ " + custom_message + "\n\n" -%}
+    {%- endif -%}
+
+    {%- if model_description or custom_message -%}
+      {%- set clean_description = (custom_message + model_description) | replace("'", "''") -%}
       {%- set footer = "
 
 🤖 Last ran on " + run_timestamp + " by " + current_user + " (target: " + target_name + ")


### PR DESCRIPTION
## Summary

- Adds custom warning message to all OLIDS models: "⚠️ Includes OLIDS data - don't publish/share outputs without DAC approval"
- Implements generic `custom_message` support via model meta config for easy reuse across other domains
- Updates timestamp display from UTC to Europe/London timezone (shows BST/GMT appropriately)

## Implementation

The warning message is configured at the OLIDS domain level in `dbt_project.yml`:
```yaml
olids:
  +meta:
    custom_message: "Includes OLIDS data - don't publish/share outputs without DAC approval"
```

The `generate_table_comment` macro checks for this meta config and prepends the warning (with emoji) to model descriptions in database comments.

## Test plan

- [ ] Run a sample OLIDS model and verify warning appears in database comment
- [ ] Confirm timestamp shows correct Europe/London time (BST or GMT based on season)
- [ ] Verify other domain models work as expected without custom messages

Fixes #61