### PR TITLE
fix: treat NULL as not deleted in OLIDS staging models

### DIFF
--- a/models/staging/olids/stg_olids_allergy_intolerance.sql
+++ b/models/staging/olids/stg_olids_allergy_intolerance.sql
@@ -32,7 +32,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_allergy_intolerance') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_appointment.sql
+++ b/models/staging/olids/stg_olids_appointment.sql
@@ -41,7 +41,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_appointment') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_appointment_practitioner.sql
+++ b/models/staging/olids/stg_olids_appointment_practitioner.sql
@@ -18,7 +18,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_appointment_practitioner') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_diagnostic_order.sql
+++ b/models/staging/olids/stg_olids_diagnostic_order.sql
@@ -36,7 +36,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_diagnostic_order') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_encounter.sql
+++ b/models/staging/olids/stg_olids_encounter.sql
@@ -33,7 +33,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_encounter') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_episode_of_care.sql
+++ b/models/staging/olids/stg_olids_episode_of_care.sql
@@ -22,7 +22,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_episode_of_care') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_flag.sql
+++ b/models/staging/olids/stg_olids_flag.sql
@@ -20,7 +20,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_flag') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_location.sql
+++ b/models/staging/olids/stg_olids_location.sql
@@ -31,7 +31,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_location') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_location_contact.sql
+++ b/models/staging/olids/stg_olids_location_contact.sql
@@ -18,7 +18,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_location_contact') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_medication_order.sql
+++ b/models/staging/olids/stg_olids_medication_order.sql
@@ -47,4 +47,4 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_medication_order') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false

--- a/models/staging/olids/stg_olids_medication_statement.sql
+++ b/models/staging/olids/stg_olids_medication_statement.sql
@@ -43,4 +43,4 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_medication_statement') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false

--- a/models/staging/olids/stg_olids_organisation.sql
+++ b/models/staging/olids/stg_olids_organisation.sql
@@ -24,7 +24,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_organisation') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_patient.sql
+++ b/models/staging/olids/stg_olids_patient.sql
@@ -26,7 +26,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_patient') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_patient_contact.sql
+++ b/models/staging/olids/stg_olids_patient_contact.sql
@@ -20,7 +20,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_patient_contact') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_patient_registered_practitioner_in_role.sql
+++ b/models/staging/olids/stg_olids_patient_registered_practitioner_in_role.sql
@@ -21,7 +21,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_patient_registered_practitioner_in_role') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_patient_uprn.sql
+++ b/models/staging/olids/stg_olids_patient_uprn.sql
@@ -26,7 +26,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_patient_uprn') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_practitioner.sql
+++ b/models/staging/olids/stg_olids_practitioner.sql
@@ -21,7 +21,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_practitioner') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_practitioner_in_role.sql
+++ b/models/staging/olids/stg_olids_practitioner_in_role.sql
@@ -20,7 +20,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_practitioner_in_role') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_procedure_request.sql
+++ b/models/staging/olids/stg_olids_procedure_request.sql
@@ -30,7 +30,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_procedure_request') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_referral_request.sql
+++ b/models/staging/olids/stg_olids_referral_request.sql
@@ -35,7 +35,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_referral_request') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_schedule.sql
+++ b/models/staging/olids/stg_olids_schedule.sql
@@ -23,7 +23,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_schedule') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc

--- a/models/staging/olids/stg_olids_schedule_practitioner.sql
+++ b/models/staging/olids/stg_olids_schedule_practitioner.sql
@@ -16,7 +16,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_schedule_practitioner') }}
-where lds_is_deleted = false
+where coalesce(lds_is_deleted, false) = false
 qualify row_number() over (
     partition by id
     order by lds_start_date_time desc


### PR DESCRIPTION
## Summary
Update `lds_is_deleted` filter across all OLIDS staging models to treat NULL values as "not deleted"

## Changes
- Changed filter from `where lds_is_deleted = false` to `where coalesce(lds_is_deleted, false) = false`
- Applied to all 22 OLIDS staging models

## Impact
- episode_of_care staging records: 1.1M → 3.4M (includes NULL deletion flags)
- All other OLIDS staging models now correctly include records with NULL `lds_is_deleted`

## Rationale
The previous filter `lds_is_deleted = false` excluded both TRUE and NULL values. NULL should be treated as "not deleted" rather than being filtered out.