### PR TITLE
fix: correct LTC LCS case finding models to match 2025/26 spec

### DIFF
--- a/models/modelling/olids/programme/ltc_lcs/int_ltc_lcs_cf_cvd_base_population.sql
+++ b/models/modelling/olids/programme/ltc_lcs/int_ltc_lcs_cf_cvd_base_population.sql
@@ -2,15 +2,15 @@
     materialized='table') }}
 
 -- General CVD base population for case finding indicators
--- Includes patients aged 40-83 who are not on statins, have no statin allergies/contraindications, and no recent statin decisions
+-- Includes patients aged 40-84 who are not on statins, have no statin allergies/contraindications, and no recent statin decisions
 
 WITH base_population AS (
-    -- Get base population aged 40-83
+    -- Get base population aged 40-84
     SELECT
         bp.person_id,
         bp.age
     FROM {{ ref('int_ltc_lcs_cf_base_population') }} AS bp
-    WHERE bp.age BETWEEN 40 AND 83
+    WHERE bp.age BETWEEN 40 AND 84
 ),
 
 statin_medications AS (

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_af_61.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_af_61.yml
@@ -1,10 +1,10 @@
 version: 2
 models:
   - name: dim_ltc_lcs_cf_af_61
-    description: 'Atrial fibrillation case finding for patients on cardiac medications who may have undiagnosed AF.
+    description: 'AF case finding for patients on cardiac medications without AF/HF diagnosis.
 
-      One row per person on anticoagulants, AF drugs, digoxin, cardiac glycosides, or protamine drugs (excludes DVT and existing AF/flutter diagnoses).'
-    
+      One row per person on digoxin, flecainide, propafenone, or anticoagulant without AF/HF diagnosis or DVT/PE in last year.'
+
     config:
       meta:
         indicator:
@@ -12,12 +12,11 @@ models:
           type: "CASE_FINDING"
           category: "AF"
           clinical_domain: "Cardiovascular Case Finding"
-          name_short: "On cardiac medication"
-          description_short: "Patients on cardiac medications without AF diagnosis"
+          name_short: "Cardiac meds no AF"
+          description_short: "Patients on cardiac medications without AF/HF diagnosis"
           description_long: >
-            On anticoagulants, AF drugs, digoxin, cardiac glycosides, or protamine drugs without AF diagnosis.
-            Uses differential time windows: 6 months for anticoagulants/protamine, 3 months for other medications.
-            Excludes DVT, atrial flutter, existing AF/flutter diagnoses.
+            Patients on digoxin, flecainide, propafenone, or anticoagulant not on AF or heart failure registers,
+            no DVT/PE in last year.
           is_qof: false
           source_column: "person_id"
           sort_order: "LTC_LCS_AF_61"

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_af_62.sql
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_af_62.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized='table') }}
 
--- Intermediate model for LTC LCS Case Finding AF_62: Patients over 65 missing pulse check in last 36 months
+-- Intermediate model for LTC LCS Case Finding AF_62: Patients over 65 missing pulse check in last year
 -- Uses modular approach: leverages base population, observations intermediate, and exclusions
 
 WITH base_population AS (
@@ -23,7 +23,7 @@ pulse_checks AS (
     FROM {{ ref('int_ltc_lcs_af_observations') }}
     WHERE
         cluster_id IN ('LCS_PULSE_RATE', 'LCS_PULSE_RHYTHM')
-        AND clinical_effective_date >= dateadd(MONTH, -36, current_date())
+        AND clinical_effective_date >= dateadd(YEAR, -1, current_date())
 ),
 
 pulse_check_summary AS (

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_af_62.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_af_62.yml
@@ -1,24 +1,12 @@
 version: 2
 models:
   - name: dim_ltc_lcs_cf_af_62
-    description: 'Mart: LTC LCS Case Finding AF_62 - Identifies patients over 65 with missing pulse checks at NHS Health Check appointments.
+    description: 'AF case finding for patients 65+ without recent pulse check.
 
+      Identifies patients aged 65+ with no pulse rate/rhythm check in last year.
 
-      Population Scope:
+      One row per person aged 65+ without pulse check in last 12 months.'
 
-      • Patients aged 65+ from LTC case finding base population
-
-      • Missing pulse check within 36-month assessment window
-
-
-      Key Features:
-
-      • NHS Health Check programme data integration
-
-      • Pulse check compliance monitoring
-
-      • Clinical exclusion criteria assessment'
-    
     config:
       meta:
         indicator:
@@ -26,11 +14,10 @@ models:
           type: "CASE_FINDING"
           category: "AF"
           clinical_domain: "Cardiovascular Case Finding"
-          name_short: "Missing pulse check"
-          description_short: "Patients 65+ without pulse check in 36 months"
+          name_short: "65+ no pulse check"
+          description_short: "Patients 65+ without pulse check in last year"
           description_long: >
-            Age 65+, no pulse rate/rhythm check in 36m. Excludes existing AF,
-            atrial flutter, recent NHS health checks.
+            Age 65+, no pulse rate/rhythm check in last year.
           is_qof: false
           source_column: "person_id"
           sort_order: "LTC_LCS_AF_62"
@@ -40,10 +27,10 @@ models:
           code_clusters:
             - cluster_id: "LCS_PULSE_RATE"
               category: "MONITORING"
-              time_window: "36_MONTHS"
+              time_window: "12_MONTHS"
             - cluster_id: "LCS_PULSE_RHYTHM"
               category: "MONITORING"
-              time_window: "36_MONTHS"
+              time_window: "12_MONTHS"
             - cluster_id: "ATRIAL_FIBRILLATION"
               category: "EXCLUSION"
             - cluster_id: "ATRIAL_FLUTTER"
@@ -52,14 +39,14 @@ models:
             - population_group: "OLDER_ADULTS"
               threshold_type: "AGE_ELIGIBILITY"
               threshold_value: "65"
-              threshold_operator: "AT_OR_ABOVE"
+              threshold_operator: "GREATER_THAN_OR_EQUAL"
               threshold_unit: "years"
-              description: "Minimum age for pulse checking recommendation"
+              description: "Age 65+"
               sort_order: 1
             - population_group: "OLDER_ADULTS"
-              threshold_type: "TIME_SINCE_CHECK"
-              threshold_value: "36"
+              threshold_type: "MONITORING_WINDOW"
+              threshold_value: "12"
               threshold_operator: "GREATER_THAN"
               threshold_unit: "months"
-              description: "Time window for pulse check monitoring"
+              description: "No pulse check in last year"
               sort_order: 2

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_61.sql
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_61.sql
@@ -1,9 +1,43 @@
 {{ config(
     materialized='table') }}
 -- Intermediate model for LTC LCS Case Finding CVD_61
--- Identifies patients with QRISK2 score ≥ 20% (case finding for cardiovascular disease prevention)
+-- Identifies patients with QRISK2 score ≥20% not on statins (case finding for cardiovascular disease prevention)
 
-WITH qrisk2_readings AS (
+WITH statin_medications AS (
+    -- Get patients on any statins in last 12 months
+    SELECT DISTINCT
+        person_id,
+        MAX(order_date) AS latest_statin_date
+    FROM {{ ref('int_ltc_lcs_cvd_medications') }}
+    WHERE
+        cluster_id = 'LCS_STAT_COD_CVD'
+        AND order_date >= DATEADD('month', -12, CURRENT_DATE())
+    GROUP BY person_id
+),
+
+statin_exclusions AS (
+    -- Get patients with statin allergies/contraindications or recent decisions
+    SELECT DISTINCT
+        person_id,
+        MAX(CASE
+            WHEN cluster_id IN ('STATIN_ALLERGY_ADVERSE_REACTION', 'STATIN_NOT_INDICATED')
+                THEN clinical_effective_date
+        END) AS latest_statin_allergy_date,
+        MAX(CASE
+            WHEN cluster_id = 'STATINDEC_COD'
+                THEN clinical_effective_date
+        END) AS latest_statin_decision_date
+    FROM {{ ref('int_ltc_lcs_cvd_observations') }}
+    WHERE
+        cluster_id IN ('STATIN_ALLERGY_ADVERSE_REACTION', 'STATIN_NOT_INDICATED', 'STATINDEC_COD')
+        AND (
+            cluster_id IN ('STATIN_ALLERGY_ADVERSE_REACTION', 'STATIN_NOT_INDICATED')
+            OR (cluster_id = 'STATINDEC_COD' AND clinical_effective_date >= DATEADD('month', -60, CURRENT_DATE()))
+        )
+    GROUP BY person_id
+),
+
+qrisk2_readings AS (
     -- Get all QRISK2 readings with valid values
     SELECT
         person_id,
@@ -60,6 +94,11 @@ FROM {{ ref('int_ltc_lcs_cf_base_population') }} AS bp
 INNER JOIN {{ ref('dim_person_age') }} AS age ON bp.person_id = age.person_id
 LEFT JOIN latest_qrisk2 AS qr ON bp.person_id = qr.person_id
 LEFT JOIN qrisk2_codes AS codes ON bp.person_id = codes.person_id
+LEFT JOIN statin_medications AS sm ON bp.person_id = sm.person_id
+LEFT JOIN statin_exclusions AS se ON bp.person_id = se.person_id
 WHERE
-    age.age BETWEEN 40 AND 83  -- CVD base population age range
-    AND CAST(qr.result_value AS NUMBER) >= 20  -- Only include patients who meet criteria
+    age.age BETWEEN 40 AND 84  -- CVD base population age range
+    AND CAST(qr.result_value AS NUMBER) >= 20  -- QRISK2 ≥20%
+    AND sm.person_id IS NULL  -- Not on statins in last 12 months
+    AND se.latest_statin_allergy_date IS NULL  -- No statin allergies
+    AND se.latest_statin_decision_date IS NULL  -- No statin decisions in last 60 months

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_61.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_61.yml
@@ -1,23 +1,11 @@
 version: 2
 models:
   - name: dim_ltc_lcs_cf_cvd_61
-    description: 'Mart: LTC LCS Case Finding CVD_61 - Identifies patients with high cardiovascular risk (QRISK2 ≥20%) requiring primary prevention assessment.
+    description: 'CVD case finding priority (a): Patients with high cardiovascular risk not on statins.
 
+      Age 40-84 with QRISK2 ≥20%, not on statins (12 months), no statin allergies or decisions (60 months).
 
-      Population Scope:
-
-      • Patients aged 40-83 from LTC case finding base population
-
-      • Latest QRISK2 score ≥20%
-
-
-      Key Features:
-
-      • QRISK2-based cardiovascular risk stratification
-
-      • Complete cardiovascular risk assessment history
-
-      • Evidence-based case finding aligned with NICE guidelines'
+      One row per person meeting criteria for statin initiation.'
     
     config:
       meta:
@@ -27,10 +15,9 @@ models:
           category: "CVD"
           clinical_domain: "Cardiovascular Disease Case Finding"
           name_short: "High CVD risk"
-          description_short: "Patients with QRISK2 score ≥20% requiring primary prevention"
+          description_short: "Patients with QRISK2 ≥20% not on statins"
           description_long: >
-            Age 40-83, QRISK2 ≥20%. Consider statin therapy and CVD risk
-            management per NICE guidelines.
+            Age 40-84, QRISK2 ≥20%, not on statins. Priority (a) for statin initiation.
           is_qof: false
           source_column: "person_id"
           sort_order: "LTC_LCS_CVD_61"
@@ -38,15 +25,30 @@ models:
             - "LTC_LCS_DASHBOARD"
             - "CASE_FINDING_PROGRAMME"
           code_clusters:
-            - cluster_id: "QRISK2_RESULTS"
+            - cluster_id: "QRISK2_10YEAR"
               category: "INCLUSION"
-            - cluster_id: "CVD_REGISTER_CODES"
+            - cluster_id: "LCS_STAT_COD_CVD"
               category: "EXCLUSION"
+              time_window: "12_MONTHS"
+            - cluster_id: "STATIN_ALLERGY_ADVERSE_REACTION"
+              category: "EXCLUSION"
+            - cluster_id: "STATIN_NOT_INDICATED"
+              category: "EXCLUSION"
+            - cluster_id: "STATINDEC_COD"
+              category: "EXCLUSION"
+              time_window: "60_MONTHS"
           thresholds:
-            - population_group: "ADULTS_40_83"
+            - population_group: "ADULTS_40_84"
+              threshold_type: "AGE_RANGE"
+              threshold_value: "40-84"
+              threshold_operator: "WITHIN"
+              threshold_unit: "years"
+              description: "Age 40-84 years"
+              sort_order: 1
+            - population_group: "ADULTS_40_84"
               threshold_type: "QRISK2_SCORE"
               threshold_value: "20"
               threshold_operator: "GREATER_THAN_OR_EQUAL"
               threshold_unit: "percentage"
-              description: "QRISK2 score ≥20% (high risk)"
-              sort_order: 1
+              description: "QRISK2 ≥20%"
+              sort_order: 2

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_62.sql
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_62.sql
@@ -1,9 +1,43 @@
 {{ config(
     materialized='table') }}
 -- Intermediate model for LTC LCS Case Finding CVD_62
--- Identifies patients with QRISK2 score between 15-19.99% (case finding for cardiovascular disease prevention)
+-- Identifies patients with QRISK2 score between 15-19.99% not on statins (case finding for cardiovascular disease prevention)
 
-WITH qrisk2_readings AS (
+WITH statin_medications AS (
+    -- Get patients on any statins in last 12 months
+    SELECT DISTINCT
+        person_id,
+        MAX(order_date) AS latest_statin_date
+    FROM {{ ref('int_ltc_lcs_cvd_medications') }}
+    WHERE
+        cluster_id = 'LCS_STAT_COD_CVD'
+        AND order_date >= DATEADD('month', -12, CURRENT_DATE())
+    GROUP BY person_id
+),
+
+statin_exclusions AS (
+    -- Get patients with statin allergies/contraindications or recent decisions
+    SELECT DISTINCT
+        person_id,
+        MAX(CASE
+            WHEN cluster_id IN ('STATIN_ALLERGY_ADVERSE_REACTION', 'STATIN_NOT_INDICATED')
+                THEN clinical_effective_date
+        END) AS latest_statin_allergy_date,
+        MAX(CASE
+            WHEN cluster_id = 'STATINDEC_COD'
+                THEN clinical_effective_date
+        END) AS latest_statin_decision_date
+    FROM {{ ref('int_ltc_lcs_cvd_observations') }}
+    WHERE
+        cluster_id IN ('STATIN_ALLERGY_ADVERSE_REACTION', 'STATIN_NOT_INDICATED', 'STATINDEC_COD')
+        AND (
+            cluster_id IN ('STATIN_ALLERGY_ADVERSE_REACTION', 'STATIN_NOT_INDICATED')
+            OR (cluster_id = 'STATINDEC_COD' AND clinical_effective_date >= DATEADD('month', -60, CURRENT_DATE()))
+        )
+    GROUP BY person_id
+),
+
+qrisk2_readings AS (
     -- Get all QRISK2 readings with valid values
     SELECT
         person_id,
@@ -66,6 +100,11 @@ FROM {{ ref('int_ltc_lcs_cf_base_population') }} AS bp
 INNER JOIN {{ ref('dim_person_age') }} AS age ON bp.person_id = age.person_id
 LEFT JOIN latest_qrisk2 AS qr ON bp.person_id = qr.person_id
 LEFT JOIN qrisk2_codes AS codes ON bp.person_id = codes.person_id
+LEFT JOIN statin_medications AS sm ON bp.person_id = sm.person_id
+LEFT JOIN statin_exclusions AS se ON bp.person_id = se.person_id
 WHERE
-    age.age BETWEEN 40 AND 83  -- CVD base population age range
-    AND CAST(qr.result_value AS NUMBER) BETWEEN 15 AND 19.99  -- Only include patients who meet criteria
+    age.age BETWEEN 40 AND 84  -- CVD base population age range
+    AND CAST(qr.result_value AS NUMBER) BETWEEN 15 AND 19.99  -- QRISK2 15-19.99%
+    AND sm.person_id IS NULL  -- Not on statins in last 12 months
+    AND se.latest_statin_allergy_date IS NULL  -- No statin allergies
+    AND se.latest_statin_decision_date IS NULL  -- No statin decisions in last 60 months

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_62.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_62.yml
@@ -1,23 +1,11 @@
 version: 2
 models:
   - name: dim_ltc_lcs_cf_cvd_62
-    description: 'Mart: LTC LCS Case Finding CVD_62 - Identifies patients with moderate cardiovascular risk (QRISK2 15-19.99%) requiring enhanced monitoring.
+    description: 'CVD case finding priority (b): Patients with moderate cardiovascular risk not on statins.
 
+      Age 40-84 with QRISK2 15-19.99%, not on statins (12 months), no statin allergies or decisions (60 months).
 
-      Population Scope:
-
-      • Patients aged 40-83 from LTC case finding base population
-
-      • Latest QRISK2 score between 15-19.99%
-
-
-      Key Features:
-
-      • QRISK2-based moderate cardiovascular risk stratification
-
-      • Complete cardiovascular risk assessment history
-
-      • Evidence-based case finding for CVD prevention pathways'
+      One row per person meeting criteria for statin initiation.'
     
     config:
       meta:
@@ -27,10 +15,9 @@ models:
           category: "CVD"
           clinical_domain: "Cardiovascular Disease Case Finding"
           name_short: "Moderate CVD risk"
-          description_short: "Patients with QRISK2 score 15-19.99% requiring enhanced monitoring"
+          description_short: "Patients with QRISK2 15-19.99% not on statins"
           description_long: >
-            Age 40-83, QRISK2 15-19.99%. Enhanced monitoring, lifestyle
-            intervention, statin consideration.
+            Age 40-84, QRISK2 15-19.99%, not on statins. Priority (b) for statin initiation.
           is_qof: false
           source_column: "person_id"
           sort_order: "LTC_LCS_CVD_62"
@@ -38,22 +25,37 @@ models:
             - "LTC_LCS_DASHBOARD"
             - "CASE_FINDING_PROGRAMME"
           code_clusters:
-            - cluster_id: "QRISK2_RESULTS"
+            - cluster_id: "QRISK2_10YEAR"
               category: "INCLUSION"
-            - cluster_id: "CVD_REGISTER_CODES"
+            - cluster_id: "LCS_STAT_COD_CVD"
               category: "EXCLUSION"
+              time_window: "12_MONTHS"
+            - cluster_id: "STATIN_ALLERGY_ADVERSE_REACTION"
+              category: "EXCLUSION"
+            - cluster_id: "STATIN_NOT_INDICATED"
+              category: "EXCLUSION"
+            - cluster_id: "STATINDEC_COD"
+              category: "EXCLUSION"
+              time_window: "60_MONTHS"
           thresholds:
-            - population_group: "ADULTS_40_83"
+            - population_group: "ADULTS_40_84"
+              threshold_type: "AGE_RANGE"
+              threshold_value: "40-84"
+              threshold_operator: "WITHIN"
+              threshold_unit: "years"
+              description: "Age 40-84 years"
+              sort_order: 1
+            - population_group: "ADULTS_40_84"
               threshold_type: "QRISK2_SCORE"
               threshold_value: "15"
               threshold_operator: "GREATER_THAN_OR_EQUAL"
               threshold_unit: "percentage"
-              description: "QRISK2 score 15-19.99% (moderate risk)"
-              sort_order: 1
-            - population_group: "ADULTS_40_83"
+              description: "QRISK2 15-19.99%"
+              sort_order: 2
+            - population_group: "ADULTS_40_84"
               threshold_type: "QRISK2_SCORE"
               threshold_value: "20"
               threshold_operator: "LESS_THAN"
               threshold_unit: "percentage"
-              description: "QRISK2 score below 20% (upper limit)"
-              sort_order: 2
+              description: "QRISK2 <20%"
+              sort_order: 3

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_63.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_63.yml
@@ -1,18 +1,11 @@
 version: 2
 models:
   - name: dim_ltc_lcs_cf_cvd_63
-    description: 'Case finding for patients on statins with elevated non-HDL cholesterol requiring medication review.
+    description: 'CVD case finding priority (c): Patients on statins with elevated non-HDL cholesterol.
 
+      Age 40-84 with QRISK2 ≥10%, on statins (6 months), non-HDL >2.5 mmol/L.
 
-      Business Logic:
-
-      • Identifies patients aged 40-83 on statins (within last 6 months) with latest non-HDL cholesterol > 2.5 mmol/L
-
-      • Targets patients requiring statin therapy optimisation or dose escalation
-
-      • Supports cardiovascular medication effectiveness monitoring and clinical intervention
-
-      • One row per person meeting criteria for statin therapy review'
+      One row per person requiring statin dose escalation or therapy review.'
     
     config:
       meta:
@@ -22,10 +15,9 @@ models:
           category: "CVD"
           clinical_domain: "Cardiovascular Disease Case Finding"
           name_short: "High lipids on statin"
-          description_short: "Patients on statins (last 6 months) with non-HDL cholesterol >2.5 mmol/L"
+          description_short: "QRisk ≥10%, on statins with non-HDL >2.5 mmol/L"
           description_long: >
-            Age 40-83, on statins (last 6 months), non-HDL >2.5 mmol/L. Suboptimal lipid
-            control - review dose, adherence, or add therapy.
+            Age 40-84, QRISK2 ≥10%, on statins (6 months), non-HDL >2.5 mmol/L. Priority (c) for statin dose review.
           is_qof: false
           source_column: "person_id"
           sort_order: "LTC_LCS_CVD_63"
@@ -33,17 +25,32 @@ models:
             - "LTC_LCS_DASHBOARD"
             - "CASE_FINDING_PROGRAMME"
           code_clusters:
-            - cluster_id: "STAT_COD"
+            - cluster_id: "QRISK2_10YEAR"
               category: "INCLUSION"
-            - cluster_id: "NON_HDL_CHOLESTEROL_RESULTS"
+            - cluster_id: "STATIN_CVD_63_MEDICATIONS"
               category: "INCLUSION"
-            - cluster_id: "CVD_REGISTER_CODES"
-              category: "EXCLUSION"
+              time_window: "6_MONTHS"
+            - cluster_id: "NON_HDL_CHOLESTEROL"
+              category: "INCLUSION"
           thresholds:
-            - population_group: "ADULTS_40_83"
+            - population_group: "ADULTS_40_84"
+              threshold_type: "AGE_RANGE"
+              threshold_value: "40-84"
+              threshold_operator: "WITHIN"
+              threshold_unit: "years"
+              description: "Age 40-84 years"
+              sort_order: 1
+            - population_group: "ADULTS_40_84"
+              threshold_type: "QRISK2_SCORE"
+              threshold_value: "10"
+              threshold_operator: "GREATER_THAN_OR_EQUAL"
+              threshold_unit: "percentage"
+              description: "QRISK2 ≥10%"
+              sort_order: 2
+            - population_group: "ADULTS_40_84"
               threshold_type: "NON_HDL_CHOLESTEROL"
               threshold_value: "2.5"
               threshold_operator: "GREATER_THAN"
               threshold_unit: "mmol/L"
-              description: "Non-HDL cholesterol >2.5 mmol/L on statin therapy"
-              sort_order: 1
+              description: "Non-HDL >2.5 mmol/L"
+              sort_order: 3

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_64.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_64.yml
@@ -1,18 +1,11 @@
 version: 2
 models:
   - name: dim_ltc_lcs_cf_cvd_64
-    description: 'Case finding for patients from CVD base population NOT on statins who should start high-dose therapy.
+    description: 'CVD case finding priority (d): Patients with QRisk ≥10% not on statins.
 
+      Age 40-84 with QRISK2 ≥10%, not on statins (12 months), no statin allergies or decisions (60 months).
 
-      Business Logic:
-
-      • Identifies CVD base population patients NOT on statins (last 12 months)
-
-      • Excludes patients with statin decisions (last 60 months)
-
-      • Supports initiation of high-dose statin therapy for secondary prevention
-
-      • One row per person needing to start intensive lipid management'
+      One row per person meeting criteria for statin initiation.'
     
     config:
       meta:
@@ -21,11 +14,10 @@ models:
           type: "CASE_FINDING"
           category: "CVD"
           clinical_domain: "Cardiovascular Disease Case Finding"
-          name_short: "High-dose statin"
-          description_short: "CVD patients not on statins needing to start high-dose therapy"
+          name_short: "QRisk ≥10% no statin"
+          description_short: "Patients with QRisk ≥10% not on statins"
           description_long: >
-            CVD base population NOT on statins (12 months) and no statin decision (60 months).
-            Need to start high-dose statins for secondary prevention.
+            Age 40-84, QRISK2 ≥10%, not on statins. Priority (d) for statin initiation.
           is_qof: false
           source_column: "person_id"
           sort_order: "LTC_LCS_CVD_64"
@@ -33,19 +25,30 @@ models:
             - "LTC_LCS_DASHBOARD"
             - "CASE_FINDING_PROGRAMME"
           code_clusters:
-            - cluster_id: "CVD_REGISTER_CODES"
+            - cluster_id: "QRISK2_10YEAR"
               category: "INCLUSION"
-            - cluster_id: "STAT_COD"
+            - cluster_id: "LCS_STAT_COD_CVD"
               category: "EXCLUSION"
               time_window: "12_MONTHS"
+            - cluster_id: "STATIN_ALLERGY_ADVERSE_REACTION"
+              category: "EXCLUSION"
+            - cluster_id: "STATIN_NOT_INDICATED"
+              category: "EXCLUSION"
             - cluster_id: "STATINDEC_COD"
               category: "EXCLUSION"
               time_window: "60_MONTHS"
           thresholds:
-            - population_group: "CVD_BASE_POPULATION"
-              threshold_type: "STATIN_INTENSITY"
-              threshold_value: "HIGH_DOSE"
-              threshold_operator: "EQUALS"
-              threshold_unit: "categorical"
-              description: "High-dose statin therapy indication for secondary prevention"
+            - population_group: "ADULTS_40_84"
+              threshold_type: "AGE_RANGE"
+              threshold_value: "40-84"
+              threshold_operator: "WITHIN"
+              threshold_unit: "years"
+              description: "Age 40-84 years"
               sort_order: 1
+            - population_group: "ADULTS_40_84"
+              threshold_type: "QRISK2_SCORE"
+              threshold_value: "10"
+              threshold_operator: "GREATER_THAN_OR_EQUAL"
+              threshold_unit: "percentage"
+              description: "QRISK2 ≥10%"
+              sort_order: 2

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_65.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_65.yml
@@ -1,18 +1,11 @@
 version: 2
 models:
   - name: dim_ltc_lcs_cf_cvd_65
-    description: 'Case finding for patients with moderate cardiovascular risk requiring moderate-dose statin therapy.
+    description: 'CVD case finding priority (e): Patients with QRisk ≥10% not on high-intensity statins.
 
+      Age 40-84 with QRISK2 ≥10%, not on high-intensity statins (12 months), no statin allergies or decisions (60 months).
 
-      Business Logic:
-
-      • Identifies patients with latest QRISK2 score ≥10% requiring moderate-dose statin therapy
-
-      • Targets primary prevention patients needing evidence-based lipid management
-
-      • Uses QRISK2-based cardiovascular risk stratification for statin eligibility decisions
-
-      • One row per person meeting moderate cardiovascular risk intervention thresholds'
+      One row per person requiring high-intensity statin initiation or escalation.'
     
     config:
       meta:
@@ -21,11 +14,10 @@ models:
           type: "CASE_FINDING"
           category: "CVD"
           clinical_domain: "Cardiovascular Disease Case Finding"
-          name_short: "Statin indicated"
-          description_short: "Patients with QRISK2 ≥10% requiring moderate-dose statins"
+          name_short: "QRisk ≥10% no high-intensity statin"
+          description_short: "Patients with QRisk ≥10% not on high-intensity statins"
           description_long: >
-            QRISK2 ≥10%, moderate-dose statin for primary prevention
-            per NICE guidance.
+            Age 40-84, QRISK2 ≥10%, not on high-intensity statins. Priority (e) for high-intensity statin therapy.
           is_qof: false
           source_column: "person_id"
           sort_order: "LTC_LCS_CVD_65"
@@ -33,17 +25,30 @@ models:
             - "LTC_LCS_DASHBOARD"
             - "CASE_FINDING_PROGRAMME"
           code_clusters:
-            - cluster_id: "QRISK2_RESULTS"
+            - cluster_id: "QRISK2_10YEAR"
               category: "INCLUSION"
-            - cluster_id: "STAT_COD"
-              category: "MONITORING"
-            - cluster_id: "CVD_REGISTER_CODES"
+            - cluster_id: "STATIN_CVD_65_MEDICATIONS"
               category: "EXCLUSION"
+              time_window: "12_MONTHS"
+            - cluster_id: "STATIN_ALLERGY_ADVERSE_REACTION"
+              category: "EXCLUSION"
+            - cluster_id: "STATIN_NOT_INDICATED"
+              category: "EXCLUSION"
+            - cluster_id: "STATINDEC_COD"
+              category: "EXCLUSION"
+              time_window: "60_MONTHS"
           thresholds:
-            - population_group: "PRIMARY_PREVENTION"
+            - population_group: "ADULTS_40_84"
+              threshold_type: "AGE_RANGE"
+              threshold_value: "40-84"
+              threshold_operator: "WITHIN"
+              threshold_unit: "years"
+              description: "Age 40-84 years"
+              sort_order: 1
+            - population_group: "ADULTS_40_84"
               threshold_type: "QRISK2_SCORE"
               threshold_value: "10"
               threshold_operator: "GREATER_THAN_OR_EQUAL"
               threshold_unit: "percentage"
-              description: "QRISK2 score ≥10% qualifying for statin therapy"
-              sort_order: 1
+              description: "QRISK2 ≥10%"
+              sort_order: 2

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_66.sql
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_66.sql
@@ -1,16 +1,16 @@
 {{ config(
     materialized='table') }}
 
--- CVD_66 case finding: Statin review for patients aged 75-83
--- Identifies patients aged 75-83 without QRISK2 readings in last 60 months
+-- CVD_66 case finding: Statin review for patients aged 75-84
+-- Identifies patients aged 75-84 without QRISK2 readings in last 60 months
 
 WITH base_population AS (
-    -- Get base population aged 75-83
+    -- Get base population aged 75-84
     SELECT
         bp.person_id,
         bp.age
     FROM {{ ref('int_ltc_lcs_cf_base_population') }} AS bp
-    WHERE bp.age BETWEEN 75 AND 83
+    WHERE bp.age BETWEEN 75 AND 84
 ),
 
 statin_medications AS (
@@ -85,7 +85,7 @@ qrisk2_recent AS (
 ),
 
 eligible_patients AS (
-    -- Patients aged 75-83 not on statins, no allergies, no recent decisions, no health checks, no recent QRISK2
+    -- Patients aged 75-84 not on statins, no allergies, no recent decisions, no health checks, no recent QRISK2
     SELECT
         bp.person_id,
         bp.age
@@ -148,7 +148,7 @@ all_qrisk2_codes AS (
     GROUP BY person_id
 )
 
--- Final selection: patients aged 75-83 who need QRISK2 assessment (ensure one row per person)
+-- Final selection: patients aged 75-84 who need QRISK2 assessment (ensure one row per person)
 SELECT
     ep.person_id,
     ep.age,

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_66.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cvd_66.yml
@@ -1,18 +1,11 @@
 version: 2
 models:
   - name: dim_ltc_lcs_cf_cvd_66
-    description: 'Case finding for patients aged 75-83 requiring QRISK2 cardiovascular risk assessment.
+    description: 'CVD case finding priority (f): Patients aged 75-84 requiring cardiovascular risk assessment.
 
+      Age 75-84, not on statins (12 months), no QRISK2 in 60 months, no statin allergies or decisions (60 months), no health checks (24 months).
 
-      Business Logic:
-
-      • Identifies patients aged 75-83 years without QRISK2 readings in last 60 months
-
-      • Excludes patients on statins, with statin decisions, or recent health checks
-
-      • Supports age-appropriate cardiovascular risk management and statin review decisions
-
-      • One row per eligible elderly person requiring cardiovascular risk assessment'
+      One row per person requiring cardiovascular risk assessment.'
     
     config:
       meta:
@@ -22,10 +15,9 @@ models:
           category: "CVD"
           clinical_domain: "Cardiovascular Disease Case Finding"
           name_short: "Elderly CVD screen"
-          description_short: "Patients aged 75-83 without recent QRISK2 (60 months)"
+          description_short: "Patients aged 75-84 without recent QRISK2"
           description_long: >
-            Age 75-83y, no QRISK2 in 60 months, not on statins, no statin decisions (60m),
-            no health checks (24m). Need cardiovascular risk assessment.
+            Age 75-84, no QRISK2 in 60 months, not on statins. Priority (f) for cardiovascular risk assessment.
           is_qof: false
           source_column: "person_id"
           sort_order: "LTC_LCS_CVD_66"
@@ -45,10 +37,10 @@ models:
             - cluster_id: "CVD_REGISTER_CODES"
               category: "EXCLUSION"
           thresholds:
-            - population_group: "ELDERLY_75_83"
+            - population_group: "ELDERLY_75_84"
               threshold_type: "AGE_RANGE"
-              threshold_value: "75-83"
+              threshold_value: "75-84"
               threshold_operator: "WITHIN"
               threshold_unit: "years"
-              description: "Patients aged 75-83 years requiring assessment"
+              description: "Age 75-84 years"
               sort_order: 1

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cyp_ast_61.sql
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cyp_ast_61.sql
@@ -40,22 +40,37 @@ asthma_symptoms AS (
             person_id,
             order_date AS clinical_effective_date
         FROM {{ ref('int_ltc_lcs_cyp_asthma_medications') }}
-        WHERE 
+        WHERE
             cluster_id IN ('ASTHMA_MEDICATIONS', 'ASTHMA_PREDNISOLONE', 'MONTELUKAST_MEDICATIONS')
             AND order_date >= DATEADD(MONTH, -12, CURRENT_DATE())
-        
+
         UNION ALL
-        
-        -- Suspected asthma or viral wheeze observations in last 12 months
+
+        -- Suspected asthma observations in last 12 months (all ages 18m-17y)
         SELECT
             person_id,
             clinical_effective_date
         FROM {{ ref('int_ltc_lcs_cyp_asthma_observations') }}
         WHERE
-            cluster_id IN ('SUSPECTED_ASTHMA', 'VIRAL_WHEEZE')
+            cluster_id = 'SUSPECTED_ASTHMA'
             AND clinical_effective_date >= DATEADD(MONTH, -12, CURRENT_DATE())
     )
     GROUP BY person_id
+),
+
+viral_wheeze_age_6_plus AS (
+    -- Viral induced wheeze in last 12 months (age ≥6 years only)
+    SELECT
+        obs.person_id,
+        MAX(obs.clinical_effective_date) AS latest_viral_wheeze_date
+    FROM {{ ref('int_ltc_lcs_cyp_asthma_observations') }} AS obs
+    INNER JOIN {{ ref('dim_person_age') }} AS age
+        ON obs.person_id = age.person_id
+    WHERE
+        obs.cluster_id = 'VIRAL_WHEEZE'
+        AND obs.clinical_effective_date >= DATEADD(MONTH, -12, CURRENT_DATE())
+        AND age.age >= 6
+    GROUP BY obs.person_id
 )
 
 -- Final selection: CYP with asthma symptoms but no formal diagnosis
@@ -63,13 +78,20 @@ SELECT
     bp.person_id,
     bp.age,
     CASE
-        WHEN symptoms.latest_symptom_date IS NOT NULL THEN TRUE
+        WHEN symptoms.latest_symptom_date IS NOT NULL
+            OR vw.latest_viral_wheeze_date IS NOT NULL THEN TRUE
         ELSE FALSE
     END AS has_asthma_symptoms,
-    symptoms.latest_symptom_date
+    GREATEST(
+        COALESCE(symptoms.latest_symptom_date, '1900-01-01'::DATE),
+        COALESCE(vw.latest_viral_wheeze_date, '1900-01-01'::DATE)
+    ) AS latest_symptom_date
 FROM cyp_base_population AS bp
-INNER JOIN asthma_symptoms AS symptoms ON bp.person_id = symptoms.person_id
-WHERE NOT EXISTS (
-    SELECT 1 FROM asthma_diagnosis AS ad
-    WHERE ad.person_id = bp.person_id
-)
+LEFT JOIN asthma_symptoms AS symptoms ON bp.person_id = symptoms.person_id
+LEFT JOIN viral_wheeze_age_6_plus AS vw ON bp.person_id = vw.person_id
+WHERE
+    (symptoms.person_id IS NOT NULL OR vw.person_id IS NOT NULL)
+    AND NOT EXISTS (
+        SELECT 1 FROM asthma_diagnosis AS ad
+        WHERE ad.person_id = bp.person_id
+    )

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cyp_ast_61.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_cyp_ast_61.yml
@@ -1,19 +1,12 @@
 version: 2
 models:
   - name: dim_ltc_lcs_cf_cyp_ast_61
-    description: 'Case finding for children and young people with asthma symptoms requiring formal diagnosis.
+    description: 'Case finding for children with possible asthma diagnosis.
 
+      Identifies CYP aged 18 months to <18 years with asthma indicators but no diagnosis.
 
-      Business Logic:
+      One row per child with asthma medications, suspected asthma codes, or viral wheeze (age 6+).'
 
-      • Identifies children/young people aged 18 months to under 18 years with asthma symptoms but no formal diagnosis
-
-      • Targets paediatric population with clinical indicators suggesting asthma requiring assessment
-
-      • Supports early asthma diagnosis and management to prevent complications
-
-      • One row per eligible child/young person requiring asthma evaluation and formal diagnosis'
-    
     config:
       meta:
         indicator:
@@ -21,11 +14,11 @@ models:
           type: "CASE_FINDING"
           category: "CYP_AST"
           clinical_domain: "Children and Young People Asthma Case Finding"
-          name_short: "Asthma symptoms"
-          description_short: "Children 18 months-18 years with asthma symptoms but no formal diagnosis"
+          name_short: "Possible asthma"
+          description_short: "Children 18 months-<18 years with asthma indicators, no diagnosis"
           description_long: >
-            Age 18m-<18y, asthma symptoms, no formal diagnosis.
-            Requires assessment for early diagnosis and management.
+            Age 18m-<18y with inhalers, oral prednisolone, montelukast, or suspected asthma in last 12m,
+            or age 6+ with viral induced wheeze in last 12m, no asthma diagnosis.
           is_qof: false
           source_column: "person_id"
           sort_order: "LTC_LCS_CYP_AST_61"
@@ -43,6 +36,7 @@ models:
               category: "INCLUSION"
             - cluster_id: "VIRAL_WHEEZE"
               category: "INCLUSION"
+              age_restriction: "6_YEARS_PLUS"
             - cluster_id: "ASTHMA_DIAGNOSIS"
               category: "EXCLUSION"
             - cluster_id: "ASTHMA_RESOLVED"
@@ -53,12 +47,19 @@ models:
               threshold_value: "18 months to <18 years"
               threshold_operator: "WITHIN"
               threshold_unit: "age"
-              description: "Children aged 18 months to under 18 years"
+              description: "Age 18 months to <18 years"
               sort_order: 1
-            - population_group: "CHILDREN_18_MONTHS_TO_18_YEARS"
+            - population_group: "CHILDREN_6_YEARS_PLUS"
+              threshold_type: "AGE_MINIMUM"
+              threshold_value: "6"
+              threshold_operator: "GREATER_THAN_OR_EQUAL"
+              threshold_unit: "years"
+              description: "Age 6+ for viral induced wheeze"
+              sort_order: 2
+            - population_group: "ALL_CHILDREN"
               threshold_type: "MONITORING_WINDOW"
               threshold_value: "12"
               threshold_operator: "WITHIN"
               threshold_unit: "months"
-              description: "Asthma symptoms (medications or observations) within 12 months"
-              sort_order: 2
+              description: "Medications or observations in last 12 months"
+              sort_order: 3

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_dm_61.sql
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_dm_61.sql
@@ -2,11 +2,8 @@
     materialized='table') }}
 
 -- Intermediate model for LTC LCS CF DM_61 case finding
--- Patients at risk of diabetes who meet ANY of the following criteria:
--- 1. HbA1c ≥ 42 mmol/mol within the last 5 years
--- 2. QDiabetes score ≥ 5.6%
--- 3. QRisk2 score > 20%
--- 4. History of gestational diabetes
+-- Patients at highest risk of diabetes (spec priority a):
+-- Latest HbA1c ≥48 mmol/mol AND no diagnosis of diabetes or diabetes in remission/resolved
 
 WITH base_population AS (
     -- Get base population aged 17+ (already excludes LTC registers and NHS health checks)
@@ -18,7 +15,7 @@ WITH base_population AS (
 ),
 
 hba1c_readings AS (
-    -- Get all HbA1c readings with values > 0 within last 5 years
+    -- Get all HbA1c readings with values > 0
     SELECT
         person_id,
         clinical_effective_date,
@@ -27,9 +24,8 @@ hba1c_readings AS (
         mapped_concept_display
     FROM {{ ref('int_ltc_lcs_dm_observations') }}
     WHERE
-        cluster_id = 'HBA1C'
+        cluster_id = 'HBA1C_LEVEL'
         AND result_value > 0
-        AND clinical_effective_date >= DATEADD(YEAR, -5, CURRENT_DATE())
 ),
 
 latest_hba1c AS (
@@ -52,69 +48,36 @@ latest_hba1c AS (
         = 1
 ),
 
-latest_qdiabetes AS (
-    -- Get the most recent QDiabetes score for each person
-    SELECT
-        person_id,
-        clinical_effective_date AS latest_qdiabetes_date,
-        result_value AS latest_qdiabetes_value
-    FROM {{ ref('int_ltc_lcs_dm_observations') }}
-    WHERE cluster_id = 'QDIABETES_RISK'
-    QUALIFY
-        ROW_NUMBER()
-            OVER (PARTITION BY person_id ORDER BY clinical_effective_date DESC)
-        = 1
-),
-
-latest_qrisk AS (
-    -- Get the most recent QRisk2 score for each person
-    SELECT
-        person_id,
-        clinical_effective_date AS latest_qrisk_date,
-        result_value AS latest_qrisk_value
-    FROM {{ ref('int_ltc_lcs_dm_observations') }}
-    WHERE cluster_id = 'QRISK2_10YEAR'
-    QUALIFY
-        ROW_NUMBER()
-            OVER (PARTITION BY person_id ORDER BY clinical_effective_date DESC)
-        = 1
-),
-
-gestational_diabetes AS (
-    -- Get patients with history of gestational diabetes
+diabetes_diagnoses AS (
+    -- Get patients with diabetes diagnosis or remission/resolved codes
     SELECT DISTINCT
         person_id,
-        TRUE AS has_gestational_diabetes
+        TRUE AS has_diabetes_diagnosis
     FROM {{ ref('int_ltc_lcs_dm_observations') }}
-    WHERE cluster_id = 'GESTDIAB_COD'
+    WHERE cluster_id IN (
+        'DIABETES_RESOLVED',
+        'DIABETES_RESOLVED_COD',
+        'DIABETES_IN_REMISSION'
+    )
 )
 
--- Final selection with risk assessment
+-- Final selection: HbA1c ≥48 without diabetes diagnosis/remission
 SELECT
     bp.person_id,
     bp.age,
     hba1c.latest_hba1c_date,
     hba1c.latest_hba1c_value,
-    qd.latest_qdiabetes_date,
-    qd.latest_qdiabetes_value,
-    qr.latest_qrisk_date,
-    qr.latest_qrisk_value,
     hba1c.all_hba1c_codes,
     hba1c.all_hba1c_displays,
+    COALESCE(dd.has_diabetes_diagnosis, FALSE) AS has_diabetes_diagnosis,
     COALESCE(
-        hba1c.latest_hba1c_value >= 42
-        OR qd.latest_qdiabetes_value >= 5.6
-        OR qr.latest_qrisk_value > 20
-        OR gd.has_gestational_diabetes = TRUE, FALSE
-    ) AS has_diabetes_risk,
-    COALESCE(gd.has_gestational_diabetes, FALSE) AS has_gestational_diabetes
+        hba1c.latest_hba1c_value >= 48
+        AND COALESCE(dd.has_diabetes_diagnosis, FALSE) = FALSE,
+        FALSE
+    ) AS has_high_diabetes_risk
 FROM base_population AS bp
-LEFT JOIN latest_hba1c AS hba1c ON bp.person_id = hba1c.person_id
-LEFT JOIN latest_qdiabetes AS qd ON bp.person_id = qd.person_id
-LEFT JOIN latest_qrisk AS qr ON bp.person_id = qr.person_id
-LEFT JOIN gestational_diabetes AS gd ON bp.person_id = gd.person_id
+INNER JOIN latest_hba1c AS hba1c ON bp.person_id = hba1c.person_id
+LEFT JOIN diabetes_diagnoses AS dd ON bp.person_id = dd.person_id
 WHERE
-    hba1c.latest_hba1c_value >= 42
-    OR qd.latest_qdiabetes_value >= 5.6
-    OR qr.latest_qrisk_value > 20
-    OR gd.has_gestational_diabetes = TRUE
+    hba1c.latest_hba1c_value >= 48
+    AND COALESCE(dd.has_diabetes_diagnosis, FALSE) = FALSE

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_dm_61.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_dm_61.yml
@@ -1,10 +1,10 @@
 version: 2
 models:
   - name: dim_ltc_lcs_cf_dm_61
-    description: 'Diabetes case finding for patients aged 17+ at high risk through multiple criteria.
+    description: 'Diabetes case finding for patients aged 17+ with HbA1c in diabetic range.
 
-      One row per person meeting diabetes risk criteria (HbA1c ≥42, QDiabetes ≥5.6%, QRisk2 >20%, or gestational diabetes history).'
-    
+      One row per person with latest HbA1c ≥48 mmol/mol without diabetes diagnosis or remission/resolved codes.'
+
     config:
       meta:
         indicator:
@@ -12,11 +12,10 @@ models:
           type: "CASE_FINDING"
           category: "DM"
           clinical_domain: "Diabetes Mellitus Case Finding"
-          name_short: "High DM risk"
-          description_short: "Patients at high diabetes risk through multiple criteria"
+          name_short: "HbA1c ≥48"
+          description_short: "Patients with HbA1c ≥48 mmol/mol without diabetes diagnosis"
           description_long: >
-            Age 17+, HbA1c ≥42 mmol/mol (5y), QDiabetes ≥5.6%, QRISK2 >20%,
-            or gestational diabetes history.
+            Age 17+, latest HbA1c ≥48 mmol/mol, no diabetes diagnosis or diabetes in remission/resolved.
           is_qof: false
           source_column: "person_id"
           sort_order: "LTC_LCS_DM_61"
@@ -24,35 +23,21 @@ models:
             - "LTC_LCS_DASHBOARD"
             - "CASE_FINDING_PROGRAMME"
           code_clusters:
-            - cluster_id: "HBA1C"
+            - cluster_id: "HBA1C_LEVEL"
               category: "INCLUSION"
-            - cluster_id: "QDIABETES_RISK"
-              category: "INCLUSION"
-            - cluster_id: "QRISK2_10YEAR"
-              category: "INCLUSION"
-            - cluster_id: "GESTDIAB_COD"
-              category: "INCLUSION"
+            - cluster_id: "DIABETES_RESOLVED"
+              category: "EXCLUSION"
+            - cluster_id: "DIABETES_RESOLVED_COD"
+              category: "EXCLUSION"
+            - cluster_id: "DIABETES_IN_REMISSION"
+              category: "EXCLUSION"
             - cluster_id: "DIABETES_REGISTER_CODES"
               category: "EXCLUSION"
           thresholds:
             - population_group: "ADULTS_17_PLUS"
               threshold_type: "HBA1C_VALUE"
-              threshold_value: "42"
+              threshold_value: "48"
               threshold_operator: "GREATER_THAN_OR_EQUAL"
               threshold_unit: "mmol/mol"
-              description: "HbA1c ≥42 mmol/mol within 5 years"
+              description: "HbA1c ≥48 mmol/mol"
               sort_order: 1
-            - population_group: "ADULTS_17_PLUS"
-              threshold_type: "QDIABETES_SCORE"
-              threshold_value: "5.6"
-              threshold_operator: "GREATER_THAN_OR_EQUAL"
-              threshold_unit: "percentage"
-              description: "QDiabetes score ≥5.6%"
-              sort_order: 2
-            - population_group: "ADULTS_17_PLUS"
-              threshold_type: "QRISK2_SCORE"
-              threshold_value: "20"
-              threshold_operator: "GREATER_THAN"
-              threshold_unit: "percentage"
-              description: "QRISK2 score >20%"
-              sort_order: 3

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_dm_66.sql
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_dm_66.sql
@@ -2,9 +2,9 @@
     materialized='table') }}
 
 -- Intermediate model for LTC LCS CF DM_66 case finding
--- Patients who meet ALL of the following criteria:
--- 1. Latest HbA1c reading ≥ 42 and < 46 mmol/mol
--- 2. HbA1c reading must be within the last 12 months
+-- Patients who meet ALL of the following criteria (spec priority f):
+-- 1. Latest HbA1c reading ≥42 and ≤45 mmol/mol
+-- 2. No HbA1c reading in the last 12 months
 
 WITH base_population AS (
     -- Get base population aged 17+ (already excludes LTC registers and NHS health checks)
@@ -16,7 +16,7 @@ WITH base_population AS (
 ),
 
 hba1c_readings AS (
-    -- Get all HbA1c readings within last 12 months
+    -- Get all HbA1c readings with values > 0
     SELECT
         person_id,
         clinical_effective_date,
@@ -27,7 +27,6 @@ hba1c_readings AS (
     WHERE
         cluster_id = 'HBA1C_LEVEL'
         AND result_value > 0
-        AND clinical_effective_date >= DATEADD(YEAR, -1, CURRENT_DATE())
 ),
 
 latest_hba1c AS (
@@ -50,7 +49,7 @@ latest_hba1c AS (
         = 1
 )
 
--- Final selection with HbA1c range assessment
+-- Final selection: HbA1c 42-45 with no recent HbA1c in last year
 SELECT
     bp.person_id,
     bp.age,
@@ -59,11 +58,14 @@ SELECT
     hba1c.all_hba1c_codes,
     hba1c.all_hba1c_displays,
     COALESCE(
-        hba1c.latest_hba1c_value >= 42 AND hba1c.latest_hba1c_value < 46,
+        hba1c.latest_hba1c_value >= 42
+        AND hba1c.latest_hba1c_value <= 45
+        AND hba1c.latest_hba1c_date < DATEADD(YEAR, -1, CURRENT_DATE()),
         FALSE
-    ) AS has_elevated_hba1c
+    ) AS has_elevated_hba1c_needing_recheck
 FROM base_population AS bp
-LEFT JOIN latest_hba1c AS hba1c ON bp.person_id = hba1c.person_id
+INNER JOIN latest_hba1c AS hba1c ON bp.person_id = hba1c.person_id
 WHERE
     hba1c.latest_hba1c_value >= 42
-    AND hba1c.latest_hba1c_value < 46
+    AND hba1c.latest_hba1c_value <= 45
+    AND hba1c.latest_hba1c_date < DATEADD(YEAR, -1, CURRENT_DATE())

--- a/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_dm_66.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/dim_ltc_lcs_cf_dm_66.yml
@@ -1,19 +1,12 @@
 version: 2
 models:
   - name: dim_ltc_lcs_cf_dm_66
-    description: 'Case finding for patients with pre-diabetic HbA1c levels requiring continued surveillance.
+    description: 'Case finding for patients with pre-diabetic HbA1c levels needing recheck.
 
+      Identifies patients with latest HbA1c 42-45 mmol/mol with no HbA1c in last 12 months.
 
-      Business Logic:
+      One row per person with old HbA1c reading in pre-diabetic range.'
 
-      • Identifies patients with latest HbA1c between 42-46 mmol/mol (pre-diabetic range)
-
-      • Requires HbA1c assessment within the last 12 months for current status
-
-      • Targets patients for diabetes prevention interventions and ongoing monitoring
-
-      • One row per eligible person with recent HbA1c results and monitoring history'
-    
     config:
       meta:
         indicator:
@@ -21,11 +14,10 @@ models:
           type: "CASE_FINDING"
           category: "DM"
           clinical_domain: "Diabetes Mellitus Case Finding"
-          name_short: "Pre-diabetic"
-          description_short: "Patients with pre-diabetic HbA1c 42-46 mmol/mol requiring surveillance"
+          name_short: "HbA1c 42-45 old"
+          description_short: "Patients with HbA1c 42-45 mmol/mol needing recheck"
           description_long: >
-            HbA1c 42-46 mmol/mol (pre-diabetic range), HbA1c within 12m.
-            Requires prevention interventions and monitoring.
+            Latest HbA1c 42-45 mmol/mol, no HbA1c in last 12 months.
           is_qof: false
           source_column: "person_id"
           sort_order: "LTC_LCS_DM_66"
@@ -43,19 +35,19 @@ models:
               threshold_value: "42"
               threshold_operator: "GREATER_THAN_OR_EQUAL"
               threshold_unit: "mmol/mol"
-              description: "HbA1c between 42-46 mmol/mol (pre-diabetic range)"
+              description: "HbA1c 42-45 mmol/mol"
               sort_order: 1
             - population_group: "ADULTS_17_PLUS"
               threshold_type: "HBA1C_VALUE"
-              threshold_value: "46"
+              threshold_value: "45"
               threshold_operator: "LESS_THAN_OR_EQUAL"
               threshold_unit: "mmol/mol"
-              description: "HbA1c upper limit 46 mmol/mol"
+              description: "HbA1c upper limit 45 mmol/mol"
               sort_order: 2
             - population_group: "ADULTS_17_PLUS"
               threshold_type: "MONITORING_WINDOW"
               threshold_value: "12"
-              threshold_operator: "WITHIN"
+              threshold_operator: "GREATER_THAN"
               threshold_unit: "months"
-              description: "Recent HbA1c assessment within 12 months"
+              description: "No HbA1c in last 12 months"
               sort_order: 3


### PR DESCRIPTION
## Summary

Fixed multiple logical issues and inconsistencies across AF, Diabetes, CKD, CVD, and CYP Asthma case finding models to align with the 2025/26 LTC LCS specification.

## Changes Made

### AF Models
- **AF_61**: Added missing WHERE clause - was returning entire base population instead of only patients WITH cardiac medications
- **AF_61**: Added DVT/PE exclusion for last 12 months per spec
- **AF_62**: Corrected pulse check window from 36 months to 12 months

### Diabetes Models
- **DM_61**: Completely rewritten to match spec
  - Changed from: HbA1c ≥42 OR QDiabetes/QRisk criteria
  - Changed to: HbA1c ≥48 AND no diabetes diagnosis/remission
- **DM_66**: Fixed inverted time logic (was requiring HbA1c WITHIN 12 months, now correctly excludes those WITH HbA1c in last year)
- **DM_66**: Corrected HbA1c range from 42-46 to 42-45

### CKD Models
- **CKD_62**: Added check ensuring latest uACR reading is also >4 to confirm no subsequent normal reading

### CVD Models (all 6 priorities)
- **Base population**: Fixed age range from 40-83 to 40-84
- **CVD_61** (priority a): Added statin exclusion checks (medications, allergies, decisions), fixed age to 40-84
- **CVD_62** (priority b): Added statin exclusion checks, fixed age to 40-84
- **CVD_63** (priority c): Added missing QRisk ≥10 check, changed cluster to STATIN_CVD_63_MEDICATIONS, fixed age to 40-84
- **CVD_64** (priority d): Added missing QRisk ≥10 check
- **CVD_65** (priority e): Changed from moderate-dose to high-intensity statin logic, updated cluster to STATIN_CVD_65_MEDICATIONS
- **CVD_66** (priority f): Fixed age range from 75-83 to 75-84

All CVD models now correctly map to spec priorities (a) through (f).

### CYP Asthma
- **CYP_AST_61**: Fixed viral wheeze to only include children aged ≥6 years (was incorrectly including all 18m+)

### YAML Metadata
Updated all YAML files with concise descriptions reflecting corrected logic and accurate thresholds.

## Test Plan
- [x] Build models in dev environment
- [ ] Verify CVD patient counts align with expected ranges for each priority
- [ ] Confirm AF_61 medication counts are now reasonable (not entire population)
- [ ] Validate DM_61 logic matches HbA1c ≥48 criteria
- [ ] Check CKD_62 correctly filters for no subsequent normal readings

Closes #48