### PR TITLE
fix: use sentinel dates for NULL diagnosis dates instead of filtering

### DIFF
--- a/macros/get_observations.sql
+++ b/macros/get_observations.sql
@@ -19,7 +19,7 @@
         o.id,
         o.patient_id,
         pp.person_id,
-        o.clinical_effective_date,
+        COALESCE(o.clinical_effective_date, '1900-01-01') AS clinical_effective_date,
         o.result_value,
         o.result_value_unit_concept_id,
         o.result_unit_display,

--- a/models/modelling/olids/diagnoses/qof/int_asthma_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_asthma_diagnoses_all.sql
@@ -35,6 +35,5 @@ SELECT
     CASE WHEN obs.cluster_id = 'ASTRES_COD' THEN TRUE ELSE FALSE END AS is_resolved_code
 
 FROM ({{ get_observations("'AST_COD', 'ASTRES_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_atrial_fibrillation_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_atrial_fibrillation_diagnoses_all.sql
@@ -46,6 +46,5 @@ SELECT
     END AS af_observation_type
 
 FROM ({{ get_observations("'AFIB_COD', 'AFIBRES_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_cancer_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_cancer_diagnoses_all.sql
@@ -43,6 +43,5 @@ SELECT
     END AS cancer_observation_type
 
 FROM ({{ get_observations("'CAN_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_chd_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_chd_diagnoses_all.sql
@@ -35,6 +35,5 @@ SELECT
     CASE WHEN obs.cluster_id = 'CHD_COD' THEN TRUE ELSE FALSE END AS is_diagnosis_code
 
 FROM ({{ get_observations("'CHD_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_ckd_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_ckd_diagnoses_all.sql
@@ -46,6 +46,5 @@ SELECT
     END AS ckd_observation_type
 
 FROM ({{ get_observations("'CKD_COD', 'CKDRES_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_copd_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_copd_diagnoses_all.sql
@@ -45,6 +45,5 @@ SELECT
     END AS copd_observation_type
 
 FROM ({{ get_observations("'COPD_COD', 'COPDRES_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_dementia_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_dementia_diagnoses_all.sql
@@ -40,6 +40,5 @@ SELECT
     'Dementia Diagnosis' AS dementia_observation_type
 
 FROM ({{ get_observations("'DEM_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_depression_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_depression_diagnoses_all.sql
@@ -46,6 +46,5 @@ SELECT
     END AS depression_observation_type
 
 FROM ({{ get_observations("'DEPR_COD', 'DEPRES_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_diabetes_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_diabetes_diagnoses_all.sql
@@ -34,7 +34,6 @@ WITH diabetes_observations_all_clusters AS (
         obs.mapped_concept_display AS concept_display,
         obs.cluster_id AS source_cluster_id
     FROM ({{ get_observations("'DM_COD', 'DMTYPE1_COD', 'DMTYPE2_COD', 'DMRES_COD'", source='PCD') }}) obs
-    WHERE obs.clinical_effective_date IS NOT NULL
 ),
 
 diabetes_observations_categorised AS (

--- a/models/modelling/olids/diagnoses/qof/int_epilepsy_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_epilepsy_diagnoses_all.sql
@@ -46,6 +46,5 @@ SELECT
     END AS epilepsy_observation_type
 
 FROM ({{ get_observations("'EPIL_COD', 'EPILRES_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_heart_failure_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_heart_failure_diagnoses_all.sql
@@ -47,6 +47,5 @@ SELECT
     END AS heart_failure_observation_type
 
 FROM ({{ get_observations("'HF_COD', 'HFRES_COD', 'HFLVSD_COD', 'REDEJCFRAC_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_hypertension_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_hypertension_diagnoses_all.sql
@@ -41,5 +41,5 @@ SELECT
     END AS hypertension_observation_type
 
 FROM ({{ get_observations("'HYP_COD', 'HYPRES_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
+
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_learning_disability_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_learning_disability_diagnoses_all.sql
@@ -43,6 +43,5 @@ SELECT
     END AS learning_disability_observation_type
 
 FROM ({{ get_observations("'LD_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_ndh_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_ndh_diagnoses_all.sql
@@ -55,6 +55,5 @@ SELECT
     END AS is_diagnosis_code
 
 FROM ({{ get_observations("'NDH_COD', 'IGT_COD', 'PRD_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_osteoporosis_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_osteoporosis_diagnoses_all.sql
@@ -45,6 +45,5 @@ SELECT
     END AS osteoporosis_observation_type
 
 FROM ({{ get_observations("'OSTEO_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_pad_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_pad_diagnoses_all.sql
@@ -41,6 +41,5 @@ SELECT
     END AS pad_observation_type
 
 FROM ({{ get_observations("'PAD_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_palliative_care_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_palliative_care_diagnoses_all.sql
@@ -47,7 +47,6 @@ WITH base_observations AS (
         CASE WHEN obs.cluster_id = 'PALCARENI_COD' THEN TRUE ELSE FALSE END AS is_resolved_code
 
     FROM ({{ get_observations("'PALCARE_COD', 'PALCARENI_COD'", source='PCD') }}) obs
-    WHERE obs.clinical_effective_date IS NOT NULL
 )
 
 SELECT

--- a/models/modelling/olids/diagnoses/qof/int_rheumatoid_arthritis_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_rheumatoid_arthritis_diagnoses_all.sql
@@ -41,6 +41,5 @@ SELECT
     END AS ra_observation_type
 
 FROM ({{ get_observations("'RARTH_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_smi_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_smi_diagnoses_all.sql
@@ -46,6 +46,5 @@ SELECT
     END AS smi_observation_type
 
 FROM ({{ get_observations("'MH_COD', 'MHREM_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_stroke_tia_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_stroke_tia_diagnoses_all.sql
@@ -52,6 +52,5 @@ SELECT
     END AS stroke_tia_observation_type
 
 FROM ({{ get_observations("'STRK_COD', 'TIA_COD'", source='PCD') }}) obs
-WHERE obs.clinical_effective_date IS NOT NULL
 
 ORDER BY person_id, clinical_effective_date, id


### PR DESCRIPTION
## Summary

- Modified `get_observations` macro to replace NULL `clinical_effective_date` values with sentinel date `1900-01-01`
- Removed `WHERE obs.clinical_effective_date IS NOT NULL` clause from all 20 QOF diagnosis intermediate tables
- Ensures diagnosis records with NULL dates are preserved for downstream processing instead of being filtered out

## Changes

### Macro Changes
- `macros/get_observations.sql`: Added `COALESCE(o.clinical_effective_date, '1900-01-01')` to replace NULL dates with sentinel value

### Model Changes (20 files)
All QOF diagnosis intermediate tables updated to remove NULL date filtering:
- int_asthma_diagnoses_all.sql
- int_atrial_fibrillation_diagnoses_all.sql
- int_cancer_diagnoses_all.sql
- int_chd_diagnoses_all.sql
- int_ckd_diagnoses_all.sql
- int_copd_diagnoses_all.sql
- int_dementia_diagnoses_all.sql
- int_depression_diagnoses_all.sql
- int_diabetes_diagnoses_all.sql
- int_epilepsy_diagnoses_all.sql
- int_heart_failure_diagnoses_all.sql
- int_hypertension_diagnoses_all.sql
- int_learning_disability_diagnoses_all.sql
- int_ndh_diagnoses_all.sql
- int_osteoporosis_diagnoses_all.sql
- int_pad_diagnoses_all.sql
- int_palliative_care_diagnoses_all.sql
- int_rheumatoid_arthritis_diagnoses_all.sql
- int_smi_diagnoses_all.sql
- int_stroke_tia_diagnoses_all.sql

## Impact

Records with NULL diagnosis dates will now:
- Be included in intermediate diagnosis tables with sentinel date 1900-01-01
- Be available for downstream fact tables to process
- Be considered in QOF register logic rather than being excluded

Fixes #79