### PR TITLE
docs: add missing model descriptions

### DIFF
--- a/models/modelling/commissioning/administrative/int_commissioning_demographics_at_event.yml
+++ b/models/modelling/commissioning/administrative/int_commissioning_demographics_at_event.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: int_commissioning_demographics_at_event
+    description: Patient demographics captured at time of healthcare event. Combines OP, APC, AE, and waiting list data. One row per person per event.

--- a/models/modelling/commissioning/diagnosis/int_sus_ae_diagnosis.yml
+++ b/models/modelling/commissioning/diagnosis/int_sus_ae_diagnosis.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: int_sus_ae_diagnosis
+    description: A&E diagnoses from SUS with SNOMED codes mapped to ICD-10. One row per diagnosis per A&E attendance.

--- a/models/modelling/olids/geography/_geography.yml
+++ b/models/modelling/olids/geography/_geography.yml
@@ -86,3 +86,5 @@ models:
         description: Flag for areas in most deprived 20% (deciles 1-2)
         tests:
           - not_null
+  - name: int_geography_london_areas
+    description: London area classifications by Local Authority District. One row per LAD with NCL, Other London, and Outside London classification.

--- a/models/modelling/olids/person_attributes/int_opt_out_type_1_all.yml
+++ b/models/modelling/olids/person_attributes/int_opt_out_type_1_all.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: int_opt_out_type_1_all
+    description: Type 1 opt-out observations for dissent from secondary use of primary care data. One row per opt-out event per person.

--- a/models/modelling/olids/programme/flu/int_flu_laiv_vaccination.yml
+++ b/models/modelling/olids/programme/flu/int_flu_laiv_vaccination.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: int_flu_laiv_vaccination
+    description: Persons with LAIV (nasal spray) flu vaccination records. One row per person per campaign with most recent vaccination date.

--- a/models/modelling/olids/programme/flu/int_flu_vaccination_declined.yml
+++ b/models/modelling/olids/programme/flu/int_flu_vaccination_declined.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: int_flu_vaccination_declined
+    description: Persons who declined flu vaccination and have not been vaccinated. One row per person per campaign with most recent decline date.

--- a/models/modelling/olids/programme/flu/int_flu_vaccination_given.yml
+++ b/models/modelling/olids/programme/flu/int_flu_vaccination_given.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: int_flu_vaccination_given
+    description: Persons with flu vaccination records including LAIV. One row per person per campaign with most recent vaccination date.

--- a/models/modelling/olids/utilities/int_practices_missing_from_olids.yml
+++ b/models/modelling/olids/utilities/int_practices_missing_from_olids.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: int_practices_missing_from_olids
+    description: Practices present in reference lookup but with no patients in OLIDS demographics. One row per practice for data quality monitoring.

--- a/models/published/direct_care/C_LTCS/cltcs_ltc_summary.yml
+++ b/models/published/direct_care/C_LTCS/cltcs_ltc_summary.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: cltcs_ltc_summary
+    description: Long-term condition summary for C-LTCS eligible patients. One row per patient per condition.

--- a/models/published/direct_care/C_LTCS/inclusion_cohort.yml
+++ b/models/published/direct_care/C_LTCS/inclusion_cohort.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: inclusion_cohort
-    description: ""
+    description: Patients eligible for C-LTCS based on multimorbidity and outpatient activity. One row per patient with eligibility flag.
     columns:
       - name: patient_id
         data_type: number

--- a/models/published/direct_care/C_LTCS/pcn_info.yml
+++ b/models/published/direct_care/C_LTCS/pcn_info.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: pcn_info
+    description: PCN and practice information for C-LTCS participating PCNs. One row per practice.

--- a/models/published/direct_care/olids/db_utils/practice_registration_comparison_all_direct_care.yml
+++ b/models/published/direct_care/olids/db_utils/practice_registration_comparison_all_direct_care.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: practice_registration_comparison_all_direct_care
+    description: PDS vs OLIDS practice registration comparison for all practices. One row per practice with match category.

--- a/models/published/secondary_use/olids/db_utils/practice_registration_comparison_all_secondary_use.yml
+++ b/models/published/secondary_use/olids/db_utils/practice_registration_comparison_all_secondary_use.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: practice_registration_comparison_all_secondary_use
+    description: PDS vs OLIDS practice registration comparison for all practices (secondary use layer). One row per practice with match category.

--- a/models/reporting/commissioning/person_level/fct_person_sus_ae_recent.yml
+++ b/models/reporting/commissioning/person_level/fct_person_sus_ae_recent.yml
@@ -2,35 +2,35 @@ version: 2
 
 models:
   - name: fct_person_sus_ae_recent
-    description: ""
+    description: Recent A&E attendance counts per patient (12mo rolling). One row per patient with illness, injury, and Type 1 A&E counts.
     columns:
       - name: sk_patient_id
         data_type: varchar
-        description: ""
+        description: Recent A&E attendance counts per patient (12mo rolling). One row per patient with illness, injury, and Type 1 A&E counts.
         tests:
           - not_null
           - unique
 
       - name: ae_ill_12mo
         data_type: number
-        description: ""
+        description: Recent A&E attendance counts per patient (12mo rolling). One row per patient with illness, injury, and Type 1 A&E counts.
 
       - name: ae_ill_3mo
         data_type: number
-        description: ""
+        description: Recent A&E attendance counts per patient (12mo rolling). One row per patient with illness, injury, and Type 1 A&E counts.
 
       - name: ae_ill_1mo
         data_type: number
-        description: ""
+        description: Recent A&E attendance counts per patient (12mo rolling). One row per patient with illness, injury, and Type 1 A&E counts.
 
       - name: ae_tot_12mo
         data_type: number
-        description: ""
+        description: Recent A&E attendance counts per patient (12mo rolling). One row per patient with illness, injury, and Type 1 A&E counts.
 
       - name: ae_inj_12mo
         data_type: number
-        description: ""
+        description: Recent A&E attendance counts per patient (12mo rolling). One row per patient with illness, injury, and Type 1 A&E counts.
 
       - name: ae_t1_12mo
         data_type: number
-        description: ""
+        description: Recent A&E attendance counts per patient (12mo rolling). One row per patient with illness, injury, and Type 1 A&E counts.

--- a/models/reporting/commissioning/person_level/fct_person_sus_ip_recent.yml
+++ b/models/reporting/commissioning/person_level/fct_person_sus_ip_recent.yml
@@ -2,27 +2,27 @@ version: 2
 
 models:
   - name: fct_person_sus_ip_recent
-    description: ""
+    description: Recent inpatient spell counts and length of stay per patient (12mo rolling). One row per patient.
     columns:
       - name: sk_patient_id
         data_type: varchar
-        description: ""
+        description: Recent inpatient spell counts and length of stay per patient (12mo rolling). One row per patient.
         tests:
           - not_null
           - unique
 
       - name: apc_3mo
         data_type: number
-        description: ""
+        description: Recent inpatient spell counts and length of stay per patient (12mo rolling). One row per patient.
 
       - name: apc_1mo
         data_type: number
-        description: ""
+        description: Recent inpatient spell counts and length of stay per patient (12mo rolling). One row per patient.
 
       - name: apc_12mo
         data_type: number
-        description: ""
+        description: Recent inpatient spell counts and length of stay per patient (12mo rolling). One row per patient.
 
       - name: apc_los_12mo
         data_type: number
-        description: ""
+        description: Recent inpatient spell counts and length of stay per patient (12mo rolling). One row per patient.

--- a/models/reporting/commissioning/person_level/fct_person_sus_op_recent.yml
+++ b/models/reporting/commissioning/person_level/fct_person_sus_op_recent.yml
@@ -2,43 +2,43 @@ version: 2
 
 models:
   - name: fct_person_sus_op_recent
-    description: ""
+    description: Recent outpatient appointment counts per patient (12mo rolling). One row per patient with attendance and provider counts.
     columns:
       - name: sk_patient_id
         data_type: varchar
-        description: ""
+        description: Recent outpatient appointment counts per patient (12mo rolling). One row per patient with attendance and provider counts.
         tests:
           - not_null
           - unique
 
       - name: op_att_tot_12mo
         data_type: number
-        description: ""
+        description: Recent outpatient appointment counts per patient (12mo rolling). One row per patient with attendance and provider counts.
 
       - name: op_att_tot_3mo
         data_type: number
-        description: ""
+        description: Recent outpatient appointment counts per patient (12mo rolling). One row per patient with attendance and provider counts.
 
       - name: op_att_tot_1mo
         data_type: number
-        description: ""
+        description: Recent outpatient appointment counts per patient (12mo rolling). One row per patient with attendance and provider counts.
 
       - name: op_att_first_12mo
         data_type: number
-        description: ""
+        description: Recent outpatient appointment counts per patient (12mo rolling). One row per patient with attendance and provider counts.
 
       - name: op_app_tot_12mo
         data_type: number
-        description: ""
+        description: Recent outpatient appointment counts per patient (12mo rolling). One row per patient with attendance and provider counts.
 
       - name: op_spec_12mo
         data_type: number
-        description: ""
+        description: Recent outpatient appointment counts per patient (12mo rolling). One row per patient with attendance and provider counts.
 
       - name: op_prov_12mo
         data_type: number
-        description: ""
+        description: Recent outpatient appointment counts per patient (12mo rolling). One row per patient with attendance and provider counts.
 
       - name: op_num_spec_2_prov_12mo
         data_type: number
-        description: ""
+        description: Recent outpatient appointment counts per patient (12mo rolling). One row per patient with attendance and provider counts.

--- a/models/reporting/olids/person_demographics/dim_person_ethnicity_combi.yml
+++ b/models/reporting/olids/person_demographics/dim_person_ethnicity_combi.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: dim_person_ethnicity_combi
+    description: Latest ethnicity per patient combining GP and event-level records. One row per patient with most recent valid ethnicity.

--- a/models/reporting/olids/person_status/dim_person_opt_out_type_1_status.yml
+++ b/models/reporting/olids/person_status/dim_person_opt_out_type_1_status.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: dim_person_opt_out_type_1_status
+    description: Latest Type 1 opt-out status per person. Only includes persons with active opt-out. One row per person.

--- a/models/reporting/olids/person_status/dim_person_secondary_use_allowed.yml
+++ b/models/reporting/olids/person_status/dim_person_secondary_use_allowed.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: dim_person_secondary_use_allowed
+    description: Persons allowed for secondary use (excludes Type 1 opt-outs). One row per person for use as opt-out filter.

--- a/models/staging/commissioning/stg_reference_ncl_provider.yml
+++ b/models/staging/commissioning/stg_reference_ncl_provider.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: stg_reference_ncl_provider
+    description: NCL provider reference data with provider codes and reporting hierarchies. One row per provider.

--- a/models/staging/commissioning/stg_sus_apc_spell_episodes.yml
+++ b/models/staging/commissioning/stg_sus_apc_spell_episodes.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: stg_sus_apc_spell_episodes
-    description: ""
+    description: Episode-level inpatient data from SUS APC spells. One row per episode per spell, deduplicated by latest transaction date.
     tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:

--- a/models/staging/commissioning/stg_sus_apc_spell_episodes_commissioning_grouping_unbundled_hrg.yml
+++ b/models/staging/commissioning/stg_sus_apc_spell_episodes_commissioning_grouping_unbundled_hrg.yml
@@ -1,6 +1,6 @@
 models:
   - name: stg_sus_apc_spell_episodes_commissioning_grouping_unbundled_hrg
-    description: ""
+    description: Unbundled HRGs for inpatient episodes from SUS APC. One row per unbundled HRG per episode.
     tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:

--- a/models/staging/commissioning/stg_sus_op_appointment_commissioning_grouping_unbundled_hrg.yml
+++ b/models/staging/commissioning/stg_sus_op_appointment_commissioning_grouping_unbundled_hrg.yml
@@ -1,6 +1,6 @@
 models:
   - name: stg_sus_op_appointment_commissioning_grouping_unbundled_hrg
-    description: ""
+    description: Unbundled HRGs for outpatient appointments from SUS OP. One row per unbundled HRG per appointment.
     tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:

--- a/models/staging/shared/stg_dictionary_dbo_diagnosis.yml
+++ b/models/staging/shared/stg_dictionary_dbo_diagnosis.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: stg_dictionary_dbo_diagnosis
+    description: ICD-10 diagnosis code dictionary from data warehouse. One row per diagnosis code.

--- a/models/staging/shared/stg_dictionary_dbo_ethnicity.yml
+++ b/models/staging/shared/stg_dictionary_dbo_ethnicity.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: stg_dictionary_dbo_ethnicity
+    description: Ethnicity code dictionary with HES and NHS codes. One row per ethnicity code.

--- a/models/staging/shared/stg_dictionary_dbo_gender.yml
+++ b/models/staging/shared/stg_dictionary_dbo_gender.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: stg_dictionary_dbo_gender
+    description: Gender code dictionary from data warehouse. One row per gender code.

--- a/models/staging/shared/stg_dictionary_dbo_procedure.yml
+++ b/models/staging/shared/stg_dictionary_dbo_procedure.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: stg_dictionary_dbo_procedure
+    description: OPCS procedure code dictionary from data warehouse. One row per procedure code.


### PR DESCRIPTION
## Summary
- Add descriptions to 27 models that were missing them
- Each description explains what the model does and its grain
- Closes #337

## Test plan
- [x] Run `python scripts/ci/audit_model_descriptions.py` - passes with no missing descriptions