### PR TITLE
fix: correct cluster_id references in COVID vaccination YML docs

### DIFF
--- a/models/modelling/olids/programme/covid/int_covid_chronic_kidney_disease.yml
+++ b/models/modelling/olids/programme/covid/int_covid_chronic_kidney_disease.yml
@@ -42,6 +42,8 @@ models:
             - "COVID_AND_FLU_DASHBOARD"
             - "COVID_REPORTING"
           code_clusters:
+            - cluster_id: "CKD_COV_COD"
+              category: "INCLUSION"
             - cluster_id: "CKD15_COD"
               category: "INCLUSION"
             - cluster_id: "CKD35_COD"

--- a/models/modelling/olids/programme/covid/int_covid_chronic_liver_disease.yml
+++ b/models/modelling/olids/programme/covid/int_covid_chronic_liver_disease.yml
@@ -5,7 +5,7 @@ models:
 
       Key Features:
 
-      • Single diagnosis pathway using CLD_COV_COD codes
+      • Single diagnosis pathway using CLD_COD codes
 
       • Earliest occurrence in medical history qualifies
 
@@ -31,7 +31,7 @@ models:
           name_short: "COVID Eligible Liver Disease"
           description_short: "People with chronic liver disease eligible for COVID vaccination"
           description_long: >
-            COVID vaccination eligibility for people with chronic liver disease using CLD_COV_COD
+            COVID vaccination eligibility for people with chronic liver disease using CLD_COD
             cluster codes with earliest occurrence qualifying. Includes chronic hepatic conditions
             and liver dysfunction that increase COVID risk requiring immunisation
             protection. Minimum age requirement of 5 years for COVID vaccination.

--- a/models/modelling/olids/programme/covid/int_covid_chronic_neurological_disease.yml
+++ b/models/modelling/olids/programme/covid/int_covid_chronic_neurological_disease.yml
@@ -5,7 +5,7 @@ models:
 
       Key Features:
 
-      • Single diagnosis pathway using CND_COV_COD codes
+      • Single diagnosis pathway using CNS_COV_COD codes
 
       • Earliest occurrence in medical history qualifies
 
@@ -31,7 +31,7 @@ models:
           name_short: "COVID Eligible Neurological Disease"
           description_short: "People with chronic neurological disease eligible for COVID vaccination"
           description_long: >
-            COVID vaccination eligibility for people with chronic neurological disease using CND_COV_COD
+            COVID vaccination eligibility for people with chronic neurological disease using CNS_COV_COD
             cluster codes with earliest occurrence qualifying. Includes chronic neurological conditions
             and nervous system dysfunction that increase COVID risk requiring immunisation
             protection. Minimum age requirement of 5 years for COVID vaccination.

--- a/models/modelling/olids/programme/covid/int_covid_diabetes.yml
+++ b/models/modelling/olids/programme/covid/int_covid_diabetes.yml
@@ -5,7 +5,7 @@ models:
 
       Key Features:
 
-      • Single diagnosis pathway using DM_COV_COD codes
+      • Single diagnosis pathway using DIAB_COD and DMRES_COD codes
 
       • Earliest occurrence in medical history qualifies
 
@@ -31,7 +31,7 @@ models:
           name_short: "COVID Eligible Diabetes"
           description_short: "People with diabetes mellitus eligible for COVID vaccination"
           description_long: >
-            COVID vaccination eligibility for people with diabetes mellitus using DM_COV_COD
+            COVID vaccination eligibility for people with diabetes mellitus using DIAB_COD and DMRES_COD
             cluster codes with earliest occurrence qualifying. Includes Type 1 and Type 2
             diabetes that increase COVID risk requiring immunisation
             protection. Minimum age requirement of 5 years for COVID vaccination.

--- a/models/modelling/olids/programme/covid/int_covid_gestational_diabetes.yml
+++ b/models/modelling/olids/programme/covid/int_covid_gestational_diabetes.yml
@@ -5,7 +5,7 @@ models:
 
       Key Features:
 
-      • Single diagnosis pathway using GDM_COV_COD codes
+      • Single diagnosis pathway using GDIAB_COD codes
 
       • Earliest occurrence in medical history qualifies
 
@@ -31,7 +31,7 @@ models:
           name_short: "COVID Eligible Gestational Diabetes"
           description_short: "People with gestational diabetes eligible for COVID vaccination"
           description_long: >
-            COVID vaccination eligibility for people with gestational diabetes using GDM_COV_COD
+            COVID vaccination eligibility for people with gestational diabetes using GDIAB_COD
             cluster codes with earliest occurrence qualifying. Includes gestational diabetes
             mellitus that increases COVID risk during pregnancy requiring immunisation
             protection. Minimum age requirement of 5 years for COVID vaccination.

--- a/models/modelling/olids/programme/covid/int_covid_homeless.yml
+++ b/models/modelling/olids/programme/covid/int_covid_homeless.yml
@@ -5,7 +5,7 @@ models:
 
       Key Features:
 
-      • Single diagnosis pathway using HOMLESS_COV_COD codes
+      • Single diagnosis pathway using HOMELESS_COD codes
 
       • Recent occurrence qualifying (lookback period from campaign)
 
@@ -31,7 +31,7 @@ models:
           name_short: "COVID Eligible Homeless"
           description_short: "People with homelessness eligible for COVID vaccination"
           description_long: >
-            COVID vaccination eligibility for people with homelessness using HOMLESS_COV_COD
+            COVID vaccination eligibility for people with homelessness using HOMELESS_COD
             cluster codes with recent occurrence qualifying. Includes homeless status and
             accommodation codes that increase COVID risk requiring immunisation
             protection. Minimum age requirement of 5 years for COVID vaccination.


### PR DESCRIPTION
## Summary
Fixes documentation inconsistencies in COVID vaccination intermediate model YML files (refs #104).

## Changes
Updated YML documentation to reference correct cluster_ids that match the SQL model implementations:

- `int_covid_homeless.yml`: `HOMLESS_COV_COD` → `HOMELESS_COD` (fixed typo)
- `int_covid_gestational_diabetes.yml`: `GDM_COV_COD` → `GDIAB_COD`
- `int_covid_diabetes.yml`: `DM_COV_COD` → `DIAB_COD and DMRES_COD`
- `int_covid_chronic_neurological_disease.yml`: `CND_COV_COD` → `CNS_COV_COD`
- `int_covid_chronic_liver_disease.yml`: `CLD_COV_COD` → `CLD_COD`
- `int_covid_chronic_kidney_disease.yml`: Added missing `CKD_COV_COD` to code_clusters metadata

## Test plan
- [x] YML documentation now matches SQL model cluster_id usage
- [x] All cluster_ids verified to exist in reference table with source='UKHSA_COVID'

## Notes
The SQL models were already using the correct cluster_ids. This PR only updates documentation. 

The models returning 0 rows is a separate data/concept mapping issue that requires further investigation beyond these documentation fixes.