### PR TITLE
feat: add snowflake native profiles.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # dbt
 target/
 profiles.yml
+!.snowflake/profiles.yml
 logs/
 package-lock.yml
 dbt_internal_packages/

--- a/.snowflake/profiles.yml
+++ b/.snowflake/profiles.yml
@@ -1,0 +1,24 @@
+ncl_analytics:
+  target: dev
+  outputs:
+    dev:
+      type: snowflake
+      account: ''  # Empty for native execution
+      user: ''     # Empty for native execution
+      role: 'DBT_ADMIN'     # Role for snowflake native
+      database: MODELLING  # Base database name - your macro will prepend DEV__
+      schema: DBT_DEV     # Default schema (rarely used due to custom schemas)
+      warehouse: NCL_ANALYTICS_M
+      threads: 16
+      client_session_keep_alive: false
+
+    prod:
+      type: snowflake
+      account: ''  # Empty for native execution
+      user: ''     # Empty for native execution
+      role: 'DBT_ADMIN'     # Empty for native execution
+      database: MODELLING  # Base database name - no prefix for prod
+      schema: DBT_PROD    # Default schema (rarely used due to custom schemas)
+      warehouse: NCL_ANALYTICS_M
+      threads: 16
+      client_session_keep_alive: false


### PR DESCRIPTION
## Summary
- Adds `.snowflake/profiles.yml` for Snowflake native dbt execution
- Updates `.gitignore` to track this file while keeping root `profiles.yml` ignored
- Separates Snowflake native config from local dev profiles

## Notes
Snowflake tasks in `setup.sql` (Snowflake-Deployment repo) have been updated to use `--profiles-dir .snowflake`.