### PR TITLE
fix: run code quality checks on all PRs

### DIFF
--- a/.github/workflows/dbt-code-quality.yml
+++ b/.github/workflows/dbt-code-quality.yml
@@ -3,10 +3,6 @@ name: dbt Code Quality
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'models/**'
-      - 'macros/**'
-      - 'analyses/**'
 
 jobs:
   hardcoded-references:


### PR DESCRIPTION
## Summary
- Removes `paths:` filter so workflow always runs on PRs to main
- Individual jobs skip gracefully when no relevant SQL files changed
- Fixes issue where branch protection blocks PRs due to missing status checks

Jobs will still only run actual checks when models/macros/analyses .sql files change.