### PR TITLE
fix: handle colons in column names and change OLIDS tests to warnings

### DIFF
--- a/models/raw/shared/raw_reference_model_hospital_theatre_imported.sql
+++ b/models/raw/shared/raw_reference_model_hospital_theatre_imported.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        description="Raw layer (Analyst-managed reference datasets and business rules). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE__NCL.ANALYST_MANAGED.model_hospital_theatre_imported \ndbt: source(''reference_analyst_managed'', ''model_hospital_theatre_imported'') \nColumns:\n  Compartment -> compartment\n  SubCompartment -> sub_compartment\n  Domain -> domain\n  Metric -> metric\n  ProviderCode -> provider_code\n  ProviderName -> provider_name\n  FilterName -> filter_name\n  ReportingDate -> reporting_date\n  ProviderValue -> provider_value\n  MedianValue -> median_value\n  MeanValue -> mean_value\n  BenchmarkValue -> benchmark_value\n  PeerValue -> peer_value\n  PeerMean -> peer_mean\n  MinValue -> min_value\n  MaxValue -> max_value\n  Numerator Description -> numerator_description\n  Num: ProviderValue -> num:_provider_value\n  Num: MedianValue -> num:_median_value\n  Denominator Description -> denominator_description\n  Denom: ProviderValue -> denom:_provider_value\n  Denom: MedianValue -> denom:_median_value"
+        description="Raw layer (Analyst-managed reference datasets and business rules). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE__NCL.ANALYST_MANAGED.model_hospital_theatre_imported \ndbt: source(''reference_analyst_managed'', ''model_hospital_theatre_imported'') \nColumns:\n  Compartment -> compartment\n  SubCompartment -> sub_compartment\n  Domain -> domain\n  Metric -> metric\n  ProviderCode -> provider_code\n  ProviderName -> provider_name\n  FilterName -> filter_name\n  ReportingDate -> reporting_date\n  ProviderValue -> provider_value\n  MedianValue -> median_value\n  MeanValue -> mean_value\n  BenchmarkValue -> benchmark_value\n  PeerValue -> peer_value\n  PeerMean -> peer_mean\n  MinValue -> min_value\n  MaxValue -> max_value\n  Numerator Description -> numerator_description\n  Num: ProviderValue -> num_provider_value\n  Num: MedianValue -> num_median_value\n  Denominator Description -> denominator_description\n  Denom: ProviderValue -> denom_provider_value\n  Denom: MedianValue -> denom_median_value"
     )
 }}
 select
@@ -21,9 +21,9 @@ select
     "MinValue" as min_value,
     "MaxValue" as max_value,
     "Numerator Description" as numerator_description,
-    "Num: ProviderValue" as num:_provider_value,
-    "Num: MedianValue" as num:_median_value,
+    "Num: ProviderValue" as num_provider_value,
+    "Num: MedianValue" as num_median_value,
     "Denominator Description" as denominator_description,
-    "Denom: ProviderValue" as denom:_provider_value,
-    "Denom: MedianValue" as denom:_median_value
+    "Denom: ProviderValue" as denom_provider_value,
+    "Denom: MedianValue" as denom_median_value
 from {{ source('reference_analyst_managed', 'model_hospital_theatre_imported') }}

--- a/models/raw/shared/raw_reference_model_hospital_theatre_imported_upload.sql
+++ b/models/raw/shared/raw_reference_model_hospital_theatre_imported_upload.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        description="Raw layer (Analyst-managed reference datasets and business rules). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE__NCL.ANALYST_MANAGED.model_hospital_theatre_imported_upload \ndbt: source(''reference_analyst_managed'', ''model_hospital_theatre_imported_upload'') \nColumns:\n  Compartment -> compartment\n  SubCompartment -> sub_compartment\n  Domain -> domain\n  Metric -> metric\n  ProviderCode -> provider_code\n  ProviderName -> provider_name\n  FilterName -> filter_name\n  ReportingDate -> reporting_date\n  ProviderValue -> provider_value\n  MedianValue -> median_value\n  MeanValue -> mean_value\n  BenchmarkValue -> benchmark_value\n  PeerValue -> peer_value\n  PeerMean -> peer_mean\n  MinValue -> min_value\n  MaxValue -> max_value\n  Numerator Description -> numerator_description\n  Num: ProviderValue -> num:_provider_value\n  Num: MedianValue -> num:_median_value\n  Denominator Description -> denominator_description\n  Denom: ProviderValue -> denom:_provider_value\n  Denom: MedianValue -> denom:_median_value"
+        description="Raw layer (Analyst-managed reference datasets and business rules). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE__NCL.ANALYST_MANAGED.model_hospital_theatre_imported_upload \ndbt: source(''reference_analyst_managed'', ''model_hospital_theatre_imported_upload'') \nColumns:\n  Compartment -> compartment\n  SubCompartment -> sub_compartment\n  Domain -> domain\n  Metric -> metric\n  ProviderCode -> provider_code\n  ProviderName -> provider_name\n  FilterName -> filter_name\n  ReportingDate -> reporting_date\n  ProviderValue -> provider_value\n  MedianValue -> median_value\n  MeanValue -> mean_value\n  BenchmarkValue -> benchmark_value\n  PeerValue -> peer_value\n  PeerMean -> peer_mean\n  MinValue -> min_value\n  MaxValue -> max_value\n  Numerator Description -> numerator_description\n  Num: ProviderValue -> num_provider_value\n  Num: MedianValue -> num_median_value\n  Denominator Description -> denominator_description\n  Denom: ProviderValue -> denom_provider_value\n  Denom: MedianValue -> denom_median_value"
     )
 }}
 select
@@ -21,9 +21,9 @@ select
     "MinValue" as min_value,
     "MaxValue" as max_value,
     "Numerator Description" as numerator_description,
-    "Num: ProviderValue" as num:_provider_value,
-    "Num: MedianValue" as num:_median_value,
+    "Num: ProviderValue" as num_provider_value,
+    "Num: MedianValue" as num_median_value,
     "Denominator Description" as denominator_description,
-    "Denom: ProviderValue" as denom:_provider_value,
-    "Denom: MedianValue" as denom:_median_value
+    "Denom: ProviderValue" as denom_provider_value,
+    "Denom: MedianValue" as denom_median_value
 from {{ source('reference_analyst_managed', 'model_hospital_theatre_imported_upload') }}

--- a/models/staging/olids/stg_olids_patient_uprn.yml
+++ b/models/staging/olids/stg_olids_patient_uprn.yml
@@ -53,3 +53,4 @@ models:
   tests:
   - dbt_expectations.expect_table_row_count_to_be_between:
       min_value: 1
+      severity: warn

--- a/models/staging/olids/stg_olids_referral_request.yml
+++ b/models/staging/olids/stg_olids_referral_request.yml
@@ -72,3 +72,4 @@ models:
   tests:
   - dbt_expectations.expect_table_row_count_to_be_between:
       min_value: 1
+      severity: warn

--- a/scripts/sources/3_generate_raw_models.py
+++ b/scripts/sources/3_generate_raw_models.py
@@ -85,8 +85,8 @@ def sanitise_column_name(col_name, apply_transformations=True, used_names=None):
                 safe_name = safe_name.replace('@', '_at_')
                 safe_name = safe_name.replace('$', '')
                 safe_name = safe_name.replace('|', '_or_')
-                # Then replace dots, slashes, hyphens, spaces, and other problematic characters
-                safe_name = re.sub(r'[\.\/\&\-\s\(\)\[\]]+', '_', safe_name)
+                # Then replace dots, slashes, hyphens, spaces, colons, and other problematic characters
+                safe_name = re.sub(r'[\.\/\&\-\s\(\)\[\]:]+', '_', safe_name)
 
             # Remove multiple consecutive underscores
             safe_name = re.sub(r'_+', '_', safe_name)


### PR DESCRIPTION
## Summary

- Fix SQL syntax errors in `raw_reference_model_hospital_theatre_imported` and `raw_reference_model_hospital_theatre_imported_upload` caused by colons in column aliases
- Add colon (`:`) to the `sanitise_column_name` regex in `scripts/sources/3_generate_raw_models.py`
- Change `stg_olids_patient_uprn` and `stg_olids_referral_request` row count tests to warnings (OLIDS is still in development by One London)

Fixes #212

## Changes

| File | Change |
|------|--------|
| `scripts/sources/3_generate_raw_models.py` | Add `:` to character replacement regex |
| `models/raw/shared/raw_reference_model_hospital_theatre_imported.sql` | Regenerated with fixed column aliases (`num_provider_value` instead of `num:_provider_value`) |
| `models/raw/shared/raw_reference_model_hospital_theatre_imported_upload.sql` | Regenerated with fixed column aliases |
| `models/staging/olids/stg_olids_patient_uprn.yml` | Add `severity: warn` to row count test |
| `models/staging/olids/stg_olids_referral_request.yml` | Add `severity: warn` to row count test |

## Test plan

- [x] `dbt build -s raw_reference_model_hospital_theatre_imported` compiles without syntax errors
- [x] `dbt build -s raw_reference_model_hospital_theatre_imported_upload` compiles without syntax errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)