### PR TITLE
fix: handle snowflake targets in generate_database_name macro

### DIFF
--- a/macros/generate_database_name.sql
+++ b/macros/generate_database_name.sql
@@ -16,8 +16,10 @@
         {%- endif -%}
     {%- else -%}
         {#- All other resources use environment-prefixed database names -#}
-        {%- if target.name is none or target.name == "prod" -%}
+        {%- if target.name is none or target.name in ['prod', 'snowflake-prod'] -%}
             {%- set database_prefix = none -%}
+        {%- elif target.name in ['dev', 'snowflake-dev'] -%}
+            {%- set database_prefix = 'DEV' -%}
         {%- else -%}
             {%- set database_prefix = target.name | upper | trim -%}
         {%- endif -%}


### PR DESCRIPTION
## Summary
Update `generate_database_name` macro to handle new Snowflake native targets:
- `snowflake-prod` → no prefix (uses prod database)
- `snowflake-dev` → `DEV__` prefix

## Why
Without this fix, `snowflake-prod` would create `SNOWFLAKE-PROD__MODELLING` instead of `MODELLING`.

## Test plan
- [ ] Verify `--target snowflake-prod` uses `MODELLING` database
- [ ] Verify `--target snowflake-dev` uses `DEV__MODELLING` database