### PR TITLE
feat: add LD, SMI, and pregnancy filters to LTC/LCS dashboard

### DIFF
--- a/models/published/direct_care/olids/ltc_lcs_cf_dashboard_base.sql
+++ b/models/published/direct_care/olids/ltc_lcs_cf_dashboard_base.sql
@@ -89,9 +89,15 @@ base_data AS (
         d.pcn_code,
         d.pcn_name,
         d.borough_registered,
-        d.neighbourhood_registered
+        d.neighbourhood_registered,
+        -- Population health inclusion group filters
+        cond.has_learning_disability,
+        cond.has_severe_mental_illness,
+        COALESCE(preg.is_currently_pregnant, FALSE) AS is_currently_pregnant
     FROM {{ ref('dim_ltc_lcs_cf_summary') }} cf
     LEFT JOIN {{ ref('dim_person_demographics') }} d ON cf.person_id = d.person_id
+    LEFT JOIN {{ ref('dim_person_conditions') }} cond ON cf.person_id = cond.person_id
+    LEFT JOIN {{ ref('fct_person_pregnancy_status') }} preg ON cf.person_id = preg.person_id
 ),
 
 final_dashboard AS (
@@ -135,13 +141,18 @@ final_dashboard AS (
         lsoa_code_21 as lsoa_code,
         
         -- Practice information
-        practice_code, 
-        practice_name, 
-        pcn_code, 
-        pcn_name, 
-        borough_registered, 
+        practice_code,
+        practice_name,
+        pcn_code,
+        pcn_name,
+        borough_registered,
         neighbourhood_registered,
-        
+
+        -- Population health inclusion group filters
+        has_learning_disability,
+        has_severe_mental_illness,
+        is_currently_pregnant,
+
         CURRENT_TIMESTAMP() AS created_at
     FROM (
         SELECT *, 'AF_61' as indicator_id FROM base_data WHERE in_af_61

--- a/models/published/direct_care/olids/ltc_lcs_cf_dashboard_base.yml
+++ b/models/published/direct_care/olids/ltc_lcs_cf_dashboard_base.yml
@@ -160,8 +160,17 @@ models:
           - accepted_values:
               values: [true]
                 
+      - name: has_learning_disability
+        description: QOF Learning Disability register flag (age ≥14 years with LD diagnosis). For population health inclusion group filtering.
+
+      - name: has_severe_mental_illness
+        description: QOF Severe Mental Illness register flag (active SMI diagnosis or recent lithium therapy). For population health inclusion group filtering.
+
+      - name: is_currently_pregnant
+        description: Currently pregnant flag (non-male, pregnancy code within last 9 months, no delivery code after). For population health inclusion group filtering.
+
       - name: created_at
         description: Timestamp when the row was created
         tests:
           - not_null
-        
+

--- a/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_person_dashboard.sql
+++ b/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_person_dashboard.sql
@@ -124,7 +124,12 @@ SELECT
     
     -- Registration context
     prac.registration_start_date,
-    
+
+    -- Population health inclusion group filters
+    cond.has_learning_disability,
+    cond.has_severe_mental_illness,
+    COALESCE(preg.is_currently_pregnant, FALSE) AS is_currently_pregnant,
+
     -- Metadata
     CURRENT_DATE() AS data_refresh_date
 
@@ -133,7 +138,11 @@ INNER JOIN {{ ref('dim_person_demographics') }} AS demo
     ON cf.person_id = demo.person_id
 INNER JOIN {{ ref('dim_person_current_practice') }} AS prac
     ON cf.person_id = prac.person_id
-WHERE 
+LEFT JOIN {{ ref('dim_person_conditions') }} AS cond
+    ON cf.person_id = cond.person_id
+LEFT JOIN {{ ref('fct_person_pregnancy_status') }} AS preg
+    ON cf.person_id = preg.person_id
+WHERE
     cf.in_any_case_finding = TRUE  -- Only include people with case finding eligibility
     AND prac.registration_end_date IS NULL  -- Current registrations only
 

--- a/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_person_dashboard.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_person_dashboard.yml
@@ -4,3 +4,16 @@ models:
     description: 'Person-level LTC case finding data with demographics for PowerBI analytics.
 
       One row per person meeting any LTC case finding criteria with demographic enrichment and practice context.'
+
+    columns:
+      - name: person_id
+        description: Unique person identifier
+
+      - name: has_learning_disability
+        description: QOF Learning Disability register flag (age ≥14 years with LD diagnosis). For population health inclusion group filtering.
+
+      - name: has_severe_mental_illness
+        description: QOF Severe Mental Illness register flag (active SMI diagnosis or recent lithium therapy). For population health inclusion group filtering.
+
+      - name: is_currently_pregnant
+        description: Currently pregnant flag (non-male, pregnancy code within last 9 months, no delivery code after). For population health inclusion group filtering.


### PR DESCRIPTION
## Summary
Add Learning Disability (LD), Severe Mental Illness (SMI), and pregnancy status filters to the LTC/LCS Case Finding Dashboard to support population health inclusion group filtering.

Closes #64

## Changes
- Add `has_learning_disability` flag from `dim_person_conditions`
- Add `has_severe_mental_illness` flag from `dim_person_conditions`
- Add `is_currently_pregnant` flag from `fct_person_pregnancy_status`
- Update both dashboard models:
  - `fct_ltc_lcs_person_dashboard` (wide format)
  - `ltc_lcs_cf_dashboard_base` (long format)
- Add YAML documentation for new filter columns

## Technical Details
- Uses LEFT JOINs to preserve all dashboard records
- LD flag uses QOF register logic (age ≥14 years)
- SMI flag includes active diagnosis or recent lithium therapy
- Pregnancy flag uses 9-month window for non-male patients
- COALESCE ensures clean FALSE values where joins don't match

## Test Plan
- Build models: `dbt build --select fct_ltc_lcs_person_dashboard ltc_lcs_cf_dashboard_base`
- Verify flag counts match source register models
- Test dashboard filtering in PowerBI