### PR TITLE
Add authorisation_type_display to medication_statement model

### DIFF
--- a/models/staging/olids/stg_olids_medication_statement.sql
+++ b/models/staging/olids/stg_olids_medication_statement.sql
@@ -13,6 +13,7 @@ select
     diagnostic_order_id,
     referral_request_id,
     authorisation_type_concept_id,
+    authorisation_type_display,
     date_precision_concept_id,
     medication_statement_source_concept_id,
     clinical_effective_date,


### PR DESCRIPTION
This PR adds the `authorisation_type_display` column to the medication_statement staging model from the raw table.