### PR TITLE
fix: add sourceclusterid to childhood imms codes unique test

### DIFF
--- a/models/staging/shared/stg_reference_childhood_imms_codes.yml
+++ b/models/staging/shared/stg_reference_childhood_imms_codes.yml
@@ -8,6 +8,7 @@ models:
       - vaccine
       - dose
       - snomedconceptid
+      - sourceclusterid
   - dbt_expectations.expect_table_row_count_to_be_between:
       min_value: 1
   columns:


### PR DESCRIPTION
## Summary
Fix failing unique combination test for childhood immunisation codes.

## Issue
The test was failing because the same SNOMED codes appear across different source clusters:
- `432636005` appears in both MMRVVAC1_COD and MMRVVAC2_COD
- `572511000119105` appears in both MMRVVAC1_COD and MMRVVAC2_COD

## Fix
Add `sourceclusterid` to the unique combination test so that vaccine + dose + snomedconceptid + sourceclusterid forms the unique key.

This correctly allows the same SNOMED code to be used in multiple source clusters.