### PR TITLE
Restore window functions for stg_olids_schedule and stg_olids_patient_person

### DIFF
--- a/models/staging/olids/stg_olids_patient_person.sql
+++ b/models/staging/olids/stg_olids_patient_person.sql
@@ -14,3 +14,7 @@ select
     lds_record_id
 
 from {{ ref('raw_olids_patient_person') }}
+qualify row_number() over (
+    partition by id
+    order by lds_start_date_time desc
+) = 1

--- a/models/staging/olids/stg_olids_schedule.sql
+++ b/models/staging/olids/stg_olids_schedule.sql
@@ -23,3 +23,7 @@ select
 
 from {{ ref('raw_olids_schedule') }}
 where coalesce(lds_is_deleted, false) = false
+qualify row_number() over (
+    partition by id
+    order by lds_start_date_time desc
+) = 1


### PR DESCRIPTION
After reverting PR #256, this restores window functions to only the two OLIDS staging models that require them: stg_olids_schedule and stg_olids_patient_person. All other OLIDS staging models remain without window functions for performance.