### PR TITLE
test(polypharmacy): add not-empty data tests to intermediate models

### DIFF
--- a/models/modelling/olids/medications/int_polypharmacy_current.yml
+++ b/models/modelling/olids/medications/int_polypharmacy_current.yml
@@ -69,3 +69,6 @@ models:
         description: Earliest order date among current medications
         data_tests:
           - not_null
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id

--- a/models/modelling/olids/medications/int_polypharmacy_history.yml
+++ b/models/modelling/olids/medications/int_polypharmacy_history.yml
@@ -82,3 +82,6 @@ models:
           - not_null
           - dbt_utils.expression_is_true:
               expression: ">= 0"
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id

--- a/models/modelling/olids/medications/int_polypharmacy_medications_current.yml
+++ b/models/modelling/olids/medications/int_polypharmacy_medications_current.yml
@@ -53,3 +53,6 @@ models:
 
       - name: latest_duration
         description: Duration in days for most recent order
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id

--- a/models/modelling/olids/medications/int_polypharmacy_medications_list.yml
+++ b/models/modelling/olids/medications/int_polypharmacy_medications_list.yml
@@ -55,3 +55,6 @@ models:
 
       - name: bnf_name
         description: BNF name/description of the medication
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: snomed_code


### PR DESCRIPTION
## Summary
- Add `dbt_utils.at_least_one` tests to polypharmacy intermediate models to ensure tables are not empty
- Tests added to: `int_polypharmacy_current`, `int_polypharmacy_history`, `int_polypharmacy_medications_current`, `int_polypharmacy_medications_list`
