### PR TITLE
fix(ci): prevent bash syntax error when echoing release-please JSON output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,8 @@ jobs:
         run: |
           echo "release_created: ${{ steps.release.outputs.release_created }}"
           echo "prs_created: ${{ steps.release.outputs.prs_created }}"
-          echo "pr output: ${{ steps.release.outputs.pr }}"
+          PR_OUTPUT='${{ steps.release.outputs.pr }}'
+          echo "pr output: $PR_OUTPUT"
           echo "tag_name: ${{ steps.release.outputs.tag_name }}"
 
       # Auto-merge Release PR


### PR DESCRIPTION
Fixes a bash syntax error in the release-please workflow where parentheses in JSON URLs were being interpreted as command substitution.

The fix stores the JSON output in a variable using single quotes before echoing, preventing bash from interpreting special characters in the JSON output.