### PR TITLE
fix: change hx_flake unique test to warning for patient fragmentation

### DIFF
--- a/models/published/direct_care/olids/db_utils/person_pseudo.yml
+++ b/models/published/direct_care/olids/db_utils/person_pseudo.yml
@@ -32,7 +32,9 @@ models:
           - not_null
 
       - name: hx_flake
-        description: 'Pseudonymized hex key in format XX-XXX-XXX for patient re-identification'
+        description: 'Pseudonymized hex key in format XX-XXX-XXX for patient re-identification. Note: Multiple person_ids may share the same hx_flake when they share the same sk_patient_id (patient fragmentation).'
         tests:
           - not_null
-          - unique
+          - unique:
+              severity: warn
+              warn_if: ">100"


### PR DESCRIPTION
## Summary

- Change `hx_flake` unique test from error to warning with threshold `>100`
- Update description to document that multiple person_ids may share the same hx_flake due to patient fragmentation (multiple person_ids mapping to the same sk_patient_id)

Closes #363

## Test plan

- [x] `dbt test -s person_pseudo` passes (240 duplicates now triggers warning instead of error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)