### PR TITLE
fix: filter null practice_code in stg_reference_emis_qof_v50_register_counts

### DIFF
--- a/models/staging/shared/stg_reference_emis_qof_v50_register_counts.sql
+++ b/models/staging/shared/stg_reference_emis_qof_v50_register_counts.sql
@@ -7,6 +7,7 @@ with source as (
             or indicator_code = 'DEP1_REG'
             or indicator_code = 'HF1 Register'
         )
+        and cdb is not null
 ),
 
 mapped as (


### PR DESCRIPTION
## Summary

- Filter out rows with null `cdb` (mapped to `practice_code`) in the source CTE

Closes #361

## Test plan

- [x] `dbt build -s stg_reference_emis_qof_v50_register_counts` passes all 7 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)