### PR TITLE
fix: correct BNF code format for ACE inhibitors

### DIFF
--- a/models/modelling/olids/medications/int_ace_inhibitor_medications_all.sql
+++ b/models/modelling/olids/medications/int_ace_inhibitor_medications_all.sql
@@ -44,6 +44,6 @@ SELECT
     END AS is_recent_12m
 
 FROM (
-    {{ get_medication_orders(bnf_code='02050501') }}
+    {{ get_medication_orders(bnf_code='0205051') }}
 ) base_orders
 ORDER BY person_id, order_date DESC


### PR DESCRIPTION
## Summary
Fixes empty table issue in `int_ace_inhibitor_medications_all` by correcting the BNF code format.

## Changes
- Changed BNF code from `'02050501'` (8 characters) to `'0205051'` (7 characters)
- This matches the actual BNF code format in the data (e.g., `0205051J0BBABAB`)
- Aligns with other medication models like ARBs which use `'0205052'` for BNF 2.5.5.2

## Testing
- Model now returns ~10.7M records for 1.8M patients
- Average of ~6 orders per patient is reasonable for chronic ACE inhibitor therapy

Fixes #102