### PR TITLE
Add extended LTC registers for population health

### DIFF
--- a/models/modelling/olids/diagnoses/int_anxiety_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/int_anxiety_diagnoses_all.sql
@@ -1,0 +1,51 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All anxiety diagnosis observations from clinical records.
+Uses anxiety cluster IDs:
+- ANX_COD: Anxiety diagnoses
+- ANXRES_COD: Anxiety resolved/remission codes
+
+Clinical Purpose:
+- Anxiety register data collection
+- Mental health care pathway monitoring
+- Anxiety severity tracking
+- Resolution status tracking
+
+Clinical Context:
+Anxiety register includes persons with anxiety diagnosis codes who may or may not
+have been resolved. Resolution logic applied in downstream fact models.
+No age restrictions applied - condition can occur at any age.
+
+Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
+This is OBSERVATION-LEVEL data - one row per anxiety observation.
+Use this model as input for fct_person_anxiety_register.sql which applies business rules.
+*/
+
+SELECT
+    obs.id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS concept_display,
+    obs.cluster_id AS source_cluster_id,
+
+    -- Anxiety-specific flags (observation-level only)
+    CASE WHEN obs.cluster_id = 'ANX_COD' THEN TRUE ELSE FALSE END AS is_diagnosis_code,
+    CASE WHEN obs.cluster_id = 'ANXRES_COD' THEN TRUE ELSE FALSE END AS is_resolved_code,
+
+    -- Anxiety observation type determination
+    CASE
+        WHEN obs.cluster_id = 'ANX_COD' THEN 'Anxiety Diagnosis'
+        WHEN obs.cluster_id = 'ANXRES_COD' THEN 'Anxiety Resolved'
+        ELSE 'Unknown'
+    END AS anxiety_observation_type
+
+FROM ({{ get_observations("'ANX_COD', 'ANXRES_COD'") }}) obs
+
+ORDER BY person_id, clinical_effective_date, id
+

--- a/models/modelling/olids/diagnoses/int_anxiety_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_anxiety_diagnoses_all.yml
@@ -1,0 +1,38 @@
+version: 2
+models:
+  - name: int_anxiety_diagnoses_all
+    description: 'Anxiety diagnosis and resolution observations for mental health register management.
+
+      One row per observation using ANX_COD (diagnosis) and ANXRES_COD (resolution) clusters.'
+    columns:
+      - name: id
+        description: 'Unique identifier for the clinical observation'
+
+      - name: person_id
+        description: 'Patient identifier'
+
+      - name: clinical_effective_date
+        description: 'Date when anxiety observation was clinically effective'
+
+      - name: concept_code
+        description: 'Clinical code for anxiety diagnosis or resolution'
+
+      - name: concept_display
+        description: 'Human-readable description of the clinical code'
+
+      - name: source_cluster_id
+        description: 'Cluster identifier (ANX_COD or ANXRES_COD)'
+
+      - name: is_diagnosis_code
+        description: 'Flag indicating anxiety diagnosis code (ANX_COD cluster)'
+
+      - name: is_resolved_code
+        description: 'Flag indicating anxiety resolution code (ANXRES_COD cluster)'
+
+      - name: anxiety_observation_type
+        description: 'Categorised anxiety observation type (Anxiety Diagnosis or Anxiety Resolved)'
+
+    tests:
+      - cluster_ids_exist:
+          cluster_ids: ANX_COD, ANXRES_COD
+

--- a/models/modelling/olids/diagnoses/int_autism_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/int_autism_diagnoses_all.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All autism spectrum disorder diagnosis observations from clinical records.
+Uses autism cluster ID:
+- AUTISM_COD: Autism spectrum disorder diagnoses
+
+Clinical Purpose:
+- Autism register data collection
+- Neurodevelopmental condition monitoring
+- Care pathway tracking
+- Complex needs identification
+
+Clinical Context:
+Autism register includes persons with autism spectrum disorder diagnosis codes.
+Autism is a lifelong neurodevelopmental condition with no resolution codes.
+No age restrictions applied - condition is typically diagnosed in childhood but persists throughout life.
+
+Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
+This is OBSERVATION-LEVEL data - one row per autism observation.
+Use this model as input for fct_person_autism_register.sql which applies business rules.
+*/
+
+SELECT
+    obs.id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS concept_display,
+    obs.cluster_id AS source_cluster_id,
+
+    -- Autism-specific flags (observation-level only)
+    TRUE AS is_diagnosis_code,
+
+    -- Autism observation type
+    'Autism Spectrum Disorder Diagnosis' AS autism_observation_type
+
+FROM ({{ get_observations("'AUTISM_COD'") }}) obs
+WHERE obs.clinical_effective_date IS NOT NULL
+
+ORDER BY person_id, clinical_effective_date, id
+

--- a/models/modelling/olids/diagnoses/int_autism_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_autism_diagnoses_all.yml
@@ -1,0 +1,39 @@
+version: 2
+models:
+  - name: int_autism_diagnoses_all
+    description: 'Autism spectrum disorder diagnosis observations for neurodevelopmental condition register management.
+
+      Key Features:
+
+      • Uses AUTISM_COD cluster for diagnosis identification
+
+      • Supports autism register data collection
+
+      • Enables neurodevelopmental condition monitoring and care pathway tracking
+
+      • No resolution codes as autism is a lifelong condition
+
+      • Distinct from learning disability - can co-occur but tracked separately
+
+      Purpose: Provide observation-level data for autism tracking and complex needs identification.'
+    tests:
+      - cluster_ids_exist:
+          cluster_ids: AUTISM_COD
+    columns:
+      - name: id
+        description: 'Unique identifier for the clinical observation'
+      - name: person_id
+        description: 'Unique identifier for the person'
+      - name: clinical_effective_date
+        description: 'Date when the autism observation was recorded'
+      - name: concept_code
+        description: 'Clinical code for the autism spectrum disorder diagnosis'
+      - name: concept_display
+        description: 'Human-readable description of the autism diagnosis'
+      - name: source_cluster_id
+        description: 'Source cluster identifier (AUTISM_COD for autism diagnoses)'
+      - name: is_diagnosis_code
+        description: 'Boolean flag indicating diagnosis code (always TRUE for autism observations)'
+      - name: autism_observation_type
+        description: 'Type of autism observation (always "Autism Spectrum Disorder Diagnosis")'
+

--- a/models/modelling/olids/diagnoses/int_cerebral_palsy_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/int_cerebral_palsy_diagnoses_all.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All cerebral palsy diagnosis observations from clinical records.
+Uses cerebral palsy cluster ID:
+- CEREBRALP_COD: Cerebral palsy diagnoses
+
+Clinical Purpose:
+- Cerebral palsy register data collection
+- Neurological condition monitoring
+- Care pathway tracking
+- Support services planning
+
+Clinical Context:
+Cerebral palsy register includes persons with cerebral palsy diagnosis codes.
+Cerebral palsy is a lifelong neurological condition with no resolution codes.
+No age restrictions applied - condition is typically diagnosed in childhood but persists throughout life.
+
+Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
+This is OBSERVATION-LEVEL data - one row per cerebral palsy observation.
+Use this model as input for fct_person_cerebral_palsy_register.sql which applies business rules.
+*/
+
+SELECT
+    obs.id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS concept_display,
+    obs.cluster_id AS source_cluster_id,
+
+    -- Cerebral palsy-specific flags (observation-level only)
+    TRUE AS is_diagnosis_code,
+
+    -- Cerebral palsy observation type
+    'Cerebral Palsy Diagnosis' AS cerebral_palsy_observation_type
+
+FROM ({{ get_observations("'CEREBRALP_COD'") }}) obs
+WHERE obs.clinical_effective_date IS NOT NULL
+
+ORDER BY person_id, clinical_effective_date, id
+

--- a/models/modelling/olids/diagnoses/int_cerebral_palsy_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_cerebral_palsy_diagnoses_all.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: int_cerebral_palsy_diagnoses_all
+    description: 'Cerebral palsy diagnosis observations for neurological condition register management.
+
+      Key Features:
+
+      • Uses CEREBRALP_COD cluster for diagnosis identification
+
+      • Supports cerebral palsy register data collection
+
+      • Enables neurological condition monitoring and care pathway tracking
+
+      • No resolution codes as cerebral palsy is a lifelong condition
+
+      Purpose: Provide observation-level data for cerebral palsy tracking and support services planning.'
+    tests:
+      - cluster_ids_exist:
+          cluster_ids: CEREBRALP_COD
+    columns:
+      - name: id
+        description: 'Unique identifier for the clinical observation'
+      - name: person_id
+        description: 'Unique identifier for the person'
+      - name: clinical_effective_date
+        description: 'Date when the cerebral palsy observation was recorded'
+      - name: concept_code
+        description: 'Clinical code for the cerebral palsy diagnosis'
+      - name: concept_display
+        description: 'Human-readable description of the cerebral palsy diagnosis'
+      - name: source_cluster_id
+        description: 'Source cluster identifier (CEREBRALP_COD for cerebral palsy diagnoses)'
+      - name: is_diagnosis_code
+        description: 'Boolean flag indicating diagnosis code (always TRUE for cerebral palsy observations)'
+      - name: cerebral_palsy_observation_type
+        description: 'Type of cerebral palsy observation (always "Cerebral Palsy Diagnosis")'
+

--- a/models/modelling/olids/diagnoses/int_hypothyroidism_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/int_hypothyroidism_diagnoses_all.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All hypothyroidism diagnosis observations from clinical records.
+Uses hypothyroidism cluster ID:
+- THY_COD: Hypothyroidism diagnoses
+
+Clinical Purpose:
+- Hypothyroidism register data collection
+- Endocrine condition monitoring
+- Care pathway tracking
+- Medication management support
+
+Clinical Context:
+Hypothyroidism register includes persons with hypothyroidism diagnosis codes.
+Hypothyroidism is a chronic endocrine condition with no resolution codes.
+No age restrictions applied - condition can occur at any age though more common in older adults, particularly women.
+
+Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
+This is OBSERVATION-LEVEL data - one row per hypothyroidism observation.
+Use this model as input for fct_person_hypothyroidism_register.sql which applies business rules.
+*/
+
+SELECT
+    obs.id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS concept_display,
+    obs.cluster_id AS source_cluster_id,
+
+    -- Hypothyroidism-specific flags (observation-level only)
+    TRUE AS is_diagnosis_code,
+
+    -- Hypothyroidism observation type
+    'Hypothyroidism Diagnosis' AS hypothyroidism_observation_type
+
+FROM ({{ get_observations("'THY_COD'") }}) obs
+WHERE obs.clinical_effective_date IS NOT NULL
+
+ORDER BY person_id, clinical_effective_date, id
+

--- a/models/modelling/olids/diagnoses/int_hypothyroidism_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_hypothyroidism_diagnoses_all.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: int_hypothyroidism_diagnoses_all
+    description: 'Hypothyroidism diagnosis observations for endocrine condition register management.
+
+      Key Features:
+
+      • Uses THY_COD cluster for diagnosis identification
+
+      • Supports hypothyroidism register data collection
+
+      • Enables endocrine condition monitoring and care pathway tracking
+
+      • No resolution codes as hypothyroidism is a chronic condition
+
+      Purpose: Provide observation-level data for hypothyroidism tracking and medication management.'
+    tests:
+      - cluster_ids_exist:
+          cluster_ids: THY_COD
+    columns:
+      - name: id
+        description: 'Unique identifier for the clinical observation'
+      - name: person_id
+        description: 'Unique identifier for the person'
+      - name: clinical_effective_date
+        description: 'Date when the hypothyroidism observation was recorded'
+      - name: concept_code
+        description: 'Clinical code for the hypothyroidism diagnosis'
+      - name: concept_display
+        description: 'Human-readable description of the hypothyroidism diagnosis'
+      - name: source_cluster_id
+        description: 'Source cluster identifier (THY_COD for hypothyroidism diagnoses)'
+      - name: is_diagnosis_code
+        description: 'Boolean flag indicating diagnosis code (always TRUE for hypothyroidism observations)'
+      - name: hypothyroidism_observation_type
+        description: 'Type of hypothyroidism observation (always "Hypothyroidism Diagnosis")'
+

--- a/models/modelling/olids/diagnoses/int_mnd_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/int_mnd_diagnoses_all.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All motor neurone disease diagnosis observations from clinical records.
+Uses motor neurone disease cluster ID:
+- MND_COD: Motor neurone disease diagnoses
+
+Clinical Purpose:
+- Motor neurone disease register data collection
+- Neurological condition monitoring
+- Care pathway tracking
+- Palliative care planning support
+
+Clinical Context:
+Motor neurone disease register includes persons with MND diagnosis codes.
+MND is a progressive neurological condition with no resolution codes.
+No age restrictions applied - condition can occur at any age though more common in older adults.
+
+Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
+This is OBSERVATION-LEVEL data - one row per MND observation.
+Use this model as input for fct_person_mnd_register.sql which applies business rules.
+*/
+
+SELECT
+    obs.id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS concept_display,
+    obs.cluster_id AS source_cluster_id,
+
+    -- MND-specific flags (observation-level only)
+    TRUE AS is_diagnosis_code,
+
+    -- MND observation type
+    'Motor Neurone Disease Diagnosis' AS mnd_observation_type
+
+FROM ({{ get_observations("'MND_COD'") }}) obs
+WHERE obs.clinical_effective_date IS NOT NULL
+
+ORDER BY person_id, clinical_effective_date, id
+

--- a/models/modelling/olids/diagnoses/int_mnd_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_mnd_diagnoses_all.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: int_mnd_diagnoses_all
+    description: 'Motor neurone disease diagnosis observations for neurological condition register management.
+
+      Key Features:
+
+      • Uses MND_COD cluster for diagnosis identification
+
+      • Supports motor neurone disease register data collection
+
+      • Enables neurological condition monitoring and care pathway tracking
+
+      • No resolution codes as MND is a progressive condition
+
+      Purpose: Provide observation-level data for motor neurone disease tracking and palliative care planning.'
+    tests:
+      - cluster_ids_exist:
+          cluster_ids: MND_COD
+    columns:
+      - name: id
+        description: 'Unique identifier for the clinical observation'
+      - name: person_id
+        description: 'Unique identifier for the person'
+      - name: clinical_effective_date
+        description: 'Date when the motor neurone disease observation was recorded'
+      - name: concept_code
+        description: 'Clinical code for the motor neurone disease diagnosis'
+      - name: concept_display
+        description: 'Human-readable description of the motor neurone disease diagnosis'
+      - name: source_cluster_id
+        description: 'Source cluster identifier (MND_COD for motor neurone disease diagnoses)'
+      - name: is_diagnosis_code
+        description: 'Boolean flag indicating diagnosis code (always TRUE for MND observations)'
+      - name: mnd_observation_type
+        description: 'Type of MND observation (always "Motor Neurone Disease Diagnosis")'
+

--- a/models/modelling/olids/diagnoses/int_ms_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/int_ms_diagnoses_all.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All multiple sclerosis diagnosis observations from clinical records.
+Uses multiple sclerosis cluster ID:
+- MS_COD: Multiple sclerosis diagnoses
+
+Clinical Purpose:
+- Multiple sclerosis register data collection
+- Neurological condition monitoring
+- Care pathway tracking
+- Disease-modifying therapy monitoring
+
+Clinical Context:
+Multiple sclerosis register includes persons with MS diagnosis codes.
+MS is a chronic neurological condition with no resolution codes.
+No age restrictions applied - condition typically diagnosed in young to middle-aged adults.
+
+Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
+This is OBSERVATION-LEVEL data - one row per MS observation.
+Use this model as input for fct_person_ms_register.sql which applies business rules.
+*/
+
+SELECT
+    obs.id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS concept_display,
+    obs.cluster_id AS source_cluster_id,
+
+    -- MS-specific flags (observation-level only)
+    TRUE AS is_diagnosis_code,
+
+    -- MS observation type
+    'Multiple Sclerosis Diagnosis' AS ms_observation_type
+
+FROM ({{ get_observations("'MS_COD'") }}) obs
+WHERE obs.clinical_effective_date IS NOT NULL
+
+ORDER BY person_id, clinical_effective_date, id
+

--- a/models/modelling/olids/diagnoses/int_ms_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_ms_diagnoses_all.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: int_ms_diagnoses_all
+    description: 'Multiple sclerosis diagnosis observations for neurological condition register management.
+
+      Key Features:
+
+      • Uses MS_COD cluster for diagnosis identification
+
+      • Supports multiple sclerosis register data collection
+
+      • Enables neurological condition monitoring and care pathway tracking
+
+      • No resolution codes as MS is a chronic condition
+
+      Purpose: Provide observation-level data for multiple sclerosis tracking and disease-modifying therapy monitoring.'
+    tests:
+      - cluster_ids_exist:
+          cluster_ids: MS_COD
+    columns:
+      - name: id
+        description: 'Unique identifier for the clinical observation'
+      - name: person_id
+        description: 'Unique identifier for the person'
+      - name: clinical_effective_date
+        description: 'Date when the multiple sclerosis observation was recorded'
+      - name: concept_code
+        description: 'Clinical code for the multiple sclerosis diagnosis'
+      - name: concept_display
+        description: 'Human-readable description of the multiple sclerosis diagnosis'
+      - name: source_cluster_id
+        description: 'Source cluster identifier (MS_COD for multiple sclerosis diagnoses)'
+      - name: is_diagnosis_code
+        description: 'Boolean flag indicating diagnosis code (always TRUE for MS observations)'
+      - name: ms_observation_type
+        description: 'Type of MS observation (always "Multiple Sclerosis Diagnosis")'
+

--- a/models/modelling/olids/diagnoses/int_parkinsons_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/int_parkinsons_diagnoses_all.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All Parkinson's disease diagnosis observations from clinical records.
+Uses Parkinson's cluster ID:
+- PD_COD: Parkinson's disease diagnoses
+
+Clinical Purpose:
+- Parkinson's disease register data collection
+- Neurological condition monitoring
+- Care pathway tracking
+- Medication management support
+
+Clinical Context:
+Parkinson's disease register includes persons with Parkinson's diagnosis codes.
+Parkinson's is a progressive neurological condition with no resolution codes.
+No age restrictions applied - condition can occur at any age though more common in older adults.
+
+Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
+This is OBSERVATION-LEVEL data - one row per Parkinson's observation.
+Use this model as input for fct_person_parkinsons_register.sql which applies business rules.
+*/
+
+SELECT
+    obs.id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS concept_display,
+    obs.cluster_id AS source_cluster_id,
+
+    -- Parkinson's-specific flags (observation-level only)
+    TRUE AS is_diagnosis_code,
+
+    -- Parkinson's observation type
+    'Parkinsons Disease Diagnosis' AS parkinsons_observation_type
+
+FROM ({{ get_observations("'PD_COD'") }}) obs
+WHERE obs.clinical_effective_date IS NOT NULL
+
+ORDER BY person_id, clinical_effective_date, id
+

--- a/models/modelling/olids/diagnoses/int_parkinsons_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_parkinsons_diagnoses_all.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: int_parkinsons_diagnoses_all
+    description: 'Parkinsons disease diagnosis observations for neurological condition register management.
+
+      Key Features:
+
+      • Uses PD_COD cluster for diagnosis identification
+
+      • Supports Parkinsons disease register data collection
+
+      • Enables neurological condition monitoring and care pathway tracking
+
+      • No resolution codes as Parkinsons is a progressive condition
+
+      Purpose: Provide observation-level data for Parkinsons disease tracking and care management.'
+    tests:
+      - cluster_ids_exist:
+          cluster_ids: PD_COD
+    columns:
+      - name: id
+        description: 'Unique identifier for the clinical observation'
+      - name: person_id
+        description: 'Unique identifier for the person'
+      - name: clinical_effective_date
+        description: 'Date when the Parkinsons disease observation was recorded'
+      - name: concept_code
+        description: 'Clinical code for the Parkinsons disease diagnosis'
+      - name: concept_display
+        description: 'Human-readable description of the Parkinsons disease diagnosis'
+      - name: source_cluster_id
+        description: 'Source cluster identifier (PD_COD for Parkinsons disease diagnoses)'
+      - name: is_diagnosis_code
+        description: 'Boolean flag indicating diagnosis code (always TRUE for Parkinsons observations)'
+      - name: parkinsons_observation_type
+        description: 'Type of Parkinsons observation (always "Parkinsons Disease Diagnosis")'
+

--- a/models/reporting/olids/disease_registers/dim_person_conditions.sql
+++ b/models/reporting/olids/disease_registers/dim_person_conditions.sql
@@ -46,6 +46,13 @@ person_conditions AS (
         COALESCE(MAX(CASE WHEN ltc.condition_code = 'RA' THEN TRUE END), FALSE) AS has_rheumatoid_arthritis,
         COALESCE(MAX(CASE WHEN ltc.condition_code = 'SMI' THEN TRUE END), FALSE) AS has_severe_mental_illness,
         COALESCE(MAX(CASE WHEN ltc.condition_code = 'STIA' THEN TRUE END), FALSE) AS has_stroke_tia,
+        COALESCE(MAX(CASE WHEN ltc.condition_code = 'PD' THEN TRUE END), FALSE) AS has_parkinsons,
+        COALESCE(MAX(CASE WHEN ltc.condition_code = 'CEREBRALP' THEN TRUE END), FALSE) AS has_cerebral_palsy,
+        COALESCE(MAX(CASE WHEN ltc.condition_code = 'MND' THEN TRUE END), FALSE) AS has_mnd,
+        COALESCE(MAX(CASE WHEN ltc.condition_code = 'MS' THEN TRUE END), FALSE) AS has_multiple_sclerosis,
+        COALESCE(MAX(CASE WHEN ltc.condition_code = 'ANX' THEN TRUE END), FALSE) AS has_anxiety,
+        COALESCE(MAX(CASE WHEN ltc.condition_code = 'THY' THEN TRUE END), FALSE) AS has_hypothyroidism,
+        COALESCE(MAX(CASE WHEN ltc.condition_code = 'AUTISM' THEN TRUE END), FALSE) AS has_autism,
         
         -- Summary counts (0 for persons with no conditions)
         COALESCE(COUNT(DISTINCT ltc.condition_code), 0) AS total_conditions,

--- a/models/reporting/olids/disease_registers/fct_person_anxiety_register.sql
+++ b/models/reporting/olids/disease_registers/fct_person_anxiety_register.sql
@@ -1,0 +1,113 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+**Anxiety Register - Clinical Quality Measures**
+
+Simple Register with Resolution Tracking
+
+Business Logic:
+- Presence of anxiety diagnosis (ANX_COD) = on register
+- Unresolved: latest_anxiety_date > latest_resolved_date OR no resolved code
+- No QOF restrictions (no age limits, no date thresholds)
+
+Note:
+- Resolution codes available (ANXRES_COD) for tracking resolved episodes
+- No specific age restrictions applied
+- Latest diagnosis date used for care planning
+
+Clinical Context:
+Used for anxiety quality measures including:
+- Mental health care pathway monitoring
+- Anxiety severity tracking
+- Recovery planning and review scheduling
+- Psychological therapy access
+- Medication management and monitoring
+*/
+
+WITH anxiety_diagnoses AS (
+    SELECT
+        person_id,
+
+        -- Person-level aggregation from observation-level data
+        MIN(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS earliest_diagnosis_date,
+        MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS latest_diagnosis_date,
+        MAX(
+            CASE
+                WHEN is_resolved_code THEN clinical_effective_date
+            END
+        ) AS latest_resolved_date,
+
+        -- Register logic: active diagnosis required (unresolved)
+        COALESCE(MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) IS NOT NULL
+        AND (
+            MAX(
+                CASE
+                    WHEN is_resolved_code THEN clinical_effective_date
+                END
+            ) IS NULL
+            OR MAX(
+                CASE
+                    WHEN is_diagnosis_code THEN clinical_effective_date
+                END
+            )
+            > MAX(
+                CASE
+                    WHEN is_resolved_code THEN clinical_effective_date
+                END
+            )
+        ), FALSE) AS has_active_anxiety_diagnosis,
+
+        -- Traceability arrays
+        ARRAY_AGG(
+            DISTINCT CASE
+                WHEN is_diagnosis_code THEN concept_code
+            END
+        ) AS all_anxiety_concept_codes,
+        ARRAY_AGG(
+            DISTINCT CASE
+                WHEN is_diagnosis_code THEN concept_display
+            END
+        ) AS all_anxiety_concept_displays,
+        ARRAY_AGG(
+            DISTINCT CASE WHEN is_resolved_code THEN concept_code END
+        ) AS all_resolved_concept_codes
+
+    FROM {{ ref('int_anxiety_diagnoses_all') }}
+    GROUP BY person_id
+)
+
+-- Final selection with person demographics
+SELECT
+    ad.person_id,
+    age.age,
+    TRUE AS is_on_register,
+    ad.earliest_diagnosis_date,
+    ad.latest_diagnosis_date,
+    ad.latest_resolved_date,
+    ad.all_anxiety_concept_codes,
+    ad.all_anxiety_concept_displays,
+    ad.all_resolved_concept_codes AS all_anxiety_resolved_concept_codes
+
+FROM anxiety_diagnoses AS ad
+INNER JOIN {{ ref('dim_person') }} AS p
+    ON ad.person_id = p.person_id
+INNER JOIN {{ ref('dim_person_age') }} AS age
+    ON ad.person_id = age.person_id
+WHERE ad.has_active_anxiety_diagnosis = TRUE  -- Only include persons with active anxiety diagnosis
+

--- a/models/reporting/olids/disease_registers/fct_person_anxiety_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_anxiety_register.yml
@@ -1,0 +1,35 @@
+version: 2
+models:
+  - name: fct_person_anxiety_register
+    description: 'Anxiety register for patients with active anxiety diagnosis.
+
+      One row per person with latest ANX_COD > latest ANXRES_COD (non-QOF).'
+    
+    config:
+      meta:
+        indicator:
+          id: "ANXIETY"
+          type: "CONDITION"
+          category: "LTC"
+          clinical_domain: "Mental Health"
+          name_short: "Anxiety"
+          description_short: "Anxiety register (non-QOF)"
+          description_long: >
+            Anxiety register for persons with active anxiety diagnosis where latest 
+            anxiety code is more recent than any resolution code. Includes active 
+            patients with anxiety diagnosis using ANX_COD for diagnosis codes and 
+            ANXRES_COD for resolution codes. No age restrictions or QOF date thresholds 
+            applied. Used for mental health care pathway monitoring, anxiety severity 
+            tracking, recovery planning, psychological therapy access, and medication 
+            management.
+          is_qof: false
+          source_column: "is_on_register"
+          sort_order: "COND_MH_ANXIETY"
+          usage_contexts:
+            - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+          code_clusters:
+            - cluster_id: "ANX_COD"
+              category: "INCLUSION"
+            - cluster_id: "ANXRES_COD"
+              category: "RESOLUTION"
+

--- a/models/reporting/olids/disease_registers/fct_person_autism_register.sql
+++ b/models/reporting/olids/disease_registers/fct_person_autism_register.sql
@@ -1,0 +1,89 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+**Autism Spectrum Disorder Register - Clinical Quality Measures**
+
+Simple Register
+
+Business Logic:
+- Presence of autism spectrum disorder diagnosis (AUTISM_COD) = on register
+- No resolution codes (lifelong condition)
+
+Note:
+- There are no resolved codes for autism (lifelong neurodevelopmental condition)
+- No specific age restrictions, though typically diagnosed in childhood
+- Latest diagnosis date used for care planning
+
+Clinical Context:
+Used for autism quality measures including:
+- Neurodevelopmental care pathway monitoring
+- Complex needs identification
+- Care coordination and support services
+- Mental health co-morbidity monitoring
+- Healthcare access support
+*/
+
+WITH autism_diagnoses AS (
+    SELECT
+        aut.person_id,
+
+        -- Person-level aggregation from observation-level data
+        MIN(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS earliest_diagnosis_date,
+        MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS latest_diagnosis_date,
+
+        -- Register logic: active diagnosis required
+        COALESCE(MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) IS NOT NULL,
+        FALSE) AS has_active_autism_diagnosis,
+
+        -- Count of autism diagnoses
+        COUNT(CASE WHEN is_diagnosis_code THEN 1 END)
+            AS total_autism_diagnoses,
+
+        -- Traceability arrays
+        ARRAY_AGG(
+            DISTINCT CASE WHEN is_diagnosis_code THEN concept_code END
+        ) AS all_autism_concept_codes,
+        ARRAY_AGG(
+            DISTINCT CASE
+                WHEN is_diagnosis_code THEN concept_display
+            END
+        ) AS all_autism_concept_displays
+
+    FROM {{ ref('int_autism_diagnoses_all') }} aut
+    GROUP BY aut.person_id
+)
+
+-- Final selection with person demographics
+SELECT
+    fd.person_id,
+    age.age,
+    TRUE AS is_on_register,
+    fd.earliest_diagnosis_date,
+    fd.latest_diagnosis_date,
+    fd.total_autism_diagnoses,
+    fd.all_autism_concept_codes,
+    fd.all_autism_concept_displays
+
+FROM autism_diagnoses AS fd
+INNER JOIN {{ ref('dim_person') }} AS p
+    ON fd.person_id = p.person_id
+INNER JOIN {{ ref('dim_person_age') }} AS age
+    ON fd.person_id = age.person_id
+WHERE fd.has_active_autism_diagnosis = TRUE  -- Only include persons with active autism diagnosis
+

--- a/models/reporting/olids/disease_registers/fct_person_autism_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_autism_register.yml
@@ -1,0 +1,33 @@
+version: 2
+models:
+  - name: fct_person_autism_register
+    description: 'Autism spectrum disorder register for patients with autism diagnosis.
+
+      One row per person with AUTISM_COD present (non-QOF).'
+    
+    config:
+      meta:
+        indicator:
+          id: "AUTISM"
+          type: "CONDITION"
+          category: "LTC"
+          clinical_domain: "Neurodevelopmental"
+          name_short: "Autism Spectrum Disorder"
+          description_short: "Autism register (non-QOF)"
+          description_long: >
+            Autism spectrum disorder register for persons with autism diagnosis. 
+            Includes active patients with autism diagnosis using AUTISM_COD cluster codes. 
+            No age restrictions or resolution codes applied. Used for neurodevelopmental care 
+            pathway monitoring, complex needs identification, care coordination, mental health 
+            co-morbidity monitoring, and healthcare access support. Lifelong neurodevelopmental 
+            condition requiring ongoing support and care coordination. Distinct from learning 
+            disability though can co-occur.
+          is_qof: false
+          source_column: "is_on_register"
+          sort_order: "COND_NEURODEV_AUTISM"
+          usage_contexts:
+            - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+          code_clusters:
+            - cluster_id: "AUTISM_COD"
+              category: "INCLUSION"
+

--- a/models/reporting/olids/disease_registers/fct_person_cerebral_palsy_register.sql
+++ b/models/reporting/olids/disease_registers/fct_person_cerebral_palsy_register.sql
@@ -1,0 +1,89 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+**Cerebral Palsy Register - Clinical Quality Measures**
+
+Simple Register
+
+Business Logic:
+- Presence of cerebral palsy diagnosis (CEREBRALP_COD) = on register
+- No resolution codes (lifelong condition)
+
+Note:
+- There are no resolved codes for cerebral palsy (lifelong neurological condition)
+- No specific age restrictions, though typically diagnosed in childhood
+- Latest diagnosis date used for care planning
+
+Clinical Context:
+Used for cerebral palsy quality measures including:
+- Neurological care pathway monitoring
+- Multidisciplinary team coordination
+- Support services planning
+- Mobility and function support
+- Care planning throughout life
+*/
+
+WITH cerebral_palsy_diagnoses AS (
+    SELECT
+        cp.person_id,
+
+        -- Person-level aggregation from observation-level data
+        MIN(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS earliest_diagnosis_date,
+        MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS latest_diagnosis_date,
+
+        -- Register logic: active diagnosis required
+        COALESCE(MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) IS NOT NULL,
+        FALSE) AS has_active_cerebral_palsy_diagnosis,
+
+        -- Count of cerebral palsy diagnoses
+        COUNT(CASE WHEN is_diagnosis_code THEN 1 END)
+            AS total_cerebral_palsy_diagnoses,
+
+        -- Traceability arrays
+        ARRAY_AGG(
+            DISTINCT CASE WHEN is_diagnosis_code THEN concept_code END
+        ) AS all_cerebral_palsy_concept_codes,
+        ARRAY_AGG(
+            DISTINCT CASE
+                WHEN is_diagnosis_code THEN concept_display
+            END
+        ) AS all_cerebral_palsy_concept_displays
+
+    FROM {{ ref('int_cerebral_palsy_diagnoses_all') }} cp
+    GROUP BY cp.person_id
+)
+
+-- Final selection with person demographics
+SELECT
+    fd.person_id,
+    age.age,
+    TRUE AS is_on_register,
+    fd.earliest_diagnosis_date,
+    fd.latest_diagnosis_date,
+    fd.total_cerebral_palsy_diagnoses,
+    fd.all_cerebral_palsy_concept_codes,
+    fd.all_cerebral_palsy_concept_displays
+
+FROM cerebral_palsy_diagnoses AS fd
+INNER JOIN {{ ref('dim_person') }} AS p
+    ON fd.person_id = p.person_id
+INNER JOIN {{ ref('dim_person_age') }} AS age
+    ON fd.person_id = age.person_id
+WHERE fd.has_active_cerebral_palsy_diagnosis = TRUE  -- Only include persons with active cerebral palsy diagnosis
+

--- a/models/reporting/olids/disease_registers/fct_person_cerebral_palsy_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_cerebral_palsy_register.yml
@@ -1,0 +1,32 @@
+version: 2
+models:
+  - name: fct_person_cerebral_palsy_register
+    description: 'Cerebral palsy register for patients with cerebral palsy diagnosis.
+
+      One row per person with CEREBRALP_COD present (non-QOF).'
+    
+    config:
+      meta:
+        indicator:
+          id: "CEREBRAL_PALSY"
+          type: "CONDITION"
+          category: "LTC"
+          clinical_domain: "Neurology"
+          name_short: "Cerebral Palsy"
+          description_short: "Cerebral palsy register (non-QOF)"
+          description_long: >
+            Cerebral palsy register for persons with cerebral palsy diagnosis. 
+            Includes active patients with cerebral palsy diagnosis using CEREBRALP_COD 
+            cluster codes. No age restrictions or resolution codes applied. Used for 
+            neurological care pathway monitoring, multidisciplinary team coordination, 
+            support services planning, and mobility and function support. Lifelong 
+            neurological condition requiring ongoing care and support throughout life.
+          is_qof: false
+          source_column: "is_on_register"
+          sort_order: "COND_NEURO_CEREBRALPALSY"
+          usage_contexts:
+            - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+          code_clusters:
+            - cluster_id: "CEREBRALP_COD"
+              category: "INCLUSION"
+

--- a/models/reporting/olids/disease_registers/fct_person_condition_episodes.sql
+++ b/models/reporting/olids/disease_registers/fct_person_condition_episodes.sql
@@ -400,6 +400,114 @@ WITH all_condition_events AS (
     FROM {{ ref('int_stroke_tia_diagnoses_all') }}
     WHERE is_diagnosis_code
     
+    UNION ALL
+    
+    -- Parkinson's Disease events (diagnosis only)
+    SELECT 
+        person_id,
+        clinical_effective_date as event_date,
+        'Parkinsons Disease' as condition_name,
+        'PD' as condition_code,
+        'Neurology' as clinical_domain,
+        'diagnosis' as event_type,
+        concept_code,
+        concept_display
+    FROM {{ ref('int_parkinsons_diagnoses_all') }}
+    WHERE is_diagnosis_code
+    
+    UNION ALL
+    
+    -- Cerebral Palsy events (diagnosis only)
+    SELECT 
+        person_id,
+        clinical_effective_date as event_date,
+        'Cerebral Palsy' as condition_name,
+        'CEREBRALP' as condition_code,
+        'Neurology' as clinical_domain,
+        'diagnosis' as event_type,
+        concept_code,
+        concept_display
+    FROM {{ ref('int_cerebral_palsy_diagnoses_all') }}
+    WHERE is_diagnosis_code
+    
+    UNION ALL
+    
+    -- Motor Neurone Disease events (diagnosis only)
+    SELECT 
+        person_id,
+        clinical_effective_date as event_date,
+        'Motor Neurone Disease' as condition_name,
+        'MND' as condition_code,
+        'Neurology' as clinical_domain,
+        'diagnosis' as event_type,
+        concept_code,
+        concept_display
+    FROM {{ ref('int_mnd_diagnoses_all') }}
+    WHERE is_diagnosis_code
+    
+    UNION ALL
+    
+    -- Multiple Sclerosis events (diagnosis only)
+    SELECT 
+        person_id,
+        clinical_effective_date as event_date,
+        'Multiple Sclerosis' as condition_name,
+        'MS' as condition_code,
+        'Neurology' as clinical_domain,
+        'diagnosis' as event_type,
+        concept_code,
+        concept_display
+    FROM {{ ref('int_ms_diagnoses_all') }}
+    WHERE is_diagnosis_code
+    
+    UNION ALL
+    
+    -- Anxiety events
+    SELECT 
+        person_id,
+        clinical_effective_date as event_date,
+        'Anxiety' as condition_name,
+        'ANX' as condition_code,
+        'Mental Health' as clinical_domain,
+        CASE 
+            WHEN is_diagnosis_code THEN 'onset'
+            WHEN is_resolved_code THEN 'resolved'
+        END as event_type,
+        concept_code,
+        concept_display
+    FROM {{ ref('int_anxiety_diagnoses_all') }}
+    WHERE is_diagnosis_code OR is_resolved_code
+    
+    UNION ALL
+    
+    -- Hypothyroidism events (diagnosis only)
+    SELECT 
+        person_id,
+        clinical_effective_date as event_date,
+        'Hypothyroidism' as condition_name,
+        'THY' as condition_code,
+        'Endocrine' as clinical_domain,
+        'diagnosis' as event_type,
+        concept_code,
+        concept_display
+    FROM {{ ref('int_hypothyroidism_diagnoses_all') }}
+    WHERE is_diagnosis_code
+    
+    UNION ALL
+    
+    -- Autism Spectrum Disorder events (diagnosis only)
+    SELECT 
+        person_id,
+        clinical_effective_date as event_date,
+        'Autism Spectrum Disorder' as condition_name,
+        'AUTISM' as condition_code,
+        'Neurodevelopmental' as clinical_domain,
+        'diagnosis' as event_type,
+        concept_code,
+        concept_display
+    FROM {{ ref('int_autism_diagnoses_all') }}
+    WHERE is_diagnosis_code
+    
     -- Note: Obesity register is BMI-based, not diagnosis code based
     -- CYP Asthma uses same diagnosis codes as regular asthma - age filtering happens in QOF layer
     -- Learning Disability All Ages uses same diagnosis codes as regular LD - age filtering happens in QOF layer

--- a/models/reporting/olids/disease_registers/fct_person_condition_episodes.yml
+++ b/models/reporting/olids/disease_registers/fct_person_condition_episodes.yml
@@ -326,6 +326,148 @@ models:
             code_clusters:
               - cluster_id: "STIA_COD"
                 category: "INCLUSION"
+                
+          - id: "CONDITION_EPISODES_PD"
+            type: "CONDITION"
+            category: "SIMPLIFIED_CONDITION_MODEL"
+            clinical_domain: "Neurology"
+            name_short: "Parkinsons Disease Episodes"
+            description_short: "Simplified Parkinsons condition episodes with diagnosis tracking only"
+            description_long: >
+              Episode tracking for Parkinsons disease using diagnosis codes only.
+              Progressive condition with no resolved state tracking - captures diagnosis events for
+              complete clinical history analysis without episode duration calculations.
+            is_qof: false
+            source_column: "current_condition_status"
+            sort_order: "CONDITION_EPISODES_PD"
+            usage_contexts:
+              - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+              - "HISTORICAL_CONDITION_TRACKING"
+            code_clusters:
+              - cluster_id: "PD_COD"
+                category: "INCLUSION"
+                
+          - id: "CONDITION_EPISODES_CEREBRALP"
+            type: "CONDITION"
+            category: "SIMPLIFIED_CONDITION_MODEL"
+            clinical_domain: "Neurology"
+            name_short: "Cerebral Palsy Episodes"
+            description_short: "Simplified cerebral palsy condition episodes with diagnosis tracking only"
+            description_long: >
+              Episode tracking for cerebral palsy using diagnosis codes only.
+              Lifelong condition with no resolved state tracking - captures diagnosis events for
+              complete clinical history analysis without episode duration calculations.
+            is_qof: false
+            source_column: "current_condition_status"
+            sort_order: "CONDITION_EPISODES_CEREBRALP"
+            usage_contexts:
+              - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+              - "HISTORICAL_CONDITION_TRACKING"
+            code_clusters:
+              - cluster_id: "CEREBRALP_COD"
+                category: "INCLUSION"
+                
+          - id: "CONDITION_EPISODES_MND"
+            type: "CONDITION"
+            category: "SIMPLIFIED_CONDITION_MODEL"
+            clinical_domain: "Neurology"
+            name_short: "Motor Neurone Disease Episodes"
+            description_short: "Simplified MND condition episodes with diagnosis tracking only"
+            description_long: >
+              Episode tracking for motor neurone disease using diagnosis codes only.
+              Progressive condition with no resolved state tracking - captures diagnosis events for
+              complete clinical history analysis without episode duration calculations.
+            is_qof: false
+            source_column: "current_condition_status"
+            sort_order: "CONDITION_EPISODES_MND"
+            usage_contexts:
+              - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+              - "HISTORICAL_CONDITION_TRACKING"
+            code_clusters:
+              - cluster_id: "MND_COD"
+                category: "INCLUSION"
+                
+          - id: "CONDITION_EPISODES_MS"
+            type: "CONDITION"
+            category: "SIMPLIFIED_CONDITION_MODEL"
+            clinical_domain: "Neurology"
+            name_short: "Multiple Sclerosis Episodes"
+            description_short: "Simplified MS condition episodes with diagnosis tracking only"
+            description_long: >
+              Episode tracking for multiple sclerosis using diagnosis codes only.
+              Chronic condition with no resolved state tracking - captures diagnosis events for
+              complete clinical history analysis without episode duration calculations.
+            is_qof: false
+            source_column: "current_condition_status"
+            sort_order: "CONDITION_EPISODES_MS"
+            usage_contexts:
+              - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+              - "HISTORICAL_CONDITION_TRACKING"
+            code_clusters:
+              - cluster_id: "MS_COD"
+                category: "INCLUSION"
+                
+          - id: "CONDITION_EPISODES_ANX"
+            type: "CONDITION"
+            category: "SIMPLIFIED_CONDITION_MODEL"
+            clinical_domain: "Mental Health"
+            name_short: "Anxiety Episodes"
+            description_short: "Simplified anxiety condition episodes with resolved state tracking"
+            description_long: >
+              Episode tracking for anxiety using diagnosis and resolved codes without QOF restrictions.
+              Captures multiple condition cycles per person for complete clinical history analysis.
+              Includes onset and resolved states enabling episode duration calculations.
+            is_qof: false
+            source_column: "current_condition_status"
+            sort_order: "CONDITION_EPISODES_ANX"
+            usage_contexts:
+              - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+              - "HISTORICAL_CONDITION_TRACKING"
+            code_clusters:
+              - cluster_id: "ANX_COD"
+                category: "INCLUSION"
+              - cluster_id: "ANXRES_COD"
+                category: "RESOLUTION"
+                
+          - id: "CONDITION_EPISODES_THY"
+            type: "CONDITION"
+            category: "SIMPLIFIED_CONDITION_MODEL"
+            clinical_domain: "Endocrine"
+            name_short: "Hypothyroidism Episodes"
+            description_short: "Simplified hypothyroidism condition episodes with diagnosis tracking only"
+            description_long: >
+              Episode tracking for hypothyroidism using diagnosis codes only.
+              Chronic condition with no resolved state tracking - captures diagnosis events for
+              complete clinical history analysis without episode duration calculations.
+            is_qof: false
+            source_column: "current_condition_status"
+            sort_order: "CONDITION_EPISODES_THY"
+            usage_contexts:
+              - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+              - "HISTORICAL_CONDITION_TRACKING"
+            code_clusters:
+              - cluster_id: "THY_COD"
+                category: "INCLUSION"
+                
+          - id: "CONDITION_EPISODES_AUTISM"
+            type: "CONDITION"
+            category: "SIMPLIFIED_CONDITION_MODEL"
+            clinical_domain: "Neurodevelopmental"
+            name_short: "Autism Episodes"
+            description_short: "Simplified autism condition episodes with diagnosis tracking only"
+            description_long: >
+              Episode tracking for autism spectrum disorder using diagnosis codes only.
+              Lifelong condition with no resolved state tracking - captures diagnosis events for
+              complete clinical history analysis without episode duration calculations.
+            is_qof: false
+            source_column: "current_condition_status"
+            sort_order: "CONDITION_EPISODES_AUTISM"
+            usage_contexts:
+              - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+              - "HISTORICAL_CONDITION_TRACKING"
+            code_clusters:
+              - cluster_id: "AUTISM_COD"
+                category: "INCLUSION"
           
           # Neurodevelopmental Conditions
           - id: "CONDITION_EPISODES_LD"
@@ -548,32 +690,6 @@ models:
         description: 'Human-readable condition name (e.g., "Depression", "Gestational Diabetes")'
         tests:
           - not_null
-          - accepted_values:
-              values:
-                - 'Asthma'
-                - 'Atrial Fibrillation'
-                - 'Cancer'
-                - 'Coronary Heart Disease'
-                - 'Chronic Kidney Disease'
-                - 'COPD'
-                - 'Dementia'
-                - 'Depression'
-                - 'Diabetes'
-                - 'Epilepsy'
-                - 'Familial Hypercholesterolaemia'
-                - 'Frailty'
-                - 'Gestational Diabetes'
-                - 'Heart Failure'
-                - 'Hypertension'
-                - 'Learning Disability'
-                - 'NAFLD'
-                - 'Non-Diabetic Hyperglycaemia'
-                - 'Osteoporosis'
-                - 'Peripheral Arterial Disease'
-                - 'Palliative Care'
-                - 'Rheumatoid Arthritis'
-                - 'Severe Mental Illness'
-                - 'Stroke and TIA'
 
       - name: condition_code
         description: 'Short condition code used in QOF registers'
@@ -605,6 +721,13 @@ models:
                 - 'RA'
                 - 'SMI'
                 - 'STIA'
+                - 'PD'
+                - 'CEREBRALP'
+                - 'MND'
+                - 'MS'
+                - 'ANX'
+                - 'THY'
+                - 'AUTISM'
 
       - name: clinical_domain
         description: 'Clinical specialty domain for the condition'

--- a/models/reporting/olids/disease_registers/fct_person_hypothyroidism_register.sql
+++ b/models/reporting/olids/disease_registers/fct_person_hypothyroidism_register.sql
@@ -1,0 +1,88 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+**Hypothyroidism Register - Clinical Quality Measures**
+
+Simple Register
+
+Business Logic:
+- Presence of hypothyroidism diagnosis (THY_COD) = on register
+- No resolution codes (chronic condition)
+
+Note:
+- There are no resolved codes for hypothyroidism (chronic endocrine condition)
+- No specific age restrictions, though more common in older adults, particularly women
+- Latest diagnosis date used for care planning
+
+Clinical Context:
+Used for hypothyroidism quality measures including:
+- Endocrine care pathway monitoring
+- Medication management (levothyroxine monitoring)
+- Thyroid function test monitoring
+- Care planning and support services
+*/
+
+WITH hypothyroidism_diagnoses AS (
+    SELECT
+        thy.person_id,
+
+        -- Person-level aggregation from observation-level data
+        MIN(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS earliest_diagnosis_date,
+        MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS latest_diagnosis_date,
+
+        -- Register logic: active diagnosis required
+        COALESCE(MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) IS NOT NULL,
+        FALSE) AS has_active_hypothyroidism_diagnosis,
+
+        -- Count of hypothyroidism diagnoses
+        COUNT(CASE WHEN is_diagnosis_code THEN 1 END)
+            AS total_hypothyroidism_diagnoses,
+
+        -- Traceability arrays
+        ARRAY_AGG(
+            DISTINCT CASE WHEN is_diagnosis_code THEN concept_code END
+        ) AS all_hypothyroidism_concept_codes,
+        ARRAY_AGG(
+            DISTINCT CASE
+                WHEN is_diagnosis_code THEN concept_display
+            END
+        ) AS all_hypothyroidism_concept_displays
+
+    FROM {{ ref('int_hypothyroidism_diagnoses_all') }} thy
+    GROUP BY thy.person_id
+)
+
+-- Final selection with person demographics
+SELECT
+    fd.person_id,
+    age.age,
+    TRUE AS is_on_register,
+    fd.earliest_diagnosis_date,
+    fd.latest_diagnosis_date,
+    fd.total_hypothyroidism_diagnoses,
+    fd.all_hypothyroidism_concept_codes,
+    fd.all_hypothyroidism_concept_displays
+
+FROM hypothyroidism_diagnoses AS fd
+INNER JOIN {{ ref('dim_person') }} AS p
+    ON fd.person_id = p.person_id
+INNER JOIN {{ ref('dim_person_age') }} AS age
+    ON fd.person_id = age.person_id
+WHERE fd.has_active_hypothyroidism_diagnosis = TRUE  -- Only include persons with active hypothyroidism diagnosis
+

--- a/models/reporting/olids/disease_registers/fct_person_hypothyroidism_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_hypothyroidism_register.yml
@@ -1,0 +1,31 @@
+version: 2
+models:
+  - name: fct_person_hypothyroidism_register
+    description: 'Hypothyroidism register for patients with hypothyroidism diagnosis.
+
+      One row per person with THY_COD present (non-QOF).'
+    
+    config:
+      meta:
+        indicator:
+          id: "HYPOTHYROIDISM"
+          type: "CONDITION"
+          category: "LTC"
+          clinical_domain: "Endocrine"
+          name_short: "Hypothyroidism"
+          description_short: "Hypothyroidism register (non-QOF)"
+          description_long: >
+            Hypothyroidism register for persons with hypothyroidism diagnosis. 
+            Includes active patients with hypothyroidism diagnosis using THY_COD cluster codes. 
+            No age restrictions or resolution codes applied. Used for endocrine care pathway 
+            monitoring, medication management (levothyroxine), thyroid function test monitoring, 
+            and care planning. Chronic endocrine condition requiring ongoing medication and monitoring.
+          is_qof: false
+          source_column: "is_on_register"
+          sort_order: "COND_ENDOCRINE_HYPOTHYROIDISM"
+          usage_contexts:
+            - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+          code_clusters:
+            - cluster_id: "THY_COD"
+              category: "INCLUSION"
+

--- a/models/reporting/olids/disease_registers/fct_person_ltc_summary.sql
+++ b/models/reporting/olids/disease_registers/fct_person_ltc_summary.sql
@@ -411,6 +411,111 @@ WITH condition_union AS (
         FALSE AS is_qof
     FROM {{ ref('fct_person_frailty_register') }}
     WHERE is_on_register = TRUE
+
+    UNION ALL
+
+    -- Parkinson's Disease
+    SELECT
+        person_id,
+        'PD' AS condition_code,
+        'Parkinsons Disease' AS condition_name,
+        'Neurology' AS clinical_domain,
+        is_on_register,
+        earliest_diagnosis_date,
+        latest_diagnosis_date,
+        FALSE AS is_qof
+    FROM {{ ref('fct_person_parkinsons_register') }}
+    WHERE is_on_register = TRUE
+
+    UNION ALL
+
+    -- Cerebral Palsy
+    SELECT
+        person_id,
+        'CEREBRALP' AS condition_code,
+        'Cerebral Palsy' AS condition_name,
+        'Neurology' AS clinical_domain,
+        is_on_register,
+        earliest_diagnosis_date,
+        latest_diagnosis_date,
+        FALSE AS is_qof
+    FROM {{ ref('fct_person_cerebral_palsy_register') }}
+    WHERE is_on_register = TRUE
+
+    UNION ALL
+
+    -- Motor Neurone Disease
+    SELECT
+        person_id,
+        'MND' AS condition_code,
+        'Motor Neurone Disease' AS condition_name,
+        'Neurology' AS clinical_domain,
+        is_on_register,
+        earliest_diagnosis_date,
+        latest_diagnosis_date,
+        FALSE AS is_qof
+    FROM {{ ref('fct_person_mnd_register') }}
+    WHERE is_on_register = TRUE
+
+    UNION ALL
+
+    -- Multiple Sclerosis
+    SELECT
+        person_id,
+        'MS' AS condition_code,
+        'Multiple Sclerosis' AS condition_name,
+        'Neurology' AS clinical_domain,
+        is_on_register,
+        earliest_diagnosis_date,
+        latest_diagnosis_date,
+        FALSE AS is_qof
+    FROM {{ ref('fct_person_ms_register') }}
+    WHERE is_on_register = TRUE
+
+    UNION ALL
+
+    -- Anxiety
+    SELECT
+        person_id,
+        'ANX' AS condition_code,
+        'Anxiety' AS condition_name,
+        'Mental Health' AS clinical_domain,
+        is_on_register,
+        earliest_diagnosis_date,
+        latest_diagnosis_date,
+        FALSE AS is_qof
+    FROM {{ ref('fct_person_anxiety_register') }}
+    WHERE is_on_register = TRUE
+
+    UNION ALL
+
+    -- Hypothyroidism
+    SELECT
+        person_id,
+        'THY' AS condition_code,
+        'Hypothyroidism' AS condition_name,
+        'Endocrine' AS clinical_domain,
+        is_on_register,
+        earliest_diagnosis_date,
+        latest_diagnosis_date,
+        FALSE AS is_qof
+    FROM {{ ref('fct_person_hypothyroidism_register') }}
+    WHERE is_on_register = TRUE
+
+    UNION ALL
+
+    -- Autism Spectrum Disorder
+    SELECT
+        person_id,
+        'AUTISM' AS condition_code,
+        'Autism Spectrum Disorder' AS condition_name,
+        'Neurodevelopmental' AS clinical_domain,
+        is_on_register,
+        earliest_diagnosis_date,
+        latest_diagnosis_date,
+        FALSE AS is_qof
+    FROM {{ ref('fct_person_autism_register') }}
+    WHERE is_on_register = TRUE
 )
 
 SELECT

--- a/models/reporting/olids/disease_registers/fct_person_mnd_register.sql
+++ b/models/reporting/olids/disease_registers/fct_person_mnd_register.sql
@@ -1,0 +1,89 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+**Motor Neurone Disease Register - Clinical Quality Measures**
+
+Simple Register
+
+Business Logic:
+- Presence of motor neurone disease diagnosis (MND_COD) = on register
+- No resolution codes (progressive condition)
+
+Note:
+- There are no resolved codes for MND (progressive neurological condition)
+- No specific age restrictions, though more common in older adults
+- Latest diagnosis date used for care planning
+
+Clinical Context:
+Used for motor neurone disease quality measures including:
+- Neurological care pathway monitoring
+- Palliative care planning and coordination
+- Multidisciplinary team coordination
+- Symptom management and monitoring
+- Care planning and support services
+*/
+
+WITH mnd_diagnoses AS (
+    SELECT
+        mnd.person_id,
+
+        -- Person-level aggregation from observation-level data
+        MIN(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS earliest_diagnosis_date,
+        MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS latest_diagnosis_date,
+
+        -- Register logic: active diagnosis required
+        COALESCE(MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) IS NOT NULL,
+        FALSE) AS has_active_mnd_diagnosis,
+
+        -- Count of MND diagnoses
+        COUNT(CASE WHEN is_diagnosis_code THEN 1 END)
+            AS total_mnd_diagnoses,
+
+        -- Traceability arrays
+        ARRAY_AGG(
+            DISTINCT CASE WHEN is_diagnosis_code THEN concept_code END
+        ) AS all_mnd_concept_codes,
+        ARRAY_AGG(
+            DISTINCT CASE
+                WHEN is_diagnosis_code THEN concept_display
+            END
+        ) AS all_mnd_concept_displays
+
+    FROM {{ ref('int_mnd_diagnoses_all') }} mnd
+    GROUP BY mnd.person_id
+)
+
+-- Final selection with person demographics
+SELECT
+    fd.person_id,
+    age.age,
+    TRUE AS is_on_register,
+    fd.earliest_diagnosis_date,
+    fd.latest_diagnosis_date,
+    fd.total_mnd_diagnoses,
+    fd.all_mnd_concept_codes,
+    fd.all_mnd_concept_displays
+
+FROM mnd_diagnoses AS fd
+INNER JOIN {{ ref('dim_person') }} AS p
+    ON fd.person_id = p.person_id
+INNER JOIN {{ ref('dim_person_age') }} AS age
+    ON fd.person_id = age.person_id
+WHERE fd.has_active_mnd_diagnosis = TRUE  -- Only include persons with active MND diagnosis
+

--- a/models/reporting/olids/disease_registers/fct_person_mnd_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_mnd_register.yml
@@ -1,0 +1,32 @@
+version: 2
+models:
+  - name: fct_person_mnd_register
+    description: 'Motor neurone disease register for patients with MND diagnosis.
+
+      One row per person with MND_COD present (non-QOF).'
+    
+    config:
+      meta:
+        indicator:
+          id: "MND"
+          type: "CONDITION"
+          category: "LTC"
+          clinical_domain: "Neurology"
+          name_short: "Motor Neurone Disease"
+          description_short: "Motor neurone disease register (non-QOF)"
+          description_long: >
+            Motor neurone disease register for persons with MND diagnosis. 
+            Includes active patients with MND diagnosis using MND_COD cluster codes. 
+            No age restrictions or resolution codes applied. Used for neurological care 
+            pathway monitoring, palliative care planning, multidisciplinary team coordination, 
+            and symptom management. Progressive neurological condition requiring specialised 
+            care and support.
+          is_qof: false
+          source_column: "is_on_register"
+          sort_order: "COND_NEURO_MND"
+          usage_contexts:
+            - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+          code_clusters:
+            - cluster_id: "MND_COD"
+              category: "INCLUSION"
+

--- a/models/reporting/olids/disease_registers/fct_person_ms_register.sql
+++ b/models/reporting/olids/disease_registers/fct_person_ms_register.sql
@@ -1,0 +1,89 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+**Multiple Sclerosis Register - Clinical Quality Measures**
+
+Simple Register
+
+Business Logic:
+- Presence of multiple sclerosis diagnosis (MS_COD) = on register
+- No resolution codes (chronic condition)
+
+Note:
+- There are no resolved codes for MS (chronic neurological condition)
+- No specific age restrictions, though typically diagnosed in young to middle-aged adults
+- Latest diagnosis date used for care planning
+
+Clinical Context:
+Used for multiple sclerosis quality measures including:
+- Neurological care pathway monitoring
+- Disease-modifying therapy monitoring
+- Multidisciplinary team coordination
+- Symptom management and monitoring
+- Care planning and support services
+*/
+
+WITH ms_diagnoses AS (
+    SELECT
+        ms.person_id,
+
+        -- Person-level aggregation from observation-level data
+        MIN(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS earliest_diagnosis_date,
+        MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS latest_diagnosis_date,
+
+        -- Register logic: active diagnosis required
+        COALESCE(MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) IS NOT NULL,
+        FALSE) AS has_active_ms_diagnosis,
+
+        -- Count of MS diagnoses
+        COUNT(CASE WHEN is_diagnosis_code THEN 1 END)
+            AS total_ms_diagnoses,
+
+        -- Traceability arrays
+        ARRAY_AGG(
+            DISTINCT CASE WHEN is_diagnosis_code THEN concept_code END
+        ) AS all_ms_concept_codes,
+        ARRAY_AGG(
+            DISTINCT CASE
+                WHEN is_diagnosis_code THEN concept_display
+            END
+        ) AS all_ms_concept_displays
+
+    FROM {{ ref('int_ms_diagnoses_all') }} ms
+    GROUP BY ms.person_id
+)
+
+-- Final selection with person demographics
+SELECT
+    fd.person_id,
+    age.age,
+    TRUE AS is_on_register,
+    fd.earliest_diagnosis_date,
+    fd.latest_diagnosis_date,
+    fd.total_ms_diagnoses,
+    fd.all_ms_concept_codes,
+    fd.all_ms_concept_displays
+
+FROM ms_diagnoses AS fd
+INNER JOIN {{ ref('dim_person') }} AS p
+    ON fd.person_id = p.person_id
+INNER JOIN {{ ref('dim_person_age') }} AS age
+    ON fd.person_id = age.person_id
+WHERE fd.has_active_ms_diagnosis = TRUE  -- Only include persons with active MS diagnosis
+

--- a/models/reporting/olids/disease_registers/fct_person_ms_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_ms_register.yml
@@ -1,0 +1,32 @@
+version: 2
+models:
+  - name: fct_person_ms_register
+    description: 'Multiple sclerosis register for patients with MS diagnosis.
+
+      One row per person with MS_COD present (non-QOF).'
+    
+    config:
+      meta:
+        indicator:
+          id: "MS"
+          type: "CONDITION"
+          category: "LTC"
+          clinical_domain: "Neurology"
+          name_short: "Multiple Sclerosis"
+          description_short: "Multiple sclerosis register (non-QOF)"
+          description_long: >
+            Multiple sclerosis register for persons with MS diagnosis. 
+            Includes active patients with MS diagnosis using MS_COD cluster codes. 
+            No age restrictions or resolution codes applied. Used for neurological care 
+            pathway monitoring, disease-modifying therapy monitoring, multidisciplinary 
+            team coordination, and symptom management. Chronic neurological condition 
+            requiring ongoing care and support.
+          is_qof: false
+          source_column: "is_on_register"
+          sort_order: "COND_NEURO_MS"
+          usage_contexts:
+            - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+          code_clusters:
+            - cluster_id: "MS_COD"
+              category: "INCLUSION"
+

--- a/models/reporting/olids/disease_registers/fct_person_parkinsons_register.sql
+++ b/models/reporting/olids/disease_registers/fct_person_parkinsons_register.sql
@@ -1,0 +1,89 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+**Parkinson's Disease Register - Clinical Quality Measures**
+
+Simple Register
+
+Business Logic:
+- Presence of Parkinson's disease diagnosis (PD_COD) = on register
+- No resolution codes (progressive condition)
+
+Note:
+- There are no resolved codes for Parkinson's (progressive neurological condition)
+- No specific age restrictions, though more common in older adults
+- Latest diagnosis date used for care planning
+
+Clinical Context:
+Used for Parkinson's disease quality measures including:
+- Neurological care pathway monitoring
+- Medication management (levodopa, dopamine agonists, etc.)
+- Multidisciplinary team coordination
+- Symptom management and monitoring
+- Care planning and support services
+*/
+
+WITH parkinsons_diagnoses AS (
+    SELECT
+        pd.person_id,
+
+        -- Person-level aggregation from observation-level data
+        MIN(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS earliest_diagnosis_date,
+        MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) AS latest_diagnosis_date,
+
+        -- Register logic: active diagnosis required
+        COALESCE(MAX(
+            CASE
+                WHEN is_diagnosis_code THEN clinical_effective_date
+            END
+        ) IS NOT NULL,
+        FALSE) AS has_active_parkinsons_diagnosis,
+
+        -- Count of Parkinson's diagnoses
+        COUNT(CASE WHEN is_diagnosis_code THEN 1 END)
+            AS total_parkinsons_diagnoses,
+
+        -- Traceability arrays
+        ARRAY_AGG(
+            DISTINCT CASE WHEN is_diagnosis_code THEN concept_code END
+        ) AS all_parkinsons_concept_codes,
+        ARRAY_AGG(
+            DISTINCT CASE
+                WHEN is_diagnosis_code THEN concept_display
+            END
+        ) AS all_parkinsons_concept_displays
+
+    FROM {{ ref('int_parkinsons_diagnoses_all') }} pd
+    GROUP BY pd.person_id
+)
+
+-- Final selection with person demographics
+SELECT
+    fd.person_id,
+    age.age,
+    TRUE AS is_on_register,
+    fd.earliest_diagnosis_date,
+    fd.latest_diagnosis_date,
+    fd.total_parkinsons_diagnoses,
+    fd.all_parkinsons_concept_codes,
+    fd.all_parkinsons_concept_displays
+
+FROM parkinsons_diagnoses AS fd
+INNER JOIN {{ ref('dim_person') }} AS p
+    ON fd.person_id = p.person_id
+INNER JOIN {{ ref('dim_person_age') }} AS age
+    ON fd.person_id = age.person_id
+WHERE fd.has_active_parkinsons_diagnosis = TRUE  -- Only include persons with active Parkinson's diagnosis
+

--- a/models/reporting/olids/disease_registers/fct_person_parkinsons_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_parkinsons_register.yml
@@ -1,0 +1,32 @@
+version: 2
+models:
+  - name: fct_person_parkinsons_register
+    description: 'Parkinsons disease register for patients with Parkinsons diagnosis.
+
+      One row per person with PD_COD present (non-QOF).'
+    
+    config:
+      meta:
+        indicator:
+          id: "PARKINSONS"
+          type: "CONDITION"
+          category: "LTC"
+          clinical_domain: "Neurology"
+          name_short: "Parkinsons Disease"
+          description_short: "Parkinsons disease register (non-QOF)"
+          description_long: >
+            Parkinsons disease register for persons with Parkinsons diagnosis. 
+            Includes active patients with Parkinsons diagnosis using PD_COD cluster codes. 
+            No age restrictions or resolution codes applied. Used for neurological care 
+            pathway monitoring, medication management, multidisciplinary team coordination, 
+            and symptom management. Progressive neurological condition requiring ongoing 
+            care and support.
+          is_qof: false
+          source_column: "is_on_register"
+          sort_order: "COND_NEURO_PARKINSONS"
+          usage_contexts:
+            - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+          code_clusters:
+            - cluster_id: "PD_COD"
+              category: "INCLUSION"
+


### PR DESCRIPTION
## Summary
Adds 7 new long-term condition registers to support population health segmentation and analysis.

## New Conditions Added

### Neurological Conditions (4)
- **Parkinsons Disease** (PD_COD) - Progressive neurological condition
- **Cerebral Palsy** (CEREBRALP_COD) - Lifelong neurological condition  
- **Motor Neurone Disease** (MND_COD) - Progressive neurological condition
- **Multiple Sclerosis** (MS_COD) - Chronic neurological condition

### Mental Health Conditions (1)
- **Anxiety** (ANX_COD/ANXRES_COD) - With resolution tracking for episodic patterns

### Endocrine Conditions (1)
- **Hypothyroidism** (THY_COD) - Chronic endocrine condition

### Neurodevelopmental Conditions (1)
- **Autism Spectrum Disorder** (AUTISM_COD) - Lifelong neurodevelopmental condition

## Implementation Details

All conditions follow the existing pattern:
- Intermediate diagnosis models (`int_*_diagnoses_all.sql`) with cluster ID tests
- Register fact tables (`fct_person_*_register.sql`) with business logic
- Comprehensive YAML documentation with metadata and tests
- Integrated into `fct_person_ltc_summary` and dim_person_conditions
- Added to condition episodes tracking (`fct_person_condition_episodes`)

## Changes
- 14 new intermediate diagnosis models (7 SQL + 7 YAML)
- 14 new register models (7 SQL + 7 YAML)
- Updated summary and dimension tables
- Removed `accepted_values` test for `condition_name` to allow flexible addition of new conditions

All conditions marked as non-QOF with appropriate clinical domain categorisation.