### PR TITLE
Remove window functions from OLIDS staging models

### DIFF
--- a/models/staging/olids/stg_olids_allergy_intolerance.sql
+++ b/models/staging/olids/stg_olids_allergy_intolerance.sql
@@ -33,7 +33,3 @@ select
 
 from {{ ref('raw_olids_allergy_intolerance') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_appointment.sql
+++ b/models/staging/olids/stg_olids_appointment.sql
@@ -42,7 +42,3 @@ select
 
 from {{ ref('raw_olids_appointment') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_appointment_practitioner.sql
+++ b/models/staging/olids/stg_olids_appointment_practitioner.sql
@@ -19,7 +19,3 @@ select
 
 from {{ ref('raw_olids_appointment_practitioner') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_diagnostic_order.sql
+++ b/models/staging/olids/stg_olids_diagnostic_order.sql
@@ -36,7 +36,3 @@ select
 
 from {{ ref('raw_olids_diagnostic_order') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_encounter.sql
+++ b/models/staging/olids/stg_olids_encounter.sql
@@ -33,7 +33,3 @@ select
 
 from {{ ref('raw_olids_encounter') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_episode_of_care.sql
+++ b/models/staging/olids/stg_olids_episode_of_care.sql
@@ -23,7 +23,3 @@ select
 
 from {{ ref('raw_olids_episode_of_care') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_flag.sql
+++ b/models/staging/olids/stg_olids_flag.sql
@@ -21,7 +21,3 @@ select
 
 from {{ ref('raw_olids_flag') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_location.sql
+++ b/models/staging/olids/stg_olids_location.sql
@@ -32,7 +32,3 @@ select
 
 from {{ ref('raw_olids_location') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_location_contact.sql
+++ b/models/staging/olids/stg_olids_location_contact.sql
@@ -19,7 +19,3 @@ select
 
 from {{ ref('raw_olids_location_contact') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_organisation.sql
+++ b/models/staging/olids/stg_olids_organisation.sql
@@ -25,7 +25,3 @@ select
 
 from {{ ref('raw_olids_organisation') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_patient.sql
+++ b/models/staging/olids/stg_olids_patient.sql
@@ -27,7 +27,3 @@ select
 
 from {{ ref('raw_olids_patient') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_patient_address.sql
+++ b/models/staging/olids/stg_olids_patient_address.sql
@@ -19,7 +19,3 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_patient_address') }}
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_patient_contact.sql
+++ b/models/staging/olids/stg_olids_patient_contact.sql
@@ -21,7 +21,3 @@ select
 
 from {{ ref('raw_olids_patient_contact') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_patient_person.sql
+++ b/models/staging/olids/stg_olids_patient_person.sql
@@ -14,7 +14,3 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_patient_person') }}
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_patient_registered_practitioner_in_role.sql
+++ b/models/staging/olids/stg_olids_patient_registered_practitioner_in_role.sql
@@ -22,7 +22,3 @@ select
 
 from {{ ref('raw_olids_patient_registered_practitioner_in_role') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_patient_uprn.sql
+++ b/models/staging/olids/stg_olids_patient_uprn.sql
@@ -27,7 +27,3 @@ select
 
 from {{ ref('raw_olids_patient_uprn') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_postcode_hash.sql
+++ b/models/staging/olids/stg_olids_postcode_hash.sql
@@ -17,7 +17,3 @@ select
     lds_start_date_time
 
 from {{ ref('raw_olids_postcode_hash') }}
-qualify row_number() over (
-    partition by postcode_hash
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_practitioner.sql
+++ b/models/staging/olids/stg_olids_practitioner.sql
@@ -22,7 +22,3 @@ select
 
 from {{ ref('raw_olids_practitioner') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_practitioner_in_role.sql
+++ b/models/staging/olids/stg_olids_practitioner_in_role.sql
@@ -21,7 +21,3 @@ select
 
 from {{ ref('raw_olids_practitioner_in_role') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_procedure_request.sql
+++ b/models/staging/olids/stg_olids_procedure_request.sql
@@ -30,7 +30,3 @@ select
 
 from {{ ref('raw_olids_procedure_request') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_referral_request.sql
+++ b/models/staging/olids/stg_olids_referral_request.sql
@@ -36,7 +36,3 @@ select
 
 from {{ ref('raw_olids_referral_request') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_schedule.sql
+++ b/models/staging/olids/stg_olids_schedule.sql
@@ -23,7 +23,3 @@ select
 
 from {{ ref('raw_olids_schedule') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1

--- a/models/staging/olids/stg_olids_schedule_practitioner.sql
+++ b/models/staging/olids/stg_olids_schedule_practitioner.sql
@@ -17,7 +17,3 @@ select
 
 from {{ ref('raw_olids_schedule_practitioner') }}
 where coalesce(lds_is_deleted, false) = false
-qualify row_number() over (
-    partition by id
-    order by lds_start_date_time desc
-) = 1


### PR DESCRIPTION
## Summary
Removed window functions from all 23 OLIDS staging models to address performance issues.

## Changes
- Removed \qualify row_number() over()\ window functions from all OLIDS staging models
- Preserved WHERE clause filters (e.g. \lds_is_deleted\ filters)
- This addresses performance issues caused by window function operations

## Files Modified
23 staging model files in \models/staging/olids/\

## Testing
- Verified all WHERE clause filters are preserved
- Confirmed no window functions remain in the modified files