### PR TITLE
refactor: standardise registration comparison models with EMIS method…

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -163,3 +163,11 @@ seeds:
         BK_ETHNICITY_CODE: varchar
         ETHNICITY_DESC: varchar
 
+    emis_list_size:
+      +column_types:
+        BOROUGH: varchar(50)
+        CODE: varchar(10)
+        GP_PRACTICE: varchar(200)
+        LIST_SIZE: integer
+        EXTRACT_DATE: varchar(10)
+

--- a/models/modelling/olids/utilities/int_emis_olids_aggregate_validation.sql
+++ b/models/modelling/olids/utilities/int_emis_olids_aggregate_validation.sql
@@ -1,0 +1,65 @@
+{{
+    config(
+        materialized='table',
+        tags=['data_quality', 'utilities', 'emis', 'olids', 'aggregate']
+    )
+}}
+
+/*
+EMIS/OLIDS Aggregate Validation
+
+Calculates aggregate variance across all practices to validate against acceptance criteria.
+Uses EMIS list size vs OLIDS Regular registrations.
+
+Acceptance Criteria: <1% variance in aggregate across all 175 practices
+Snapshot Date: 04/11/2025 (from EMIS extract)
+
+Purpose:
+- Validate overall data quality at aggregate level
+- Complement per-practice validation
+- Monitor system-wide accuracy
+*/
+
+with aggregate_counts as (
+    select
+        count(distinct practice_code) as practice_count,
+        sum(emis_list_size) as total_emis_list_size,
+        sum(olids_regular_count) as total_olids_regular_count,
+        max(extract_date) as snapshot_date
+    from {{ ref('int_emis_olids_practice_registration_comparison') }}
+    where emis_list_size is not null
+)
+
+select
+    practice_count,
+    total_emis_list_size,
+    total_olids_regular_count,
+
+    -- Calculate aggregate difference (signed)
+    total_olids_regular_count - total_emis_list_size as aggregate_difference,
+
+    -- Calculate aggregate percentage difference
+    round(
+        (total_olids_regular_count - total_emis_list_size) * 100.0 / total_emis_list_size,
+        4
+    ) as aggregate_percent_difference,
+
+    -- Calculate absolute aggregate percentage difference
+    abs(round(
+        (total_olids_regular_count - total_emis_list_size) * 100.0 / total_emis_list_size,
+        4
+    )) as aggregate_absolute_percent_difference,
+
+    -- Acceptance criteria: <1% variance
+    case
+        when abs(round(
+            (total_olids_regular_count - total_emis_list_size) * 100.0 / total_emis_list_size,
+            4
+        )) < 1 then 'PASS'
+        else 'FAIL'
+    end as aggregate_acceptance_status,
+
+    snapshot_date,
+    current_timestamp() as validation_timestamp
+
+from aggregate_counts

--- a/models/modelling/olids/utilities/int_emis_olids_aggregate_validation.yml
+++ b/models/modelling/olids/utilities/int_emis_olids_aggregate_validation.yml
@@ -1,0 +1,41 @@
+version: 2
+
+models:
+  - name: int_emis_olids_aggregate_validation
+    description: |
+      Aggregate-level validation of OLIDS Regular registrations against EMIS list size.
+
+      Calculates aggregate variance across all practices to validate against acceptance criteria.
+
+      Acceptance Criteria: <1% variance in aggregate across all practices
+      Snapshot Date: Dynamic (from EMIS extract date in seed file)
+
+      Returns a single row with aggregate statistics and PASS/FAIL status.
+
+    columns:
+      - name: practice_count
+        description: Number of practices included in aggregate calculation
+
+      - name: total_emis_list_size
+        description: Sum of all EMIS list sizes across practices
+
+      - name: total_olids_regular_count
+        description: Sum of all OLIDS Regular registration counts across practices
+
+      - name: aggregate_difference
+        description: Total difference between OLIDS and EMIS (signed)
+
+      - name: aggregate_percent_difference
+        description: Aggregate percentage difference (signed, 4 decimals)
+
+      - name: aggregate_absolute_percent_difference
+        description: Absolute aggregate percentage difference
+
+      - name: aggregate_acceptance_status
+        description: PASS if <1% variance, FAIL if ≥1% variance
+
+      - name: snapshot_date
+        description: Date of EMIS extract (from seed file)
+
+      - name: validation_timestamp
+        description: Timestamp when validation was run

--- a/models/modelling/olids/utilities/int_emis_olids_practice_registration_comparison.sql
+++ b/models/modelling/olids/utilities/int_emis_olids_practice_registration_comparison.sql
@@ -1,0 +1,128 @@
+{{
+    config(
+        materialized='table',
+        tags=['data_quality', 'utilities', 'emis', 'olids']
+    )
+}}
+
+/*
+EMIS/OLIDS Practice Registration Comparison
+
+Compares OLIDS Regular registration counts against EMIS list size to identify discrepancies.
+Uses EMIS acceptance criteria for validation.
+
+Acceptance Criteria:
+- Aggregate: <1% variance across all practices
+- Per-practice: <2% variance OR fewer than 5 persons difference (whichever is greater)
+
+Categorization:
+- Meets Criteria: <2% variance OR <5 persons difference
+- 2-5% Variance: Between 2-5% variance
+- 5-20% Variance: Between 5-20% variance
+- 20%+ Variance: 20% or greater variance
+- Missing Data: No EMIS or OLIDS data available
+
+Data Sources:
+- EMIS: Static extract from 04/11/2025
+- OLIDS: Regular episode types only, active as of 04/11/2025
+*/
+
+with emis_registrations as (
+    select
+        practice_code,
+        practice_name,
+        borough,
+        list_size as emis_list_size,
+        extract_date
+    from {{ ref('stg_emis_list_size') }}
+),
+
+olids_regular_counts as (
+    select
+        practice_ods_code as practice_code,
+        regular_registered_patients as olids_regular_count,
+        snapshot_date
+    from {{ ref('int_olids_regular_registrations_at_point_in_time') }}
+),
+
+comparison as (
+    select
+        coalesce(e.practice_code, o.practice_code) as practice_code,
+        e.practice_name,
+        e.borough,
+        coalesce(e.emis_list_size, 0) as emis_list_size,
+        coalesce(o.olids_regular_count, 0) as olids_regular_count,
+        e.extract_date,
+
+        -- Calculate difference (signed)
+        coalesce(o.olids_regular_count, 0) - coalesce(e.emis_list_size, 0) as difference,
+
+        -- Calculate absolute difference
+        abs(coalesce(o.olids_regular_count, 0) - coalesce(e.emis_list_size, 0)) as absolute_difference,
+
+        -- Calculate percentage difference (signed)
+        case
+            when e.emis_list_size = 0 or e.emis_list_size is null then null
+            else round(
+                (coalesce(o.olids_regular_count, 0) - e.emis_list_size) * 100.0 / e.emis_list_size,
+                2
+            )
+        end as percent_difference,
+
+        -- Calculate absolute percentage difference
+        case
+            when e.emis_list_size = 0 or e.emis_list_size is null then null
+            else abs(round(
+                (coalesce(o.olids_regular_count, 0) - e.emis_list_size) * 100.0 / e.emis_list_size,
+                2
+            ))
+        end as absolute_percent_difference
+
+    from emis_registrations as e
+    full outer join olids_regular_counts as o
+        on e.practice_code = o.practice_code
+)
+
+select
+    practice_code,
+    practice_name,
+    borough,
+    emis_list_size,
+    olids_regular_count,
+    difference,
+    absolute_difference,
+    percent_difference,
+    absolute_percent_difference,
+    extract_date,
+
+    -- Acceptance criteria: <2% variance OR <5 persons difference
+    case
+        when emis_list_size is null or emis_list_size = 0 then false
+        when absolute_percent_difference < 2 then true
+        when absolute_difference < 5 then true
+        else false
+    end as meets_acceptance_criteria,
+
+    -- Categorization for analysis
+    case
+        when emis_list_size is null or emis_list_size = 0 then 'Missing Data'
+        when absolute_percent_difference < 2 or absolute_difference < 5 then 'Meets Criteria'
+        when absolute_percent_difference < 5 then '2-5% Variance'
+        when absolute_percent_difference < 20 then '5-20% Variance'
+        else '20%+ Variance'
+    end as variance_category,
+
+    -- Validation methodology description
+    'EMIS Regular Registration Comparison: <2% variance OR <5 persons difference (per-practice); <1% aggregate variance (all practices)' as validation_methodology
+
+from comparison
+order by
+    case variance_category
+        when '20%+ Variance' then 1
+        when '5-20% Variance' then 2
+        when '2-5% Variance' then 3
+        when 'Meets Criteria' then 4
+        else 5
+    end,
+    absolute_percent_difference desc nulls last,
+    practice_code

--- a/models/modelling/olids/utilities/int_emis_olids_practice_registration_comparison.yml
+++ b/models/modelling/olids/utilities/int_emis_olids_practice_registration_comparison.yml
@@ -1,0 +1,61 @@
+version: 2
+
+models:
+  - name: int_emis_olids_practice_registration_comparison
+    description: |
+      Compares OLIDS Regular registration counts against EMIS list size per practice.
+
+      Acceptance Criteria:
+      - Aggregate: <1% variance across all practices
+      - Per-practice: <2% variance OR fewer than 5 persons difference (whichever is greater)
+
+      Categorisation:
+      - Meets Criteria: <2% variance OR <5 persons difference
+      - 2-5% Variance: Between 2-5% variance
+      - 5-20% Variance: Between 5-20% variance
+      - 20%+ Variance: 20% or greater variance
+      - Missing Data: No EMIS or OLIDS data available
+
+      Data Sources:
+      - EMIS: Static extract (date from seed file)
+      - OLIDS: Regular episode types only, active as of EMIS extract date
+
+    columns:
+      - name: practice_code
+        description: GP practice ODS code
+
+      - name: practice_name
+        description: GP practice name
+
+      - name: borough
+        description: Borough name
+
+      - name: emis_list_size
+        description: Number of registered patients from EMIS extract
+
+      - name: olids_regular_count
+        description: Number of patients with Regular registration episodes in OLIDS
+
+      - name: difference
+        description: Difference between OLIDS and EMIS (signed, can be negative)
+
+      - name: absolute_difference
+        description: Absolute difference between OLIDS and EMIS
+
+      - name: percent_difference
+        description: Percentage difference (signed, can be negative)
+
+      - name: absolute_percent_difference
+        description: Absolute percentage difference
+
+      - name: extract_date
+        description: Date of EMIS extract (from seed file)
+
+      - name: meets_acceptance_criteria
+        description: Boolean flag indicating if practice meets acceptance criteria (<2% variance OR <5 persons difference)
+
+      - name: variance_category
+        description: Categorisation of variance (Meets Criteria, 2-5% Variance, 5-20% Variance, 20%+ Variance, Missing Data)
+
+      - name: validation_methodology
+        description: Description of the validation test applied (EMIS Regular Registration Comparison with thresholds)

--- a/models/modelling/olids/utilities/int_olids_regular_registrations_at_point_in_time.sql
+++ b/models/modelling/olids/utilities/int_olids_regular_registrations_at_point_in_time.sql
@@ -1,0 +1,112 @@
+{{
+    config(
+        materialized='table',
+        tags=['intermediate', 'registration', 'patient', 'practice', 'emis_comparison']
+    )
+}}
+
+/*
+OLIDS Regular Registrations at Point in Time
+
+Counts OLIDS patients with Regular registration episodes active at a fixed point in time.
+Filters to Regular episode type only (excludes Temporary, Emergency, Private, etc.)
+Used for EMIS list size comparison validation.
+
+Snapshot Date: 04/11/2025 (from EMIS extract)
+Episode Type: Regular only
+Patient Counting: Deduplicated by person_id (handles patient ID mergers)
+Deceased Handling: Excludes patients deceased on or before snapshot date
+*/
+
+with emis_extract_date as (
+    -- Get reference date from EMIS staging model
+    select extract_date as reference_date
+    from {{ ref('stg_emis_list_size') }}
+    limit 1
+),
+
+patient_to_person as (
+    -- Map patient_id to canonical person_id
+    select
+        pp.patient_id,
+        pp.person_id
+    from {{ ref('stg_olids_patient_person') }} as pp
+    where pp.patient_id is not null
+        and pp.person_id is not null
+),
+
+patient_deceased_status as (
+    -- Calculate approximate death date from year/month
+    select
+        p.id as patient_id,
+        p.death_year,
+        p.death_month,
+        p.death_year is not null as is_deceased,
+        case
+            when p.death_year is not null and p.death_month is not null
+                then dateadd(
+                    day,
+                    floor(
+                        day(last_day(to_date(p.death_year || '-' || p.death_month || '-01'))) / 2
+                    ),
+                    to_date(p.death_year || '-' || p.death_month || '-01')
+                )
+        end as death_date_approx
+    from {{ ref('stg_olids_patient') }} as p
+),
+
+regular_episodes as (
+    -- Get Regular registration episodes
+    select
+        eoc.id,
+        eoc.patient_id,
+        eoc.organisation_id,
+        eoc.record_owner_organisation_code as practice_ods_code,
+        eoc.episode_of_care_start_date,
+        eoc.episode_of_care_end_date,
+        eoc.episode_type_source_display
+    from {{ ref('stg_olids_episode_of_care') }} as eoc
+    cross join emis_extract_date as ed
+    where eoc.episode_type_code = '24531000000104'  -- Registration type
+        and eoc.episode_type_source_display = 'Regular'
+        -- Episode active on reference date
+        and eoc.episode_of_care_start_date <= ed.reference_date
+        and (
+            eoc.episode_of_care_end_date is null
+            or eoc.episode_of_care_end_date > ed.reference_date
+        )
+),
+
+active_registrations as (
+    -- Join with person mapping and filter out deceased patients
+    select
+        r.practice_ods_code,
+        ptp.person_id,
+        p.sk_patient_id
+    from regular_episodes as r
+    cross join emis_extract_date as ed
+    inner join patient_to_person as ptp
+        on r.patient_id = ptp.patient_id
+    left join {{ ref('stg_olids_patient') }} as p
+        on r.patient_id = p.id
+    left join patient_deceased_status as pds
+        on r.patient_id = pds.patient_id
+    where r.practice_ods_code is not null
+        -- Exclude deceased patients as of reference date
+        and (
+            pds.death_date_approx is null
+            or pds.death_date_approx > ed.reference_date
+        )
+    qualify row_number() over (
+        partition by ptp.person_id, r.practice_ods_code
+        order by r.id
+    ) = 1
+)
+
+-- Count distinct persons per practice
+select
+    practice_ods_code,
+    count(distinct person_id) as regular_registered_patients,
+    (select reference_date from emis_extract_date) as snapshot_date
+from active_registrations
+group by practice_ods_code

--- a/models/modelling/olids/utilities/int_olids_regular_registrations_at_point_in_time.yml
+++ b/models/modelling/olids/utilities/int_olids_regular_registrations_at_point_in_time.yml
@@ -1,0 +1,24 @@
+version: 2
+
+models:
+  - name: int_olids_regular_registrations_at_point_in_time
+    description: |
+      OLIDS patients with Regular registration episodes active at fixed point in time.
+
+      Filters to Regular episode type only (excludes Temporary, Emergency, Private, etc.)
+      Used for EMIS list size comparison validation.
+
+      Snapshot Date: Dynamic (matches EMIS extract_date from seed file)
+      Episode Type: Regular only
+      Patient Counting: Deduplicated by person_id (handles patient ID mergers)
+      Deceased Handling: Excludes patients deceased on or before snapshot date
+
+    columns:
+      - name: practice_ods_code
+        description: GP practice ODS code
+
+      - name: regular_registered_patients
+        description: Count of distinct persons with Regular registration episodes active on snapshot date
+
+      - name: snapshot_date
+        description: Reference date for point-in-time calculation (from EMIS extract_date)

--- a/models/modelling/olids/utilities/int_pds_olids_practice_registration_comparison.yml
+++ b/models/modelling/olids/utilities/int_pds_olids_practice_registration_comparison.yml
@@ -1,0 +1,49 @@
+version: 2
+
+models:
+  - name: int_pds_olids_practice_registration_comparison
+    description: |
+      Compares OLIDS all registration counts against PDS to identify discrepancies.
+
+      Acceptance Criteria (Updated to match EMIS):
+      - Per-practice: <2% variance OR fewer than 5 persons difference (whichever is greater)
+
+      Uses PDS merger handling to account for NHS number changes.
+      Includes all registration types (not filtered to Regular only like EMIS).
+
+    columns:
+      - name: practice_code
+        description: GP practice ODS code
+
+      - name: practice_name
+        description: GP practice name
+
+      - name: pds_unmerged_persons
+        description: Count of distinct persons in PDS before merger handling
+
+      - name: pds_merged_persons
+        description: Count of distinct persons in PDS after NHS number merger handling (recommended for comparison)
+
+      - name: olids_patient_count
+        description: Count of distinct patients with registration episodes in OLIDS
+
+      - name: difference
+        description: Difference between OLIDS and PDS (signed, can be negative)
+
+      - name: percent_difference
+        description: Percentage difference (signed, can be negative)
+
+      - name: absolute_difference
+        description: Absolute difference between OLIDS and PDS
+
+      - name: absolute_percent_difference
+        description: Absolute percentage difference
+
+      - name: meets_acceptance_criteria
+        description: Boolean flag indicating if practice meets acceptance criteria (<2% variance OR <5 persons difference)
+
+      - name: has_significant_discrepancy
+        description: Legacy flag for >=20% discrepancy (deprecated, kept for backwards compatibility)
+
+      - name: validation_methodology
+        description: Description of the validation test applied (PDS All Registration Types Comparison with thresholds)

--- a/models/published/direct_care/olids/db_utils/emis_olids_reg_aggregate_validation_direct_care.sql
+++ b/models/published/direct_care/olids/db_utils/emis_olids_reg_aggregate_validation_direct_care.sql
@@ -1,0 +1,39 @@
+{{
+    config(
+        materialized='table',
+        alias='emis_olids_reg_aggregate_validation',
+        tags=['data_quality', 'published', 'direct_care']
+    )
+}}
+
+/*
+EMIS/OLIDS Aggregate Validation (Direct Care)
+
+Aggregate-level validation of OLIDS Regular registrations against EMIS list size.
+Shows whether the overall system meets the <1% variance acceptance criteria.
+
+Acceptance Criteria: <1% variance in aggregate across all 175 practices
+
+Use Cases:
+- System-wide data quality monitoring
+- Monthly validation reporting
+- Acceptance criteria compliance tracking
+- Complement to per-practice validation
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__DIRECT_CARE.OLIDS_PUBLISHED schema
+- Table alias: emis_olids_aggregate_validation
+- Single row showing aggregate statistics and PASS/FAIL status
+*/
+
+select
+    practice_count,
+    total_emis_list_size,
+    total_olids_regular_count,
+    aggregate_difference,
+    aggregate_percent_difference,
+    aggregate_absolute_percent_difference,
+    aggregate_acceptance_status,
+    snapshot_date,
+    validation_timestamp
+from {{ ref('int_emis_olids_aggregate_validation') }}

--- a/models/published/direct_care/olids/db_utils/emis_olids_reg_comparison_all_direct_care.sql
+++ b/models/published/direct_care/olids/db_utils/emis_olids_reg_comparison_all_direct_care.sql
@@ -1,0 +1,63 @@
+{{
+    config(
+        materialized='table',
+        alias='emis_olids_reg_comparison_all',
+        tags=['data_quality', 'published', 'direct_care']
+    )
+}}
+
+/*
+EMIS/OLIDS Practice Registration Comparison - All Practices (Direct Care)
+
+Complete comparison of all practices using EMIS acceptance criteria.
+Compares OLIDS Regular registrations against EMIS list size.
+
+Categories:
+- Meets Criteria: <2% variance OR <5 persons difference
+- 2-5% Variance: Between 2-5% variance
+- 5-20% Variance: Between 5-20% variance
+- 20%+ Variance: 20% or greater variance
+- Missing Data: No EMIS or OLIDS data available
+
+Acceptance Criteria:
+- Aggregate: <1% variance across all practices
+- Per-practice: <2% variance OR fewer than 5 persons difference
+
+Use Cases:
+- Comprehensive data quality monitoring for Regular registrations
+- Practice-level completeness assessment
+- Acceptance criteria validation
+- Monthly reporting
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__DIRECT_CARE.OLIDS_PUBLISHED schema
+- Table alias: emis_olids_practice_comparison_all
+- Filter by variance_category for different views
+- Group by variance_category to see distribution
+- Calculate aggregate variance to check <1% threshold
+*/
+
+select
+    practice_code,
+    practice_name,
+    borough,
+    emis_list_size,
+    olids_regular_count,
+    difference,
+    absolute_difference,
+    percent_difference,
+    absolute_percent_difference,
+    extract_date as snapshot_date,
+    meets_acceptance_criteria,
+    variance_category
+from {{ ref('int_emis_olids_practice_registration_comparison') }}
+order by
+    case variance_category
+        when '20%+ Variance' then 1
+        when '5-20% Variance' then 2
+        when '2-5% Variance' then 3
+        when 'Meets Criteria' then 4
+        else 5
+    end,
+    absolute_percent_difference desc nulls last,
+    practice_code

--- a/models/published/direct_care/olids/db_utils/emis_olids_reg_fail_direct_care.sql
+++ b/models/published/direct_care/olids/db_utils/emis_olids_reg_fail_direct_care.sql
@@ -1,0 +1,58 @@
+{{
+    config(
+        materialized='table',
+        alias='emis_olids_reg_fail',
+        tags=['data_quality', 'published', 'direct_care']
+    )
+}}
+
+/*
+EMIS/OLIDS Unvalidated Practices (Direct Care)
+
+Practices NOT meeting EMIS acceptance criteria for Regular registrations.
+These practices require investigation before use in analyses.
+
+Validation Criteria: >=2% variance AND >=5 persons difference
+Snapshot Date: 04/11/2025 (from EMIS extract)
+Registration Type: Regular only (excludes Temporary, Emergency, etc.)
+
+Issue Categories:
+- 2-5% Variance: Minor discrepancy, may warrant review
+- 5-20% Variance: Moderate discrepancy, requires investigation
+- 20%+ Variance: Major discrepancy, immediate attention needed
+- Missing Data: No EMIS or OLIDS data available
+
+Use Cases:
+- Identifying practices requiring data quality investigation
+- Monthly data quality reports
+- Monitoring completeness of OLIDS Regular episode data
+- Understanding which practices should be excluded from analyses
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__DIRECT_CARE.OLIDS_PUBLISHED schema
+- Table alias: emis_olids_practices_unvalidated
+- Review regularly to identify practices needing attention
+- Filter by variance_category to prioritize investigations
+*/
+
+select
+    practice_code,
+    practice_name,
+    borough,
+    emis_list_size,
+    olids_regular_count,
+    difference,
+    absolute_difference,
+    percent_difference,
+    extract_date as snapshot_date,
+    variance_category as issue_category
+from {{ ref('int_emis_olids_practice_registration_comparison') }}
+where meets_acceptance_criteria = false
+order by
+    case variance_category
+        when '20%+ Variance' then 1
+        when '5-20% Variance' then 2
+        when '2-5% Variance' then 3
+        else 4
+    end,
+    absolute_percent_difference desc

--- a/models/published/direct_care/olids/db_utils/emis_olids_reg_pass_direct_care.sql
+++ b/models/published/direct_care/olids/db_utils/emis_olids_reg_pass_direct_care.sql
@@ -1,0 +1,49 @@
+{{
+    config(
+        materialized='table',
+        alias='emis_olids_reg_pass',
+        tags=['data_quality', 'published', 'direct_care']
+    )
+}}
+
+/*
+EMIS/OLIDS Validated Practices (Direct Care)
+
+Practices meeting EMIS acceptance criteria for Regular registrations.
+Use this table for inner joins to filter datasets to practices with validated registration data.
+
+Validation Criteria: <2% variance OR <5 persons difference
+Snapshot Date: 04/11/2025 (from EMIS extract)
+Registration Type: Regular only (excludes Temporary, Emergency, etc.)
+Methodology: EMIS comparison using Regular episode type filtering
+
+Acceptance Criteria Details:
+- Per-practice: <2% variance OR fewer than 5 persons difference (whichever is greater)
+- This flexible threshold accounts for both percentage and absolute differences
+- Small practices can have larger percentage differences if absolute difference is small
+
+Use Cases:
+- Filter analyses to practices with reliable Regular registration data
+- Inner join to exclude practices with data quality issues
+- Quality assurance dashboards
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__DIRECT_CARE.OLIDS_PUBLISHED schema
+- Table alias: emis_olids_practices_validated
+- Join on practice_code to filter to validated practices only
+*/
+
+select
+    practice_code,
+    practice_name,
+    borough,
+    emis_list_size,
+    olids_regular_count,
+    difference,
+    absolute_difference,
+    percent_difference,
+    extract_date as snapshot_date,
+    variance_category as match_quality
+from {{ ref('int_emis_olids_practice_registration_comparison') }}
+where meets_acceptance_criteria = true
+order by absolute_percent_difference desc

--- a/models/published/direct_care/olids/db_utils/olids_practice_registration_comparisons_direct_care.yml
+++ b/models/published/direct_care/olids/db_utils/olids_practice_registration_comparisons_direct_care.yml
@@ -1,0 +1,74 @@
+version: 2
+
+models:
+  - name: pds_olids_reg_pass_direct_care
+    description: |
+      Practices passing PDS registration count validation.
+
+      Use this for inner joins to filter datasets to practices with validated registration data.
+
+      Validation: <2% variance OR <5 persons difference (same threshold as EMIS)
+      Methodology: PDS All Registration Types Comparison
+      Includes: validation_methodology column describing the test
+
+  - name: pds_olids_reg_fail_direct_care
+    description: |
+      Practices failing PDS registration count validation.
+
+      These practices require investigation before use in analyses.
+
+      Validation: ≥2% variance AND ≥5 persons difference
+      Methodology: PDS All Registration Types Comparison
+      Includes: validation_methodology column and issue_category (2-5%, 5-20%, 20%+)
+
+  - name: pds_olids_reg_comparison_all_direct_care
+    description: |
+      Complete PDS registration comparison for all practices with categorisation.
+
+      Categories: Major Difference (≥20%), Minor Difference (5-20%), Good Match (<5%), No Data
+
+      Methodology: PDS All Registration Types Comparison using merged NHS numbers
+
+  - name: emis_olids_reg_pass_direct_care
+    description: |
+      Practices passing EMIS Regular registration count validation.
+
+      Use this for inner joins to filter datasets to practices with validated Regular registration data.
+
+      Validation: <2% variance OR <5 persons difference
+      Snapshot: Dynamic (from EMIS extract date)
+      Registration Type: Regular only (excludes Temporary, Emergency, etc.)
+
+  - name: emis_olids_reg_fail_direct_care
+    description: |
+      Practices failing EMIS Regular registration count validation.
+
+      These practices require investigation before use in analyses.
+
+      Issue Categories: 2-5% Variance, 5-20% Variance, 20%+ Variance, Missing Data
+
+      Validation: ≥2% variance AND ≥5 persons difference
+      Snapshot: Dynamic (from EMIS extract date)
+      Registration Type: Regular only
+
+  - name: emis_olids_reg_comparison_all_direct_care
+    description: |
+      Complete EMIS Regular registration comparison for all practices using acceptance criteria.
+
+      Categories: Meets Criteria, 2-5% Variance, 5-20% Variance, 20%+ Variance, Missing Data
+
+      Acceptance Criteria:
+      - Aggregate: <1% variance across all practices
+      - Per-practice: <2% variance OR <5 persons difference
+
+      Snapshot: Dynamic (from EMIS extract date)
+      Registration Type: Regular only
+
+  - name: emis_olids_reg_aggregate_validation_direct_care
+    description: |
+      Aggregate-level validation of OLIDS Regular registrations against EMIS list size.
+
+      Returns a single row showing whether the overall system meets the <1% variance acceptance criteria.
+
+      Acceptance Criteria: <1% variance in aggregate across all practices
+      Snapshot: Dynamic (from EMIS extract date)

--- a/models/published/direct_care/olids/db_utils/pds_olids_reg_comparison_all_direct_care.sql
+++ b/models/published/direct_care/olids/db_utils/pds_olids_reg_comparison_all_direct_care.sql
@@ -1,0 +1,56 @@
+{{
+    config(
+        materialized='table',
+        alias='pds_olids_reg_comparison_all',
+        tags=['data_quality', 'published', 'direct_care']
+    )
+}}
+
+/*
+PDS/OLIDS Practice Registration Comparison - All Practices (Direct Care)
+
+Complete comparison of all practices with categorized discrepancies.
+Uses registration episode filtering and PDS merger handling.
+
+Categories:
+- Major Difference: >=20% discrepancy
+- Minor Difference: 5-20% discrepancy
+- Good Match: <5% discrepancy
+- No Data: Missing PDS or OLIDS data
+
+Use Cases:
+- Comprehensive data quality monitoring
+- Practice-level completeness assessment
+- Trend analysis over time
+- Monthly reporting
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__DIRECT_CARE.OLIDS_PUBLISHED schema
+- Table alias: pds_olids_practice_comparison_all
+- Filter by match_category for different views
+- pds_patient_count is the merged count (accounts for NHS number changes)
+*/
+
+select
+    practice_code,
+    practice_name,
+    pds_merged_persons as pds_patient_count,
+    olids_patient_count,
+    difference,
+    percent_difference,
+    case
+        when abs(percent_difference) >= 20 then 'Major Difference'
+        when abs(percent_difference) >= 5 then 'Minor Difference'
+        when percent_difference is not null then 'Good Match'
+        else 'No Data'
+    end as match_category
+from {{ ref('int_pds_olids_practice_registration_comparison') }}
+order by
+    case
+        when abs(coalesce(percent_difference, 0)) >= 20 then 1
+        when abs(coalesce(percent_difference, 0)) >= 5 then 2
+        when percent_difference is not null then 3
+        else 4
+    end,
+    abs(coalesce(percent_difference, 0)) desc,
+    practice_code

--- a/models/published/direct_care/olids/db_utils/pds_olids_reg_fail_direct_care.sql
+++ b/models/published/direct_care/olids/db_utils/pds_olids_reg_fail_direct_care.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='table',
+        alias='pds_olids_reg_fail',
+        tags=['data_quality', 'published', 'direct_care']
+    )
+}}
+
+/*
+PDS/OLIDS Unvalidated Practices (Direct Care)
+
+Practices with >=20% discrepancy between PDS and OLIDS registration counts.
+These practices require investigation before use in analyses.
+
+Validation Threshold: >=20% difference between PDS merged persons and OLIDS patients
+Methodology: PDS comparison using merged NHS numbers, registration episode filtering
+
+Use Cases:
+- Identifying practices requiring data quality investigation
+- Monthly data quality reports
+- Monitoring completeness of OLIDS coverage
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__DIRECT_CARE.OLIDS_PUBLISHED schema
+- Table alias: pds_olids_practices_unvalidated
+- Review regularly to identify practices needing attention
+*/
+
+select
+    practice_code,
+    practice_name,
+    pds_merged_persons as pds_patient_count,
+    olids_patient_count,
+    difference,
+    absolute_difference,
+    percent_difference,
+    absolute_percent_difference,
+    validation_methodology,
+    case
+        when absolute_percent_difference >= 20 then '20%+ Variance'
+        when absolute_percent_difference >= 5 then '5-20% Variance'
+        else '2-5% Variance'
+    end as issue_category
+from {{ ref('int_pds_olids_practice_registration_comparison') }}
+where meets_acceptance_criteria = false
+order by absolute_percent_difference desc

--- a/models/published/direct_care/olids/db_utils/pds_olids_reg_pass_direct_care.sql
+++ b/models/published/direct_care/olids/db_utils/pds_olids_reg_pass_direct_care.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='table',
+        alias='pds_olids_reg_pass',
+        tags=['data_quality', 'published', 'direct_care']
+    )
+}}
+
+/*
+PDS/OLIDS Validated Practices (Direct Care)
+
+Practices with <20% discrepancy between PDS and OLIDS registration counts.
+Use this table for inner joins to filter datasets to practices with validated registration data.
+
+Validation Threshold: <20% difference between PDS merged persons and OLIDS patients
+Methodology: PDS comparison using merged NHS numbers, registration episode filtering
+
+Use Cases:
+- Filter analyses to practices with reliable registration data
+- Inner join to exclude practices with data quality issues
+- Quality assurance dashboards
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__DIRECT_CARE.OLIDS_PUBLISHED schema
+- Table alias: pds_olids_practices_validated
+- Join on practice_code to filter to validated practices only
+*/
+
+select
+    practice_code,
+    practice_name,
+    pds_merged_persons as pds_patient_count,
+    olids_patient_count,
+    difference,
+    absolute_difference,
+    percent_difference,
+    absolute_percent_difference,
+    validation_methodology,
+    case
+        when absolute_percent_difference < 1 then 'Excellent Match (<1%)'
+        when absolute_percent_difference < 2 or absolute_difference < 5 then 'Meets Criteria'
+        else 'Good Match'
+    end as match_quality
+from {{ ref('int_pds_olids_practice_registration_comparison') }}
+where meets_acceptance_criteria = true
+order by absolute_percent_difference desc

--- a/models/published/direct_care/olids/db_utils/practices_with_significant_registration_differences_direct_care.sql
+++ b/models/published/direct_care/olids/db_utils/practices_with_significant_registration_differences_direct_care.sql
@@ -7,6 +7,18 @@
 }}
 
 /*
+DEPRECATED: This model is deprecated and will be removed in a future release.
+
+Please use the new models instead:
+- pds_olids_practices_validated: practices passing validation (<20% discrepancy)
+- pds_olids_practices_unvalidated: practices failing validation (>=20% discrepancy)
+- pds_olids_practice_comparison_all: all practices with categorization
+
+The new models use table materialization for better performance and follow
+inverted logic (validated/unvalidated) for easier filtering.
+
+---
+
 PDS/OLIDS Practice Registration Discrepancies - Suspect Practices (Direct Care)
 
 Shows practices with major discrepancies (>=20%) between PDS and OLIDS registration counts.

--- a/models/published/secondary_use/olids/db_utils/olids_practice_registration_comparisons_secondary_use.yml
+++ b/models/published/secondary_use/olids/db_utils/olids_practice_registration_comparisons_secondary_use.yml
@@ -1,0 +1,36 @@
+version: 2
+
+models:
+  - name: pds_olids_reg_pass_secondary_use
+    description: |
+      Practices passing PDS registration count validation (Secondary Use).
+
+      Use this for inner joins to filter datasets to practices with validated registration data.
+      PDS models support opt-out filtering via sk_patient_id.
+
+      Validation: <2% variance OR <5 persons difference (same threshold as EMIS)
+      Methodology: PDS All Registration Types Comparison
+      Includes: validation_methodology column describing the test
+
+  - name: pds_olids_reg_fail_secondary_use
+    description: |
+      Practices failing PDS registration count validation (Secondary Use).
+
+      These practices require investigation before use in analyses.
+      PDS models support opt-out filtering via sk_patient_id.
+
+      Validation: ≥2% variance AND ≥5 persons difference
+      Methodology: PDS All Registration Types Comparison
+      Includes: validation_methodology column and issue_category (2-5%, 5-20%, 20%+)
+
+  - name: pds_olids_reg_comparison_all_secondary_use
+    description: |
+      Complete PDS registration comparison for all practices with categorisation (Secondary Use).
+
+      Categories: Major Difference (≥20%), Minor Difference (5-20%), Good Match (<5%), No Data
+      PDS models support opt-out filtering via sk_patient_id.
+
+      Methodology: PDS All Registration Types Comparison using merged NHS numbers
+
+      Note: EMIS comparisons are NOT available in secondary_use layer as EMIS data
+      cannot be joined to opt-out tables (no sk_patient_id).

--- a/models/published/secondary_use/olids/db_utils/pds_olids_practice_discrepancies_secondary_use.sql
+++ b/models/published/secondary_use/olids/db_utils/pds_olids_practice_discrepancies_secondary_use.sql
@@ -7,6 +7,18 @@
 }}
 
 /*
+DEPRECATED: This model is deprecated and will be removed in a future release.
+
+Please use the new models instead:
+- pds_olids_practices_validated: practices passing validation (<20% discrepancy)
+- pds_olids_practices_unvalidated: practices failing validation (>=20% discrepancy)
+- pds_olids_practice_comparison_all: all practices with categorization
+
+The new models use table materialization for better performance and follow
+inverted logic (validated/unvalidated) for easier filtering.
+
+---
+
 PDS/OLIDS Practice Registration Discrepancies - Suspect Practices (Secondary Use)
 
 Shows practices with major discrepancies (>=20%) between PDS and OLIDS registration counts.

--- a/models/published/secondary_use/olids/db_utils/pds_olids_reg_comparison_all_secondary_use.sql
+++ b/models/published/secondary_use/olids/db_utils/pds_olids_reg_comparison_all_secondary_use.sql
@@ -1,0 +1,56 @@
+{{
+    config(
+        materialized='table',
+        alias='pds_olids_reg_comparison_all',
+        tags=['data_quality', 'published', 'secondary_use']
+    )
+}}
+
+/*
+PDS/OLIDS Practice Registration Comparison - All Practices (Secondary Use)
+
+Complete comparison of all practices with categorized discrepancies.
+Uses registration episode filtering and PDS merger handling.
+
+Categories:
+- Major Difference: >=20% discrepancy
+- Minor Difference: 5-20% discrepancy
+- Good Match: <5% discrepancy
+- No Data: Missing PDS or OLIDS data
+
+Use Cases:
+- Comprehensive data quality monitoring
+- Practice-level completeness assessment
+- Trend analysis over time
+- Monthly reporting
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__SECONDARY_USE.OLIDS_PUBLISHED schema
+- Table alias: pds_olids_practice_comparison_all
+- Filter by match_category for different views
+- pds_patient_count is the merged count (accounts for NHS number changes)
+*/
+
+select
+    practice_code,
+    practice_name,
+    pds_merged_persons as pds_patient_count,
+    olids_patient_count,
+    difference,
+    percent_difference,
+    case
+        when abs(percent_difference) >= 20 then 'Major Difference'
+        when abs(percent_difference) >= 5 then 'Minor Difference'
+        when percent_difference is not null then 'Good Match'
+        else 'No Data'
+    end as match_category
+from {{ ref('int_pds_olids_practice_registration_comparison') }}
+order by
+    case
+        when abs(coalesce(percent_difference, 0)) >= 20 then 1
+        when abs(coalesce(percent_difference, 0)) >= 5 then 2
+        when percent_difference is not null then 3
+        else 4
+    end,
+    abs(coalesce(percent_difference, 0)) desc,
+    practice_code

--- a/models/published/secondary_use/olids/db_utils/pds_olids_reg_fail_secondary_use.sql
+++ b/models/published/secondary_use/olids/db_utils/pds_olids_reg_fail_secondary_use.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='table',
+        alias='pds_olids_reg_fail',
+        tags=['data_quality', 'published', 'secondary_use']
+    )
+}}
+
+/*
+PDS/OLIDS Unvalidated Practices (Secondary Use)
+
+Practices with >=20% discrepancy between PDS and OLIDS registration counts.
+These practices require investigation before use in analyses.
+
+Validation Threshold: >=20% difference between PDS merged persons and OLIDS patients
+Methodology: PDS comparison using merged NHS numbers, registration episode filtering
+
+Use Cases:
+- Identifying practices requiring data quality investigation
+- Monthly data quality reports
+- Monitoring completeness of OLIDS coverage
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__SECONDARY_USE.OLIDS_PUBLISHED schema
+- Table alias: pds_olids_practices_unvalidated
+- Review regularly to identify practices needing attention
+*/
+
+select
+    practice_code,
+    practice_name,
+    pds_merged_persons as pds_patient_count,
+    olids_patient_count,
+    difference,
+    absolute_difference,
+    percent_difference,
+    absolute_percent_difference,
+    validation_methodology,
+    case
+        when absolute_percent_difference >= 20 then '20%+ Variance'
+        when absolute_percent_difference >= 5 then '5-20% Variance'
+        else '2-5% Variance'
+    end as issue_category
+from {{ ref('int_pds_olids_practice_registration_comparison') }}
+where meets_acceptance_criteria = false
+order by absolute_percent_difference desc

--- a/models/published/secondary_use/olids/db_utils/pds_olids_reg_pass_secondary_use.sql
+++ b/models/published/secondary_use/olids/db_utils/pds_olids_reg_pass_secondary_use.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='table',
+        alias='pds_olids_reg_pass',
+        tags=['data_quality', 'published', 'secondary_use']
+    )
+}}
+
+/*
+PDS/OLIDS Validated Practices (Secondary Use)
+
+Practices with <20% discrepancy between PDS and OLIDS registration counts.
+Use this table for inner joins to filter datasets to practices with validated registration data.
+
+Validation Threshold: <20% difference between PDS merged persons and OLIDS patients
+Methodology: PDS comparison using merged NHS numbers, registration episode filtering
+
+Use Cases:
+- Filter analyses to practices with reliable registration data
+- Inner join to exclude practices with data quality issues
+- Quality assurance dashboards
+
+PowerBI Usage:
+- Connect to PUBLISHED_REPORTING__SECONDARY_USE.OLIDS_PUBLISHED schema
+- Table alias: pds_olids_practices_validated
+- Join on practice_code to filter to validated practices only
+*/
+
+select
+    practice_code,
+    practice_name,
+    pds_merged_persons as pds_patient_count,
+    olids_patient_count,
+    difference,
+    absolute_difference,
+    percent_difference,
+    absolute_percent_difference,
+    validation_methodology,
+    case
+        when absolute_percent_difference < 1 then 'Excellent Match (<1%)'
+        when absolute_percent_difference < 2 or absolute_difference < 5 then 'Meets Criteria'
+        else 'Good Match'
+    end as match_quality
+from {{ ref('int_pds_olids_practice_registration_comparison') }}
+where meets_acceptance_criteria = true
+order by absolute_percent_difference desc

--- a/models/staging/emis/stg_emis_list_size.sql
+++ b/models/staging/emis/stg_emis_list_size.sql
@@ -1,0 +1,29 @@
+{{
+    config(
+        materialized='view',
+        tags=['staging', 'emis', 'reference']
+    )
+}}
+
+/*
+EMIS List Size - Staging
+
+Stages EMIS list size reference data with proper date type conversion.
+Source: emis_list_size seed file
+Extract Date: 04/11/2025
+
+Data Quality Notes:
+- Converts EXTRACT_DATE from VARCHAR to DATE
+- Standardizes column naming to lowercase
+- Used as reference data for OLIDS validation
+*/
+
+select
+    BOROUGH as borough,
+    CODE as practice_code,
+    GP_PRACTICE as practice_name,
+    LIST_SIZE as list_size,
+    TO_DATE(EXTRACT_DATE, 'DD/MM/YYYY') as extract_date
+
+from {{ ref('emis_list_size') }}
+where EXTRACT_DATE is not null

--- a/models/staging/emis/stg_emis_list_size.yml
+++ b/models/staging/emis/stg_emis_list_size.yml
@@ -1,0 +1,30 @@
+version: 2
+
+models:
+  - name: stg_emis_list_size
+    description: |
+      EMIS list size reference data with proper date type conversion.
+
+      Source: emis_list_size seed file
+      Extract Date: Dynamic (from seed file)
+
+      Converts EXTRACT_DATE from VARCHAR to DATE and standardises column naming.
+      Used as reference data for OLIDS Regular registration validation.
+
+      To update: Replace seed file with new EMIS extract and re-run models.
+
+    columns:
+      - name: borough
+        description: Borough name (e.g., Barnet, Camden, Enfield, Haringey, Islington)
+
+      - name: practice_code
+        description: GP practice ODS code
+
+      - name: practice_name
+        description: GP practice name
+
+      - name: list_size
+        description: Number of registered patients according to EMIS extract
+
+      - name: extract_date
+        description: Date the EMIS data was extracted, converted from DD/MM/YYYY VARCHAR to DATE

--- a/seeds/emis_list_size.csv
+++ b/seeds/emis_list_size.csv
@@ -1,0 +1,176 @@
+BOROUGH,CODE,GP_PRACTICE,LIST_SIZE,EXTRACT_DATE
+Barnet,E83038,Jai Medical Centre,9091,04/11/2025
+Barnet,E83041,Wakemans Hill Surgery,4661,04/11/2025
+Barnet,E83637,Colindale Medical centre,12478,04/11/2025
+Barnet,Y03663,Hendon Way Surgery,9694,04/11/2025
+Barnet,E83011,The Everglade Medical Practice,11228,04/11/2025
+Barnet,E83018,Watling Medical Centre,18248,04/11/2025
+Barnet,E83028,Parkview Surgery,6236,04/11/2025
+Barnet,E83668,Deans Lane Medical Centre,4022,04/11/2025
+Barnet,E83003,The Clinic (Oakleigh Rd North),10489,04/11/2025
+Barnet,E83010,The Speedwell Practice,13091,04/11/2025
+Barnet,E83021,Torrington Park Group Practice,12516,04/11/2025
+Barnet,E83024,St Andrews Medical Practice,11247,04/11/2025
+Barnet,E83031,The Village Surgery,6230,04/11/2025
+Barnet,E83034,Colney Hatch Lane Surgery,5112,04/11/2025
+Barnet,E83045,Friern Barnet Medical Centre,9766,04/11/2025
+Barnet,E83050,East Finchley Medical Practice,7461,04/11/2025
+Barnet,E83613,East Barnet HC (Monkman),11313,04/11/2025
+Barnet,E83621,Brunswick Park Medical Practice,9401,04/11/2025
+Barnet,E83639,Rosemary Surgery,6214,04/11/2025
+Barnet,Y00316,Woodlands Medical Practice,5747,04/11/2025
+Barnet,E83005,Lichfield Grove Surgery,6110,04/11/2025
+Barnet,E83007,Squires Lane Medical Practice,5145,04/11/2025
+Barnet,E83012,The Old Courthouse Surgery,10261,04/11/2025
+Barnet,E83013,Cornwall House Surgery,5478,04/11/2025
+Barnet,E83017,Longrove Surgery,17507,04/11/2025
+Barnet,E83035,Wentworth Medical Practice,18162,04/11/2025
+Barnet,E83044,Addington Medical Centre,9978,04/11/2025
+Barnet,E83016,Millway Medical Practice,24809,04/11/2025
+Barnet,E83030,Penshurst Gardens,7521,04/11/2025
+Barnet,E83049,Langstone Way Surgery,7395,04/11/2025
+Barnet,E83053,Lane End Medical Group,14819,04/11/2025
+Barnet,E83006,Greenfield Medical Centre,6996,04/11/2025
+Barnet,E83020,St Georges Medical Centre,11982,04/11/2025
+Barnet,E83025,Pennine Drive Surgery,7865,04/11/2025
+Barnet,E83039,Ravenscroft Medical Centre,5702,04/11/2025
+Barnet,E83653,Phoenix Practice,12203,04/11/2025
+Barnet,Y03664,Dr Azim & Partners,8282,04/11/2025
+Barnet,E83008,Heathfielde,8291,04/11/2025
+Barnet,E83009,PHGH Doctors,12899,04/11/2025
+Barnet,E83026,Supreme Medical Centre,3894,04/11/2025
+Barnet,E83027,The Practice @ 188,10728,04/11/2025
+Barnet,E83600,Adler & Rosenberg (682 Finchley Road),7787,04/11/2025
+Barnet,E83622,Temple Fortune Health Centre,9471,04/11/2025
+Barnet,E83638,Mountfield Surgery,5203,04/11/2025
+Barnet,E83649,Hodford Road Surgery,4482,04/11/2025
+Barnet,Y02986,Cricklewood Health Centre,5177,04/11/2025
+Barnet,E83032,Oak Lodge Medical Centre,17643,04/11/2025
+Barnet,E83046,Mulberry Medical Practice,8200,04/11/2025
+Camden,F83006,Ampthill Practice,15949,04/11/2025
+Camden,F83043,Ridgmount Practice ,17546,04/11/2025
+Camden,F83044,Bloomsbury Surgery,9228,04/11/2025
+Camden,F83048,Brunswick Medical Centre,9325,04/11/2025
+Camden,F83635,Kings Cross  Surgery,8717,04/11/2025
+Camden,F83665,Swiss Cottage Surgery,17156,04/11/2025
+Camden,F83683,Somers Town Medical Centre,5982,04/11/2025
+Camden,Y02674,Camden Health Improvement Practice (CHIP),521,04/11/2025
+Camden,F83011,Primrose Hill Surgery,8906,04/11/2025
+Camden,F83042,Grays Inn Road Medical Centre,8835,04/11/2025
+Camden,F83050,Fortune Green Practice,3568,04/11/2025
+Camden,F83615,Cholmley Gardens Medical Practice,8179,04/11/2025
+Camden,F83633,Daleham Gardens Health Centre,5087,04/11/2025
+Camden,F83658,Belsize Priory Medical Practice,6490,04/11/2025
+Camden,F83018,Prince of Wales Group Practice,8259,04/11/2025
+Camden,F83022,Caversham Group Practice,17087,04/11/2025
+Camden,F83057,Parliament Hill Surgery,8552,04/11/2025
+Camden,F83023,James Wigg Practice,25103,04/11/2025
+Camden,F83632,Queens Crescent Surgery,6706,04/11/2025
+Camden,F83003,Park End Surgery,7741,04/11/2025
+Camden,F83017,Hampstead Group Practice,17809,04/11/2025
+Camden,F83020,Adelaide Medical Centre,11687,04/11/2025
+Camden,F83052,Brookfield Park Surgery,3955,04/11/2025
+Camden,F83623,The Keats Group Practice,13463,04/11/2025
+Camden,F83058,Holborn Medical Centre,11273,04/11/2025
+Camden,F83061,The Museum Practice,5800,04/11/2025
+Camden,F83672,St Philips Medical Centre,16536,04/11/2025
+Camden,F83005,Gower Street Practice,22211,04/11/2025
+Camden,F83059,Brondesbury Medical Centre,23467,04/11/2025
+Camden,F83019,Abbey Medical Centre,13707,04/11/2025
+Camden,F83055,West Hampstead Medical Centre,23171,04/11/2025
+Enfield,F85010,Keats Surgery,4356,04/11/2025
+Enfield,F85663,Latymer Road Surgery,4744,04/11/2025
+Enfield,F85666,Edmonton Medical Centre,3992,04/11/2025
+Enfield,F85676,Boundary House,5666,04/11/2025
+Enfield,Y00057,Angel Surgery,15577,04/11/2025
+Enfield,F85023,Ordnance Unity Centre for Health,12407,04/11/2025
+Enfield,F85025,White Lodge Medical Practice,15102,04/11/2025
+Enfield,F85039,Rainbow Surgery,7244,04/11/2025
+Enfield,F85072,Grovelands & Grenoble Gardens,9563,04/11/2025
+Enfield,F85634,East Enfield Surgery,9307,04/11/2025
+Enfield,F85682,Chalfont Surgery,6140,04/11/2025
+Enfield,Y03402,Evergreen Surgery,19061,04/11/2025
+Enfield,F85020,The Woodberry Practice,10111,04/11/2025
+Enfield,F85625,Bincote Surgery,6856,04/11/2025
+Enfield,F85642,North London Health Centre,9185,04/11/2025
+Enfield,F85650,Morecambe Surgery,5999,04/11/2025
+Enfield,F85700,Arnos Grove Medical Centre,8035,04/11/2025
+Enfield,F85701,Gillan House Surgery,12711,04/11/2025
+Enfield,F85002,Medicus Health Partners,94295,04/11/2025
+Enfield,F85004,Eagle House Surgery,12593,04/11/2025
+Enfield,F85016,Cockfosters Medical Centre,6971,04/11/2025
+Enfield,F85032,Southgate,8890,04/11/2025
+Enfield,F85035,Highlands Practice,11782,04/11/2025
+Enfield,F85044,Bounces Road Surgery,7063,04/11/2025
+Enfield,F85058,Nightingale House Surgery,6121,04/11/2025
+Enfield,F85687,Oakwood Medical Centre,8545,04/11/2025
+Enfield,Y00612,Green Cedars,4689,04/11/2025
+Enfield,F85029,Abernethy House,11959,04/11/2025
+Enfield,F85033,Winchmore Hill Practice,20767,04/11/2025
+Enfield,F85678,Town Surgery,4255,04/11/2025
+Haringey,F85008,Staunton Group Practice,11706,04/11/2025
+Haringey,F85046,The Surgery (Hornsey Park Surgery),10953,04/11/2025
+Haringey,F85669,West Green Road Surgery,24087,04/11/2025
+Haringey,F85697,The Old Surgery,1764,04/11/2025
+Haringey,Y03135,Bridge House,9172,04/11/2025
+Haringey,F85060,Havergal Surgery,5420,04/11/2025
+Haringey,F85623,The Surgery (Grove Road),4691,04/11/2025
+Haringey,F85705,JS Medical Practice ,13426,04/11/2025
+Haringey,Y02117,St Anns Road Surgery,14334,04/11/2025
+Haringey,F85034,Arcadian Gardens NHS Medical Centre,8640,04/11/2025
+Haringey,F85064,The High Rd Surgery,7780,04/11/2025
+Haringey,F85065,Stuart Crescent Health Centre,3237,04/11/2025
+Haringey,F85066,Bounds Green Group Practice,19251,04/11/2025
+Haringey,F85640,Cheshire Road Surgery,6498,04/11/2025
+Haringey,F85675,The Alexandra Surgery,5791,04/11/2025
+Haringey,F85017,Charlton House Medical Centre,6483,04/11/2025
+Haringey,F85019,The Morris House Medical Practice,14877,04/11/2025
+Haringey,F85028,Bruce Grove Primary Care Health Centre,6933,04/11/2025
+Haringey,F85030,Somerset Gardens Family Health Care,13229,04/11/2025
+Haringey,F85031,Westbury Medical Centre (Steinberg/Kirilov),12644,04/11/2025
+Haringey,F85014,Highgate Group Practice,16443,04/11/2025
+Haringey,F85063,The Muswell Hill Practice,17700,04/11/2025
+Haringey,F85688,Rutland House Surgery,10677,04/11/2025
+Haringey,Y01655,The Vale Practice,9976,04/11/2025
+Haringey,F85061,The Christchurch Hall Surgery,2870,04/11/2025
+Haringey,F85067,The 157 Medical Practice,4362,04/11/2025
+Haringey,F85069,Crouch Hall Road Surgery,8697,04/11/2025
+Haringey,Y03035,Queenswood Medical Practice,21720,04/11/2025
+Haringey,F85007,Lawrence House (Dr Rohan),16212,04/11/2025
+Haringey,F85013,Tynemouth Road Health Centre,9163,04/11/2025
+Haringey,F85071,Fernlea Surgery,12505,04/11/2025
+Haringey,F85615,Tottenham Health Centre,5925,04/11/2025
+Haringey,F85628,The Surgery (Dowsett road surgery ),9416,04/11/2025
+Haringey,Y05330,Tottenham Hale Medical Centre,4680,04/11/2025
+Islington,Y03103,Medicus Select Care (SAS),0,04/11/2025
+Islington,F83008,Goodinge Group Practice  ,12582,04/11/2025
+Islington,F83004,Archway Primary Care Team,32333,04/11/2025
+Islington,F83039,The Rise Group Practice,4751,04/11/2025
+Islington,F83666,The Andover Medical Centre,6874,04/11/2025
+Islington,F83671,The Beaumont Practice,3319,04/11/2025
+Islington,F83674,The Junction Medical Practice,9103,04/11/2025
+Islington,F83686,Stroud Green Medical Clinic,10613,04/11/2025
+Islington,Y01066,Hanley Primary Care Centre,8551,04/11/2025
+Islington,F83002,The Group Practice at River Place,10976,04/11/2025
+Islington,F83012,Elizabeth Avenue Group Practice,7627,04/11/2025
+Islington,F83032,St Peter's Street Medical Practice,12055,04/11/2025
+Islington,F83034,New North Health Centre,1475,04/11/2025
+Islington,F83045,The Miller Practice ,9149,04/11/2025
+Islington,F83021,Ritchie Street Group Practice,16930,04/11/2025
+Islington,F83033,Barnsbury Medical Practice,6601,04/11/2025
+Islington,F83063,Killick Street Health Centre,14054,04/11/2025
+Islington,F83064,City Road Medical Centre,9614,04/11/2025
+Islington,F83624,Clerkenwell Medical Practice,17403,04/11/2025
+Islington,F83652,Amwell Group Practice,11790,04/11/2025
+Islington,F83678,Pine Street Medical Practice,2124,04/11/2025
+Islington,F83015,St John's Way Medical Centre,13085,04/11/2025
+Islington,F83060,The Northern Medical Centre,7201,04/11/2025
+Islington,F83664,The Village Practice,12856,04/11/2025
+Islington,F83681,Partnership Primary Care Centre,8868,04/11/2025
+Islington,F83007,Roman Way Medical Centre,3634,04/11/2025
+Islington,F83010,Islington Central Medical Centre,22637,04/11/2025
+Islington,F83053,Mildmay Medical Practice,8050,04/11/2025
+Islington,F83056,Mitchison Road Surgery,10191,04/11/2025
+Islington,F83660,Highbury Grange Medical Practice,9151,04/11/2025
+Islington,F83673,The Medical Centre,6505,04/11/2025
+Islington,F83680,Sobell Medical Centre,4949,04/11/2025


### PR DESCRIPTION
Add EMIS comparison methodology alongside existing PDS approach, standardising acceptance criteria across both methodologies.

Changes:
- Add EMIS comparison using Regular episode types at fixed point in time
- Standardise acceptance criteria: <2% variance OR <5 persons difference
- Add aggregate validation for EMIS (<1% threshold across all practices)
- Rename models for clarity: practice_registration -> reg, validated -> pass/fail
- Add validation_methodology column describing test criteria
- Remove EMIS models from secondary_use (cannot support opt-out filtering)
- Implement dynamic snapshot date from EMIS seed file
- Deprecate legacy models using 20% threshold

Model counts:
- 1 staging model (EMIS seed with date conversion)
- 3 intermediate models (OLIDS Regular regs, EMIS comparison, aggregate validation)
- 10 published models (7 direct_care, 3 secondary_use)
- 6 yml documentation files

Breaking changes:
- PDS models now use 2%/5 persons threshold instead of 20%
- Legacy has_significant_discrepancy flag kept for backwards compatibility