### PR TITLE
Csds deduplication

### DIFF
--- a/macros/deduplicate_csds.sql
+++ b/macros/deduplicate_csds.sql
@@ -3,23 +3,34 @@
 {% macro deduplicate_csds(
         csds_table,
         partition_cols = []
-        ) %}
+    ) %}
+
+    {# 
+        This macro deduplicates a CSDS table by keeping the most recent record
+        (based on `effective_from`) within each unique combination of `partition_cols`.
+
+        Example usage:
+          {{ deduplicate_csds('my_schema.my_table', ['unique_service_request_identifier', 'unique_care_contact_identifier']) }}
+    #}
+
+    {% if partition_cols | length == 0 %}
+        {{ exceptions.raise_compiler_error("You must provide at least one partition column to deduplicate_csds.") }}
+    {% endif %}
 
     SELECT
         ROW_NUMBER() OVER (
-            PARTITION BY tbl.unique_service_request_identifier
+            PARTITION BY 
             {%- for col in partition_cols %}
-                , tbl.{{ col }}
+                {{ "tbl." ~ col }}{% if not loop.last %}, {% endif %}
             {%- endfor %}
             ORDER BY tbl.effective_from DESC
         ) AS sequence,
-        tbl.* 
+        tbl.*
+    FROM {{ csds_table }} AS tbl
 
-    FROM {{csds_table}} AS tbl
-
-    INNER JOIN {{ref('raw_csds_activesubmission')}} AS a
+    INNER JOIN {{ ref('raw_csds_activesubmission') }} AS a
         ON tbl.unique_submission_id = a.unique_submission_id
- 
+
     QUALIFY sequence = 1
 
 {% endmacro %}

--- a/models/modelling/commissioning/encounters/int_csds_encounters.yml
+++ b/models/modelling/commissioning/encounters/int_csds_encounters.yml
@@ -7,3 +7,6 @@ models:
       - name: sk_patient_id
         data_type: varchar
         description: pseudo NHS number
+        tests:
+          - not_null
+  

--- a/models/modelling/commissioning/encounters/int_sus_op_encounters.yml
+++ b/models/modelling/commissioning/encounters/int_sus_op_encounters.yml
@@ -11,6 +11,8 @@ models:
       - name: sk_patient_id
         data_type: varchar
         description: "Common commissioning patient identifier"
+        tests:
+          - not_null
 
       - name: provider_id
         data_type: varchar

--- a/models/staging/commissioning/stg_csds_cyp101referral.sql
+++ b/models/staging/commissioning/stg_csds_cyp101referral.sql
@@ -6,7 +6,8 @@
 WITH deduplicated AS (
     {{
         deduplicate_csds(
-            csds_table = ref('raw_csds_cyp101referral')
+            csds_table = ref('raw_csds_cyp101referral'),
+            partition_cols = ['unique_service_request_identifier']
         )
     }}
 )

--- a/models/staging/commissioning/stg_csds_cyp201carecontact.sql
+++ b/models/staging/commissioning/stg_csds_cyp201carecontact.sql
@@ -6,7 +6,7 @@ WITH deduplicated AS (
 {{
     deduplicate_csds(
         csds_table = ref('raw_csds_cyp201carecontact'),
-        partition_cols = ['unique_care_contact_identifier']
+        partition_cols = ['unique_service_request_identifier', 'unique_care_contact_identifier']
     )
 }} )
 

--- a/models/staging/commissioning/stg_csds_cyp201carecontact.yml
+++ b/models/staging/commissioning/stg_csds_cyp201carecontact.yml
@@ -2,6 +2,13 @@ version: 2
 models:
 - name: stg_csds_cyp201carecontact
   description: CSDS CYP care contacts (deduplicated)
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      combination_of_columns:
+        - unique_service_request_identifier
+        - unique_care_contact_identifier
+  - dbt_expectations.expect_table_row_count_to_be_between:
+      min_value: 1
   columns:
   - name: unique_service_request_identifier
     description: Service request identifier (FK to referral)
@@ -10,9 +17,8 @@ models:
   - name: person_id
     description: CSDS person identifier
   - name: unique_care_contact_identifier
-    description: Primary key - unique care contact identifier (currently has duplicates due to primary/refresh submission types - see issue #TBD)
+    description: unique identifier within a given service request
     tests:
-    - unique  
     - not_null
   - name: care_contact_date
     description: Date of care contact
@@ -20,6 +26,3 @@ models:
     description: Code for type of location where activity took place
   - name: attendance_status
     description: Attendance status (attended, DNA, etc.)
-  tests:
-  - dbt_expectations.expect_table_row_count_to_be_between:
-      min_value: 1

--- a/models/staging/commissioning/stg_csds_cyp202careactivity.sql
+++ b/models/staging/commissioning/stg_csds_cyp202careactivity.sql
@@ -6,7 +6,7 @@ WITH deduplicated AS (
 {{
     deduplicate_csds(
         csds_table = ref('raw_csds_cyp202careactivity'),
-        partition_cols = ['unique_care_activity_identifier']
+        partition_cols = ['unique_care_contact_identifier', 'unique_care_activity_identifier']
     )
 }} )
 

--- a/models/staging/commissioning/stg_csds_cyp202careactivity.yml
+++ b/models/staging/commissioning/stg_csds_cyp202careactivity.yml
@@ -2,11 +2,16 @@ version: 2
 models:
 - name: stg_csds_cyp202careactivity
   description: CSDS CYP care activities (deduplicated)
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      combination_of_columns:
+        - unique_care_contact_identifier
+        - unique_care_activity_identifier
+  - dbt_expectations.expect_table_row_count_to_be_between:
+      min_value: 1
   columns:
   - name: unique_care_activity_identifier
     description: activity identifier (PK) 
-    tests:
-    - unique
   - name: unique_care_contact_identifier
     description: Care contact identifier (FK to care contact)
     tests:
@@ -25,6 +30,3 @@ models:
     description: SNOMED CT code for observation
   - name: effective_from
     description: Effective from date for the activity
-  tests:
-  - dbt_expectations.expect_table_row_count_to_be_between:
-      min_value: 1


### PR DESCRIPTION
Fixing some problem with the deduplication macro:
1. 'tbl.unique_service_request_identifier' should not be a string
2. rewritten the macro so all partition cols must be passed in as parameters. This is because not all tables partition by 'unique_service_request_identifier'