### PR TITLE
fix(ci): add checkout step before auto-merge to ensure git repository is available

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,11 @@ jobs:
           echo "pr output: $PR_OUTPUT"
           echo "tag_name: ${{ steps.release.outputs.tag_name }}"
 
+      # Checkout code for gh CLI
+      - name: Checkout code
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/checkout@v4
+
       # Auto-merge Release PR
       - name: Auto-merge Release PR
         if: ${{ steps.release.outputs.pr }}


### PR DESCRIPTION
Fixes the 'fatal: not a git repository' error when running gh pr merge in the auto-merge step.

The gh pr merge command requires a git repository context to work properly. This adds a checkout step before the auto-merge step to ensure the repository is available when the gh CLI needs it.