### PR TITLE
refactor(valproate): improve medication matching logic

### DIFF
--- a/analyses/valproate_patient_count.sql
+++ b/analyses/valproate_patient_count.sql
@@ -1,0 +1,22 @@
+-- Count of distinct patients with recent valproate prescriptions
+-- in the child-bearing age cohort (non-male, age 0-55, last 6 months)
+--
+-- Note: Registration status intentionally not included
+--
+-- Usage: dbt compile -s valproate_patient_count, then execute the compiled SQL
+
+WITH child_bearing_age AS (
+    SELECT person_id
+    FROM {{ ref('dim_person_women_child_bearing_age') }}
+    WHERE is_child_bearing_age_0_55 = TRUE
+),
+
+recent_valproate AS (
+    SELECT person_id
+    FROM {{ ref('int_valproate_medications_6m_latest') }}
+)
+
+SELECT COUNT(DISTINCT cba.person_id) AS patient_count
+FROM child_bearing_age cba
+INNER JOIN recent_valproate rv
+    ON cba.person_id = rv.person_id

--- a/models/modelling/olids/medications/int_valproate_medications_all.sql
+++ b/models/modelling/olids/medications/int_valproate_medications_all.sql
@@ -7,16 +7,18 @@
 
 /*
 All valproate medication orders for seizure management and bipolar disorder.
-Uses special matching logic combining medication name patterns and concept ID validation.
+Uses two matching approaches:
+1. Valproate programme codes lookup (legacy)
+2. VALPROATE cluster_id from combined codesets
 Critical for pregnancy safety monitoring and teratogenicity risk assessment.
 Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
 */
 
-WITH base_medication_orders AS (
-    -- Get base medication order and statement data following legacy pattern
+WITH valproate_from_prog_codes AS (
+    -- Get medication orders using valproate_prog_codes lookup
     SELECT DISTINCT
         mo.id AS medication_order_id,
-        ms.id AS medication_statement_id,
+        NULL AS medication_statement_id,
         pp.person_id,
         mo.clinical_effective_date::DATE AS order_date,
         mo.medication_name AS order_medication_name,
@@ -24,20 +26,19 @@ WITH base_medication_orders AS (
         mo.quantity_value AS order_quantity_value,
         mo.quantity_unit AS order_quantity_unit,
         mo.duration_days AS order_duration_days,
-        ms.medication_name AS statement_medication_name,
+        NULL AS statement_medication_name,
         mc.code AS mapped_concept_code,
         mc.display AS mapped_concept_display,
         mc.id AS mapped_concept_id,
         vp.valproate_product_term,
         NULL AS bnf_code,
-        NULL AS bnf_name
+        NULL AS bnf_name,
+        'PROG_CODES' AS source_method
     FROM {{ ref('stg_olids_medication_order') }} AS mo
-    INNER JOIN {{ ref('stg_olids_medication_statement') }} AS ms
-        ON mo.medication_statement_id = ms.id
     INNER JOIN {{ ref('int_patient_person_unique') }} AS pp
         ON mo.patient_id = pp.patient_id
     LEFT JOIN {{ ref('stg_olids_concept_map') }} AS cm
-        ON ms.medication_statement_source_concept_id = cm.source_code_id
+        ON mo.medication_order_source_concept_id = cm.source_code_id
     LEFT JOIN {{ ref('stg_olids_concept') }} AS mc
         ON cm.target_code_id = mc.id
     LEFT JOIN {{ ref('stg_reference_valproate_prog_codes') }} AS vp
@@ -45,16 +46,66 @@ WITH base_medication_orders AS (
             mc.code = vp.code
             AND vp.code_category = 'DRUG'
     WHERE (
-        -- Name-based matching for valproate (following legacy logic)
+        -- Name-based matching for valproate
         mo.medication_name ILIKE '%VALPROATE%'
         OR mo.medication_name ILIKE '%VALPROIC ACID%'
-        OR ms.medication_name ILIKE '%VALPROATE%'
-        OR ms.medication_name ILIKE '%VALPROIC ACID%'
     )
     OR (
         -- Concept ID matching via VALPROATE_PROG_CODES
         vp.code IS NOT NULL
     )
+),
+
+valproate_from_cluster AS (
+    -- Get medication orders using VALPROATE cluster_id
+    SELECT DISTINCT
+        medication_order_id,
+        medication_statement_id,
+        person_id,
+        order_date::DATE AS order_date,
+        order_medication_name,
+        order_dose,
+        order_quantity_value,
+        order_quantity_unit,
+        order_duration_days,
+        statement_medication_name,
+        mapped_concept_code,
+        mapped_concept_display,
+        NULL AS mapped_concept_id,
+        NULL AS valproate_product_term,
+        bnf_code,
+        bnf_name,
+        'CLUSTER_ID' AS source_method
+    FROM ({{ get_medication_orders(cluster_id='VALPROATE') }})
+),
+
+base_medication_orders AS (
+    -- Combine both sources, deduplicating by medication_order_id
+    SELECT
+        COALESCE(pc.medication_order_id, cl.medication_order_id) AS medication_order_id,
+        COALESCE(pc.medication_statement_id, cl.medication_statement_id) AS medication_statement_id,
+        COALESCE(pc.person_id, cl.person_id) AS person_id,
+        COALESCE(pc.order_date, cl.order_date) AS order_date,
+        COALESCE(pc.order_medication_name, cl.order_medication_name) AS order_medication_name,
+        COALESCE(pc.order_dose, cl.order_dose) AS order_dose,
+        COALESCE(pc.order_quantity_value, cl.order_quantity_value) AS order_quantity_value,
+        COALESCE(pc.order_quantity_unit, cl.order_quantity_unit) AS order_quantity_unit,
+        COALESCE(pc.order_duration_days, cl.order_duration_days) AS order_duration_days,
+        COALESCE(pc.statement_medication_name, cl.statement_medication_name) AS statement_medication_name,
+        COALESCE(pc.mapped_concept_code, cl.mapped_concept_code) AS mapped_concept_code,
+        COALESCE(pc.mapped_concept_display, cl.mapped_concept_display) AS mapped_concept_display,
+        pc.mapped_concept_id,
+        pc.valproate_product_term,
+        COALESCE(pc.bnf_code, cl.bnf_code) AS bnf_code,
+        COALESCE(pc.bnf_name, cl.bnf_name) AS bnf_name,
+        CASE
+            WHEN pc.medication_order_id IS NOT NULL AND cl.medication_order_id IS NOT NULL THEN 'BOTH'
+            WHEN pc.medication_order_id IS NOT NULL THEN 'PROG_CODES'
+            ELSE 'CLUSTER_ID'
+        END AS source_method
+    FROM valproate_from_prog_codes pc
+    FULL OUTER JOIN valproate_from_cluster cl
+        ON pc.medication_order_id = cl.medication_order_id
 ),
 
 valproate_orders AS (
@@ -65,8 +116,6 @@ valproate_orders AS (
         (
             bmo.order_medication_name ILIKE '%VALPROATE%'
             OR bmo.order_medication_name ILIKE '%VALPROIC ACID%'
-            OR bmo.statement_medication_name ILIKE '%VALPROATE%'
-            OR bmo.statement_medication_name ILIKE '%VALPROIC ACID%'
         ) AS matched_on_name,
 
         -- Concept ID matching flag
@@ -78,19 +127,15 @@ valproate_orders AS (
                 bmo.valproate_product_term IS NOT NULL
                 THEN bmo.valproate_product_term
             WHEN
-                bmo.statement_medication_name ILIKE '%SODIUM VALPROATE%'
-                OR bmo.order_medication_name ILIKE '%SODIUM VALPROATE%'
+                bmo.order_medication_name ILIKE '%SODIUM VALPROATE%'
                 THEN 'SODIUM_VALPROATE'
             WHEN
-                bmo.statement_medication_name ILIKE '%VALPROIC ACID%'
-                OR bmo.order_medication_name ILIKE '%VALPROIC ACID%'
+                bmo.order_medication_name ILIKE '%VALPROIC ACID%'
                 THEN 'VALPROIC_ACID'
             WHEN
-                bmo.statement_medication_name ILIKE '%EPILIM%'
-                OR bmo.order_medication_name ILIKE '%EPILIM%' THEN 'EPILIM'
+                bmo.order_medication_name ILIKE '%EPILIM%' THEN 'EPILIM'
             WHEN
-                bmo.statement_medication_name ILIKE '%DEPAKOTE%'
-                OR bmo.order_medication_name ILIKE '%DEPAKOTE%' THEN 'DEPAKOTE'
+                bmo.order_medication_name ILIKE '%DEPAKOTE%' THEN 'DEPAKOTE'
             ELSE 'OTHER_VALPROATE'
         END AS valproate_product_type
 
@@ -134,22 +179,16 @@ valproate_enhanced AS (
         -- Formulation type for bioequivalence monitoring
         CASE
             WHEN
-                vo.order_medication_name ILIKE '%TABLET%'
-                OR vo.statement_medication_name ILIKE '%TABLET%' THEN 'TABLET'
+                vo.order_medication_name ILIKE '%TABLET%' THEN 'TABLET'
             WHEN
-                vo.order_medication_name ILIKE '%CAPSULE%'
-                OR vo.statement_medication_name ILIKE '%CAPSULE%' THEN 'CAPSULE'
+                vo.order_medication_name ILIKE '%CAPSULE%' THEN 'CAPSULE'
             WHEN
                 vo.order_medication_name ILIKE '%LIQUID%'
                 OR vo.order_medication_name ILIKE '%SYRUP%'
-                OR vo.statement_medication_name ILIKE '%LIQUID%'
-                OR vo.statement_medication_name ILIKE '%SYRUP%'
                 THEN 'LIQUID'
             WHEN
                 vo.order_medication_name ILIKE '%MODIFIED RELEASE%'
                 OR vo.order_medication_name ILIKE '%MR%'
-                OR vo.statement_medication_name ILIKE '%MODIFIED RELEASE%'
-                OR vo.statement_medication_name ILIKE '%MR%'
                 THEN 'MODIFIED_RELEASE'
             ELSE 'UNKNOWN_FORMULATION'
         END AS formulation_type,
@@ -165,7 +204,33 @@ valproate_enhanced AS (
 -- Final selection with ALL persons - no filtering by active status
 -- Critical for pregnancy safety monitoring across all patient populations
 SELECT
-    ve.*,
+    ve.medication_order_id,
+    ve.medication_statement_id,
+    ve.person_id,
+    ve.order_date,
+    ve.order_medication_name,
+    ve.order_dose,
+    ve.order_quantity_value,
+    ve.order_quantity_unit,
+    ve.order_duration_days,
+    ve.statement_medication_name,
+    ve.mapped_concept_code,
+    ve.mapped_concept_display,
+    ve.mapped_concept_id,
+    ve.valproate_product_term,
+    ve.bnf_code,
+    ve.bnf_name,
+    ve.source_method,
+    ve.matched_on_name,
+    ve.matched_on_concept_id,
+    ve.valproate_product_type,
+    ve.is_high_teratogenic_risk,
+    ve.clinical_indication,
+    ve.dose_category,
+    ve.formulation_type,
+    ve.is_recent_3m,
+    ve.is_recent_6m,
+    ve.is_recent_12m,
 
     -- Add person demographics for reference
     p.current_practice_id,


### PR DESCRIPTION
## Summary
- Removes medication_statement INNER JOIN to capture more valproate prescriptions to work around a bug where many orders do not link to a statement.
- Changes concept mapping from medication_statement_source_concept_id to medication_order_source_concept_id
- Adds VALPROATE cluster_id lookup using get_medication_orders macro alongside existing valproate_prog_codes
- Combines both approaches with FULL OUTER JOIN, deduplicating by medication_order_id
- Adds source_method field to track which approach found each medication (PROG_CODES, CLUSTER_ID, or BOTH)
- Includes new analysis file for validating patient counts

## Test plan
- [x] Compile and run int_valproate_medications_all model
- [x] Verify patient count increased from 249 to expected ~351
- [x] Check source_method distribution to understand coverage from each approach
- [x] Compile and run valproate_patient_count analysis
- [x] Verify downstream models (int_valproate_medications_6m_latest, dim_valproate_db_scope) build successfully