### PR TITLE
feat: add PDS/OLIDS data quality models and patient opt-out summary

### DIFF
--- a/models/olids/modelling/utilities/int_pds_olids_practice_registration_comparison.sql
+++ b/models/olids/modelling/utilities/int_pds_olids_practice_registration_comparison.sql
@@ -1,0 +1,104 @@
+{{
+    config(
+        materialized='table',
+        tags=['data_quality', 'utilities', 'pds', 'olids']
+    )
+}}
+
+/*
+PDS/OLIDS Practice Registration Comparison
+
+Compares patient registration counts between Personal Demographics Service and OLIDS
+to identify discrepancies at practice level.
+
+Discrepancies may indicate:
+- Data quality issues in either system
+- Timing differences in data updates
+- Practices with incomplete OLIDS coverage
+- Registration processing delays
+
+Highlights practices with >=20% discrepancy for investigation.
+*/
+
+WITH pds_counts AS (
+    -- Count active patients per practice from Personal Demographics Service
+    SELECT
+        org.organisation_code as practice_code,
+        org.organisation_name as practice_name,
+        COUNT(DISTINCT person.pseudo_nhs_number) as pds_patient_count
+    FROM {{ ref('stg_pds_pds_person') }} person
+    INNER JOIN {{ ref('stg_pds_pds_patient_care_practice') }} practice
+        ON person.pseudo_nhs_number = practice.pseudo_nhs_number
+    INNER JOIN {{ ref('stg_dictionary_dbo_organisation') }} org
+        ON practice.primary_care_provider = org.organisation_code
+    WHERE (
+        practice.primary_care_provider_business_effective_to_date IS NULL
+        OR practice.primary_care_provider_business_effective_to_date >= CURRENT_DATE()
+    )
+    GROUP BY
+        org.organisation_code,
+        org.organisation_name
+),
+
+olids_current_registrations AS (
+    -- Get the current registration for each patient from OLIDS
+    SELECT
+        p.sk_patient_id,
+        o.organisation_code as practice_code,
+        o.name as practice_name
+    FROM {{ ref('stg_olids_patient_registered_practitioner_in_role') }} prpr
+    INNER JOIN {{ ref('stg_olids_patient') }} p
+        ON prpr.patient_id = p.id
+    INNER JOIN {{ ref('stg_olids_organisation') }} o
+        ON prpr.organisation_id = o.id
+    WHERE
+        prpr.start_date IS NOT NULL
+        AND p.sk_patient_id IS NOT NULL
+        AND (
+            prpr.end_date IS NULL
+            OR prpr.end_date > CURRENT_DATE()
+        )
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY p.sk_patient_id
+        ORDER BY
+            prpr.start_date DESC,
+            prpr.id DESC
+    ) = 1
+),
+
+olids_counts AS (
+    -- Count distinct patients per practice from OLIDS
+    SELECT
+        practice_code,
+        practice_name,
+        COUNT(DISTINCT sk_patient_id) as olids_patient_count
+    FROM olids_current_registrations
+    GROUP BY
+        practice_code,
+        practice_name
+)
+
+-- Calculate discrepancies for all practices
+SELECT
+    COALESCE(pds.practice_code, olids.practice_code) as practice_code,
+    COALESCE(pds.practice_name, olids.practice_name) as practice_name,
+    COALESCE(pds.pds_patient_count, 0) as pds_patient_count,
+    COALESCE(olids.olids_patient_count, 0) as olids_patient_count,
+    pds.pds_patient_count - COALESCE(olids.olids_patient_count, 0) as difference,
+    CASE
+        WHEN olids.olids_patient_count = 0 OR olids.olids_patient_count IS NULL THEN NULL
+        ELSE ROUND(
+            (pds.pds_patient_count - olids.olids_patient_count) * 100.0 / olids.olids_patient_count,
+            2
+        )
+    END as percent_difference,
+    CASE
+        WHEN ABS(COALESCE(
+            (pds.pds_patient_count - olids.olids_patient_count) * 100.0 / NULLIF(olids.olids_patient_count, 0),
+            0
+        )) >= 20 THEN TRUE
+        ELSE FALSE
+    END as has_significant_discrepancy
+FROM pds_counts pds
+FULL OUTER JOIN olids_counts olids
+    ON pds.practice_code = olids.practice_code

--- a/models/olids/modelling/utilities/int_practices_missing_from_olids.sql
+++ b/models/olids/modelling/utilities/int_practices_missing_from_olids.sql
@@ -1,0 +1,31 @@
+{{
+    config(
+        materialized='table',
+        tags=['data_quality', 'utilities', 'olids']
+    )
+}}
+
+/*
+Practices Missing from OLIDS
+
+Identifies practices present in the reference practice lookup but with no patients
+registered in OLIDS demographics.
+
+This may indicate:
+- New practices not yet in OLIDS
+- Practices with data feed issues
+- Closed practices still in reference data
+- Configuration or mapping problems
+
+Uses the practice neighbourhood lookup as the master list of expected practices.
+*/
+
+SELECT
+    l.practicecode as practice_code,
+    l.practicename as practice_name,
+    l.localauthority as local_authority,
+    l.practiceneighbourhood as practice_neighbourhood
+FROM {{ ref('stg_reference_practice_neighbourhood_lookup') }} l
+LEFT JOIN {{ ref('dim_person_demographics') }} d
+    ON d.practice_code = l.practicecode
+WHERE d.practice_code IS NULL

--- a/models/olids/published_reporting_direct_care/practices_not_yet_in_olids_direct_care.sql
+++ b/models/olids/published_reporting_direct_care/practices_not_yet_in_olids_direct_care.sql
@@ -1,0 +1,33 @@
+{{
+    config(
+        materialized='view',
+        alias='practices_not_yet_in_olids',
+        tags=['data_quality', 'published', 'direct_care']
+    )
+}}
+
+/*
+Practices Missing from OLIDS (Direct Care)
+
+Published view showing practices in the reference lookup with no registered
+patients in OLIDS demographics.
+
+Use Cases:
+- Practice coverage monitoring
+- Data feed troubleshooting
+- Onboarding validation for new practices
+- Regular data completeness checks
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__DIRECT_CARE.OLIDS_PUBLISHED schema
+- Use for data quality dashboards
+- Track count over time to monitor improvements
+*/
+
+SELECT
+    practice_code,
+    practice_name,
+    local_authority,
+    practice_neighbourhood
+FROM {{ ref('int_practices_missing_from_olids') }}
+ORDER BY practice_name

--- a/models/olids/published_reporting_direct_care/practices_with_significant_registration_differences_direct_care.sql
+++ b/models/olids/published_reporting_direct_care/practices_with_significant_registration_differences_direct_care.sql
@@ -1,0 +1,37 @@
+{{
+    config(
+        materialized='view',
+        alias='practices_with_suspect_registration_counts',
+        tags=['data_quality', 'published', 'direct_care']
+    )
+}}
+
+/*
+PDS/OLIDS Practice Registration Discrepancies (Direct Care)
+
+Published view showing practices with significant discrepancies (>=20%) between
+PDS and OLIDS registration counts.
+
+Use Cases:
+- Data quality monitoring dashboards
+- Practice-level data completeness assessment
+- Identifying practices requiring investigation
+- Monthly data quality reporting
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__DIRECT_CARE.OLIDS_PUBLISHED schema
+- Filter by has_significant_discrepancy = TRUE for problem practices
+- Use percent_difference for severity assessment
+*/
+
+SELECT
+    practice_code,
+    practice_name,
+    pds_patient_count,
+    olids_patient_count,
+    difference,
+    percent_difference,
+    has_significant_discrepancy
+FROM {{ ref('int_pds_olids_practice_registration_comparison') }}
+WHERE has_significant_discrepancy = TRUE
+ORDER BY ABS(percent_difference) DESC

--- a/models/olids/published_reporting_secondary_use/patient_opt_out_summary_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/patient_opt_out_summary_secondary_use.sql
@@ -1,0 +1,68 @@
+{{
+    config(
+        materialized='view',
+        alias='patient_opt_out_summary',
+        tags=['data_quality', 'published', 'secondary_use', 'opt_out']
+    )
+}}
+
+/*
+Patient Opt-Out Summary (Secondary Use)
+
+Simple count showing total registered patients and patients allowed for secondary use.
+The difference represents patients opted out (any opt-out type).
+
+Future-proof design: As new opt-out types are added to dim_person_secondary_use_allowed,
+the counts automatically adjust without code changes.
+
+Use Cases:
+- Data governance reporting
+- Secondary use eligibility monitoring
+- Opt-out compliance tracking
+- Monthly reporting on data availability
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__SECONDARY_USE.OLIDS_PUBLISHED schema
+- Use for executive dashboards
+- Track opt-out trends over time
+*/
+
+WITH total_registered_patients AS (
+    -- Use dim_person_demographics as the definitive registered patient count
+    SELECT COUNT(DISTINCT person_id) as total_count
+    FROM {{ ref('dim_person_demographics') }}
+),
+
+allowed_secondary_use AS (
+    -- Patients allowed for secondary use (from demographics, excluding opt-outs)
+    SELECT COUNT(DISTINCT d.person_id) as allowed_count
+    FROM {{ ref('dim_person_demographics') }} d
+    INNER JOIN {{ ref('dim_person_secondary_use_allowed') }} a
+        ON d.person_id = a.person_id
+),
+
+opted_out_type_1 AS (
+    -- Patients with Type 1 opt-outs (from demographics only)
+    SELECT COUNT(DISTINCT d.person_id) as opted_out_count
+    FROM {{ ref('dim_person_demographics') }} d
+    INNER JOIN {{ ref('dim_person_opt_out_type_1_status') }} o
+        ON d.person_id = o.person_id
+    WHERE o.is_opted_out = TRUE
+)
+
+SELECT
+    total_registered_patients.total_count as total_registered_patients,
+    allowed_secondary_use.allowed_count as patients_allowed_secondary_use,
+    opted_out_type_1.opted_out_count as patients_opted_out_type_1,
+    (total_registered_patients.total_count - allowed_secondary_use.allowed_count) as patients_opted_out_all_types,
+    ROUND(
+        (opted_out_type_1.opted_out_count * 100.0) / NULLIF(total_registered_patients.total_count, 0),
+        2
+    ) as percent_opted_out_type_1,
+    ROUND(
+        ((total_registered_patients.total_count - allowed_secondary_use.allowed_count) * 100.0) / NULLIF(total_registered_patients.total_count, 0),
+        2
+    ) as percent_opted_out_all_types
+FROM total_registered_patients
+CROSS JOIN allowed_secondary_use
+CROSS JOIN opted_out_type_1

--- a/models/olids/published_reporting_secondary_use/pds_olids_practice_discrepancies_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/pds_olids_practice_discrepancies_secondary_use.sql
@@ -1,0 +1,37 @@
+{{
+    config(
+        materialized='view',
+        alias='practices_with_suspect_registration_counts',
+        tags=['data_quality', 'published', 'secondary_use']
+    )
+}}
+
+/*
+PDS/OLIDS Practice Registration Discrepancies (Secondary Use)
+
+Published view showing practices with significant discrepancies (>=20%) between
+PDS and OLIDS registration counts.
+
+Use Cases:
+- Data quality monitoring dashboards
+- Practice-level data completeness assessment
+- Identifying practices requiring investigation
+- Monthly data quality reporting
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__SECONDARY_USE.OLIDS_PUBLISHED schema
+- Filter by has_significant_discrepancy = TRUE for problem practices
+- Use percent_difference for severity assessment
+*/
+
+SELECT
+    practice_code,
+    practice_name,
+    pds_patient_count,
+    olids_patient_count,
+    difference,
+    percent_difference,
+    has_significant_discrepancy
+FROM {{ ref('int_pds_olids_practice_registration_comparison') }}
+WHERE has_significant_discrepancy = TRUE
+ORDER BY ABS(percent_difference) DESC

--- a/models/olids/published_reporting_secondary_use/practices_missing_from_olids_secondary_use.sql
+++ b/models/olids/published_reporting_secondary_use/practices_missing_from_olids_secondary_use.sql
@@ -1,0 +1,33 @@
+{{
+    config(
+        materialized='view',
+        alias='practices_not_yet_in_olids',
+        tags=['data_quality', 'published', 'secondary_use']
+    )
+}}
+
+/*
+Practices Missing from OLIDS (Secondary Use)
+
+Published view showing practices in the reference lookup with no registered
+patients in OLIDS demographics.
+
+Use Cases:
+- Practice coverage monitoring
+- Data feed troubleshooting
+- Onboarding validation for new practices
+- Regular data completeness checks
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__SECONDARY_USE.OLIDS_PUBLISHED schema
+- Use for data quality dashboards
+- Track count over time to monitor improvements
+*/
+
+SELECT
+    practice_code,
+    practice_name,
+    local_authority,
+    practice_neighbourhood
+FROM {{ ref('int_practices_missing_from_olids') }}
+ORDER BY practice_name

--- a/scripts/sources/3_generate_staging_models.py
+++ b/scripts/sources/3_generate_staging_models.py
@@ -132,7 +132,7 @@ def main():
         sources = yaml.safe_load(f)
 
     total_models = 0
-    models_by_domain = {'commissioning': 0, 'olids': 0, 'shared': 0}
+    models_by_domain = {'commissioning': 0, 'olids': 0, 'shared': 0, 'phenolab': 0}
 
     for source in sources['sources']:
         source_name = source['name']

--- a/scripts/sources/source_mappings.yml
+++ b/scripts/sources/source_mappings.yml
@@ -202,3 +202,15 @@ sources:
   # ADDITIONAL OLIDS DATA SOURCES
   # ========================================
   # Additional OLIDS sources can be added here if needed
+
+  # ========================================
+  # PDS DATA SOURCES
+  # ========================================
+
+  # Personal Demographics Service
+  - source_name: pds
+    database: DATA_LAKE
+    schema: PDS
+    description: Personal Demographics Service data
+    staging_prefix: stg_pds
+    domain: shared


### PR DESCRIPTION
## Summary

Adds data quality monitoring models comparing PDS and OLIDS registration data, plus patient opt-out summary reporting.

## Changes

**Data Quality Models (Modelling Layer):**
- `int_pds_olids_practice_registration_comparison` - Compares patient registration counts between PDS and OLIDS at practice level
- `int_practices_missing_from_olids` - Identifies practices in reference lookup but not in OLIDS

**Published Reporting Views (Direct Care & Secondary Use):**
- `practices_with_suspect_registration_counts` - Practices with >=20% discrepancy between PDS and OLIDS
- `practices_not_yet_in_olids` - Practices in lookup but missing from OLIDS demographics
- `patient_opt_out_summary` - Summary counts of total patients, opted out, and allowed for secondary use

**Infrastructure:**
- Added PDS source mapping to `DATA_LAKE.PDS` schema
- Fixed phenolab domain support in staging model generation script
- All models properly use lowercase column names from staging models
- Patient counts aligned to `dim_person_demographics` as definitive source

## Test Plan

- [ ] Run `dbt build --select int_pds_olids_practice_registration_comparison+ int_practices_missing_from_olids+` to verify models compile and run
- [ ] Verify PDS/OLIDS comparison shows expected practice discrepancies
- [ ] Confirm patient opt-out summary shows correct counts aligned to demographics
- [ ] Check published views exist in both DIRECT_CARE and SECONDARY_USE schemas with correct aliases
- [ ] Validate PowerBI can connect to new published views