### PR TITLE
fix: improve release-please workflow reliability

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,16 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple
 
+      # Auto-merge Release PR
+      - name: Auto-merge Release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.release.outputs.pr }}"
+          echo "Auto-merging Release PR #$PR_NUMBER"
+          gh pr merge $PR_NUMBER --auto --squash --delete-branch
+
       # Checkout code if a release was created
       - name: Checkout code
         if: ${{ steps.release.outputs.release_created }}
@@ -51,23 +61,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Get current release notes
-          CURRENT_NOTES=$(gh release view ${{ steps.release.outputs.tag_name }} --json body -q .body)
+          # Get current release notes and save to file
+          gh release view ${{ steps.release.outputs.tag_name }} --json body -q .body > /tmp/current-notes.md
 
-          # Read analysis
-          DBT_ANALYSIS=$(cat /tmp/dbt-analysis.md)
+          # Combine notes using cat
+          cat /tmp/current-notes.md > /tmp/combined-notes.md
+          echo "" >> /tmp/combined-notes.md
+          echo "---" >> /tmp/combined-notes.md
+          echo "" >> /tmp/combined-notes.md
+          echo "## dbt Models Changed" >> /tmp/combined-notes.md
+          echo "" >> /tmp/combined-notes.md
+          cat /tmp/dbt-analysis.md >> /tmp/combined-notes.md
 
-          # Combine notes
-          NEW_NOTES="$CURRENT_NOTES
-
----
-
-## dbt Models Changed
-
-$DBT_ANALYSIS"
-
-          # Update release
-          gh release edit ${{ steps.release.outputs.tag_name }} --notes "$NEW_NOTES"
+          # Update release with combined notes
+          gh release edit ${{ steps.release.outputs.tag_name }} --notes-file /tmp/combined-notes.md
 
       # Optional: Post to Slack/Teams
       # - name: Notify team


### PR DESCRIPTION
## Summary
- Add auto-merge for Release PRs to keep changelog current
- Fix shell quoting issue that caused workflow failures

## Details

### Auto-merge Release PRs
When Release PRs are created, they will now automatically merge. This ensures the CHANGELOG.md stays current and prevents the changelog from becoming outdated when PRs are merged but releases sit unmerged.

### Fix Release Notes Quoting Issue
The workflow was failing when updating release notes with dbt model analysis due to improper bash quoting of multi-line strings:
```
/home/runner/work/_temp/*.sh: line 8: unexpected EOF while looking for matching `"'
```

Changed to use file-based approach instead of string variables to avoid quoting issues entirely.

## Test Plan
- [x] Workflow compiles without syntax errors
- [x] Verify Release PR auto-merges when created
- [x] Verify release notes are updated with dbt analysis
- [x] Confirm no shell quoting errors

Fixes the failure from workflow run 18817816669