### PR TITLE
fix: add default values to env_var calls for Snowflake native parsing

### DIFF
--- a/profiles.yml
+++ b/profiles.yml
@@ -12,26 +12,26 @@ ncl_analytics:
   outputs:
     dev:
       type: snowflake
-      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
-      user: "{{ env_var('SNOWFLAKE_USER') }}"
+      account: "{{ env_var('SNOWFLAKE_ACCOUNT', '') }}"
+      user: "{{ env_var('SNOWFLAKE_USER', '') }}"
       authenticator: externalbrowser
       role: "{{ env_var('SNOWFLAKE_ROLE', 'ANALYST') }}"
-      database: "MODELLING"  # Base database for dev environment
-      schema: DBT_DEV  # Dev schema
-      warehouse: "{{ env_var('SNOWFLAKE_WAREHOUSE') }}"
+      database: "MODELLING"
+      schema: DBT_DEV
+      warehouse: "{{ env_var('SNOWFLAKE_WAREHOUSE', '') }}"
       threads: 16
       client_session_keep_alive: true
       query_tag: "dbt_ncl_analytics_dev"
-    
+
     prod:
       type: snowflake
-      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
-      user: "{{ env_var('SNOWFLAKE_USER') }}"
+      account: "{{ env_var('SNOWFLAKE_ACCOUNT', '') }}"
+      user: "{{ env_var('SNOWFLAKE_USER', '') }}"
       authenticator: externalbrowser
       role: "{{ env_var('SNOWFLAKE_ROLE', 'ANALYST') }}"
-      database: "MODELLING"  # Production database
+      database: "MODELLING"
       schema: DBT_PROD
-      warehouse: "{{ env_var('SNOWFLAKE_WAREHOUSE') }}"
+      warehouse: "{{ env_var('SNOWFLAKE_WAREHOUSE', '') }}"
       threads: 16
       client_session_keep_alive: true
       query_tag: "dbt_ncl_analytics_prod"


### PR DESCRIPTION
## Summary
- Add empty string defaults to env_var() calls in ncl_analytics profile
- Prevents parsing errors when Snowflake native dbt reads the entire profiles.yml

## Problem
dbt parses all profiles in profiles.yml, not just the selected one. The `ncl_analytics` profile's env_var() calls without defaults caused errors in Snowflake native execution.