### PR TITLE
feat: add ethnicity and language indicator metadata

### DIFF
--- a/models/reporting/olids/person_demographics/dim_person_ethnicity.yml
+++ b/models/reporting/olids/person_demographics/dim_person_ethnicity.yml
@@ -16,7 +16,55 @@ models:
       • Includes sorting helpers for consistent display ordering
 
       Purpose: Supports ethnicity analysis, health equity monitoring, and demographic profiling.'
-    
+
+    config:
+      meta:
+        indicator:
+          id: "DEMO_ETHNICITY"
+          type: "DEMOGRAPHIC_ATTRIBUTE"
+          category: "DEMOGRAPHICS"
+          clinical_domain: "Demographics"
+          name_short: "Ethnicity"
+          description_short: "Three-tier ethnicity classification from latest clinical recording"
+          description_long: >
+            Ethnicity classification based on most recent clinical observations with three-tier
+            hierarchy: Category > Subcategory > Granular detail. Uses ETHNICITY_CODES reference
+            table mapping to NHS Digital 2016+ ethnicity categories. Prioritises non-deprioritised
+            records and higher specificity, then most recent date. Supports health equity monitoring,
+            population analysis, and demographic profiling.
+          is_qof: false
+          source_column: "ethnicity_category"
+          sort_order: "DEMO_1_ETHNICITY"
+          usage_contexts:
+            - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+            - "DEMOGRAPHICS"
+            - "HEALTH_EQUITY"
+          code_clusters:
+            - cluster_id: "ETH2016AI_COD"
+              category: "INCLUSION"
+            - cluster_id: "ETH2016AP_COD"
+              category: "INCLUSION"
+            - cluster_id: "ETH2016AB_COD"
+              category: "INCLUSION"
+            - cluster_id: "ETH2016AC_COD"
+              category: "INCLUSION"
+            - cluster_id: "ETH2016AO_COD"
+              category: "INCLUSION"
+            - cluster_id: "ETH2016MWA_COD"
+              category: "INCLUSION"
+            - cluster_id: "ETH2016OA_COD"
+              category: "INCLUSION"
+            - cluster_id: "ETH2016BA_COD"
+              category: "INCLUSION"
+            - cluster_id: "ETH2016MWBA_COD"
+              category: "INCLUSION"
+            - cluster_id: "ETH2016BC_COD"
+              category: "INCLUSION"
+            - cluster_id: "ETH2016MWBC_COD"
+              category: "INCLUSION"
+            - cluster_id: "ETH2016BO_COD"
+              category: "INCLUSION"
+
     columns:
       - name: person_id
         description: 'Unique identifier for the person'

--- a/models/reporting/olids/person_demographics/dim_person_main_language.yml
+++ b/models/reporting/olids/person_demographics/dim_person_main_language.yml
@@ -19,6 +19,34 @@ models:
 
       Purpose: Supports accessibility planning, interpreter service allocation, and communication needs assessment.'
 
+    config:
+      meta:
+        indicator:
+          id: "DEMO_LANGUAGE"
+          type: "DEMOGRAPHIC_ATTRIBUTE"
+          category: "DEMOGRAPHICS"
+          clinical_domain: "Demographics"
+          name_short: "Main Language"
+          description_short: "Preferred language and interpreter needs from latest clinical recording"
+          description_long: >
+            Main language preference and interpreter requirements based on most recent clinical
+            observations from PREFLANG_COD (language preference) and REQINTERPRETER_COD (interpreter
+            needs). Includes language type classification (Spoken, Sign, Other Communication Method),
+            interpreter requirements, and communication support needs. Supports accessibility planning,
+            interpreter service allocation, and communication needs assessment.
+          is_qof: false
+          source_column: "language"
+          sort_order: "DEMO_2_LANGUAGE"
+          usage_contexts:
+            - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+            - "DEMOGRAPHICS"
+            - "ACCESSIBILITY"
+          code_clusters:
+            - cluster_id: "PREFLANG_COD"
+              category: "INCLUSION"
+            - cluster_id: "REQINTERPRETER_COD"
+              category: "INCLUSION"
+
     columns:
       - name: person_id
         description: 'Unique identifier for the person'


### PR DESCRIPTION
## Summary

Adds standard indicator metadata to `dim_person_ethnicity` and `dim_person_main_language` dimension tables to support POPULATION_HEALTH_NEEDS_DASHBOARD and demographic analysis.

## Changes

- Added `config.meta.indicator` block to `dim_person_ethnicity.yml`
  - Indicator ID: `DEMO_ETHNICITY`
  - Documents 12 ETH2016*_COD code clusters
  - Usage contexts: POPULATION_HEALTH_NEEDS_DASHBOARD, DEMOGRAPHICS, HEALTH_EQUITY

- Added `config.meta.indicator` block to `dim_person_main_language.yml`
  - Indicator ID: `DEMO_LANGUAGE`
  - Documents PREFLANG_COD and REQINTERPRETER_COD clusters
  - Usage contexts: POPULATION_HEALTH_NEEDS_DASHBOARD, DEMOGRAPHICS, ACCESSIBILITY

Both indicators use new `DEMOGRAPHIC_ATTRIBUTE` type to distinguish from clinical conditions.

## Test plan

- [x] YAML syntax validated (dbt parse shows no YAML errors)
- [ ] Verify cluster IDs exist in combined_codesets
- [ ] Confirm metadata structure matches existing patterns
- [ ] Review indicator definitions appear correctly in def_indicator table

Resolves #53