### PR TITLE
fix: revert gender to sex in raw layer source columns

### DIFF
--- a/models/raw/shared/raw_reference_gp_reg_pat_prac_lsoa_all.sql
+++ b/models/raw/shared/raw_reference_gp_reg_pat_prac_lsoa_all.sql
@@ -8,6 +8,6 @@ select
     "PRACTICE_CODE" as practice_code,
     "PRACTICE_NAME" as practice_name,
     "LSOA_CODE" as lsoa_code,
-    "GENDER" as gender,
+    "SEX" as sex,
     "NUMBER_OF_PATIENTS" as number_of_patients
 from {{ source('reference_analyst_managed', 'GP_REG_PAT_PRAC_LSOA_ALL') }}

--- a/models/raw/shared/raw_reference_indicator_data.sql
+++ b/models/raw/shared/raw_reference_indicator_data.sql
@@ -11,7 +11,7 @@ select
     "Area Name" as area_name,
     "Area Type" as area_type,
     "AREA_ID" as area_id,
-    "Gender" as gender,
+    "Sex" as sex,
     "Age" as age,
     "Category Type" as category_type,
     "Category" as category,


### PR DESCRIPTION
## Summary
- Reverted `GENDER` to `SEX` in `raw_reference_gp_reg_pat_prac_lsoa_all.sql`
- Reverted `Gender` to `Sex` in `raw_reference_indicator_data.sql`

## Context
PR #124 changed column references from `SEX` to `GENDER` in the raw layer, but the source tables still use `SEX` columns. This caused SQL database errors.

Raw layer models should match source column names exactly. Gender/sex terminology standardisation should happen in the staging layer if needed.

Fixes #130