### PR TITLE
fix: align age band upper limits with dim_person_age standard

### DIFF
--- a/macros/calculate_age_attributes.sql
+++ b/macros/calculate_age_attributes.sql
@@ -90,7 +90,7 @@
     CASE
         WHEN {{ birth_date_field }} IS NULL THEN 'Unknown'
         WHEN ({{ age_calc }}) < 0 THEN 'Unknown'
-        WHEN ({{ age_calc }}) >= 100 THEN '100+'
+        WHEN ({{ age_calc }}) >= 85 THEN '85+'
         ELSE TO_VARCHAR(FLOOR(({{ age_calc }}) / 5) * 5) || '-' || TO_VARCHAR(FLOOR(({{ age_calc }}) / 5) * 5 + 4)
     END AS age_band_5y,
 
@@ -98,7 +98,7 @@
     CASE
         WHEN {{ birth_date_field }} IS NULL THEN 'Unknown'
         WHEN ({{ age_calc }}) < 0 THEN 'Unknown'
-        WHEN ({{ age_calc }}) >= 100 THEN '100+'
+        WHEN ({{ age_calc }}) >= 80 THEN '80+'
         ELSE TO_VARCHAR(FLOOR(({{ age_calc }}) / 10) * 10) || '-' || TO_VARCHAR(FLOOR(({{ age_calc }}) / 10) * 10 + 9)
     END AS age_band_10y,
 


### PR DESCRIPTION
## Summary

Fixes age band inconsistencies between `calculate_age_attributes` macro and `dim_person_age`:
- 5-year age bands: changed upper limit from 100+ to 85+
- 10-year age bands: changed upper limit from 100+ to 80+

## Changes

- `macros/calculate_age_attributes.sql:93` - Updated 5-year age band threshold
- `macros/calculate_age_attributes.sql:101` - Updated 10-year age band threshold

## Impact

Models using `calculate_age_attributes` macro will now produce consistent age band groupings with `dim_person_age`:
- `dim_person_demographics`
- `person_month_analysis_base`

## Test Plan

- [x] Run `dbt build --select dim_person_demographics person_month_analysis_base`
- [x] Verify age band distributions match `dim_person_age` standards
- [x] Confirm no data quality issues in downstream models