### PR TITLE
feat: add Early Years (GP) age group for flu dashboard

### DIFF
--- a/macros/calculate_school_age_flags.sql
+++ b/macros/calculate_school_age_flags.sql
@@ -1,4 +1,11 @@
 {% macro calculate_school_age_flags(birth_date_field, reference_date_field) %}
+    -- Early years age flag (ages 2-3): children eligible for GP-based flu vaccination
+    CASE
+        WHEN {{ birth_date_field }} IS NOT NULL
+             AND DATEDIFF(year, {{ birth_date_field }}, {{ reference_date_field }}) BETWEEN 2 AND 3 THEN TRUE
+        ELSE FALSE
+    END AS is_early_years_age,
+
     -- Primary school age flag (Reception to Year 6): born Sept 2013 to Aug 2020 for 2024-25 academic year
     CASE
         WHEN {{ birth_date_field }} IS NOT NULL 

--- a/models/published/direct_care/olids/covid_flu/covid_flu_dashboard_base.sql
+++ b/models/published/direct_care/olids/covid_flu/covid_flu_dashboard_base.sql
@@ -73,16 +73,17 @@ WITH uptake_with_demographics AS (
         d.borough_registered,
         d.neighbourhood_registered,
         
-        -- School information from dim_person_age (now handles NULL for non-school ages upstream)
+        -- School information from dim_person_age (Early Years for ages 2-3, Reception+ for school ages)
         pa.age_school_stage AS school_year,
+        pa.is_early_years_age,
         pa.is_primary_school_age,
         pa.is_secondary_school_age,
 
-        -- Flu vaccination setting (Early Years at GP, School-based for Reception-Year 11)
+        -- Flu vaccination setting (Early Years at GP for ages 2-3, School-based for Reception-Year 11)
         CASE
             WHEN u.programme_type = 'FLU' THEN
                 CASE
-                    WHEN pa.age < 4 THEN 'Early Years (GP)'  -- Pre-school and Nursery ages
+                    WHEN pa.age >= 2 AND pa.age < 4 THEN 'Early Years (GP)'  -- Ages 2-3
                     WHEN pa.age_school_stage IN ('Reception', 'Year 1', 'Year 2', 'Year 3', 'Year 4',
                                                   'Year 5', 'Year 6', 'Year 7', 'Year 8', 'Year 9',
                                                   'Year 10', 'Year 11') THEN 'School-based'

--- a/models/published/direct_care/olids/covid_flu/covid_flu_dashboard_base.yml
+++ b/models/published/direct_care/olids/covid_flu/covid_flu_dashboard_base.yml
@@ -178,6 +178,21 @@ models:
         
       - name: laiv_given
         description: Whether LAIV was administered (flu only)
-        
+
+      - name: school_year
+        description: School year stage (Early Years, Reception, Year 1-13)
+
+      - name: is_early_years_age
+        description: Flag indicating early years age (ages 2-3)
+
+      - name: is_primary_school_age
+        description: Flag indicating primary school age (Reception to Year 6)
+
+      - name: is_secondary_school_age
+        description: Flag indicating secondary school age (Year 7 to Year 13)
+
+      - name: flu_vaccination_setting
+        description: Vaccination setting for flu (Early Years (GP) for ages 2-3, School-based for Reception-Year 11)
+
       - name: campaign_start_date
         description: Campaign start date

--- a/models/reporting/olids/person_demographics/dim_person_age.sql
+++ b/models/reporting/olids/person_demographics/dim_person_age.sql
@@ -156,8 +156,9 @@ SELECT
     END AS age_life_stage,
 
     -- UK school year/stage based on age at academic year start
-    -- Shows Reception to Year 13 (all school years), excludes pre-school and post-secondary
+    -- Shows Early Years (ages 2-3), Reception to Year 13, excludes under 2 and post-secondary
     CASE
+        WHEN ac.age >= 2 AND ac.age < 4 THEN 'Early Years'
         WHEN ac.age = 4 OR (ac.age = 5 AND DATEDIFF(month, ac.birth_date_approx, DATE_FROM_PARTS(ac.academic_year_start, 9, 1)) < 60) THEN 'Reception'
         WHEN ac.age = 5 OR (ac.age = 6 AND DATEDIFF(month, ac.birth_date_approx, DATE_FROM_PARTS(ac.academic_year_start, 9, 1)) < 72) THEN 'Year 1'
         WHEN ac.age = 6 OR (ac.age = 7 AND DATEDIFF(month, ac.birth_date_approx, DATE_FROM_PARTS(ac.academic_year_start, 9, 1)) < 84) THEN 'Year 2'
@@ -172,7 +173,7 @@ SELECT
         WHEN ac.age = 15 OR (ac.age = 16 AND DATEDIFF(month, ac.birth_date_approx, DATE_FROM_PARTS(ac.academic_year_start, 9, 1)) < 192) THEN 'Year 11'
         WHEN ac.age = 16 OR (ac.age = 17 AND DATEDIFF(month, ac.birth_date_approx, DATE_FROM_PARTS(ac.academic_year_start, 9, 1)) < 204) THEN 'Year 12'
         WHEN ac.age = 17 OR (ac.age = 18 AND DATEDIFF(month, ac.birth_date_approx, DATE_FROM_PARTS(ac.academic_year_start, 9, 1)) < 216) THEN 'Year 13'
-        ELSE NULL  -- Pre-school, Nursery, Post-secondary, Unknown all become NULL
+        ELSE NULL  -- Under 2, Post-secondary, Unknown all become NULL
     END AS age_school_stage,
 
     -- Broader education level category

--- a/models/reporting/olids/person_demographics/dim_person_age.yml
+++ b/models/reporting/olids/person_demographics/dim_person_age.yml
@@ -65,10 +65,15 @@ models:
         description: 'Age in days (approximate calculation)'
 
       - name: age_school_stage
-        description: 'School year classification (Pre-school, Nursery, Reception, Year 1-13, Post-secondary)'
+        description: 'School year classification (Early Years for ages 2-3, Reception, Year 1-13, or NULL for under 2/post-secondary)'
 
       - name: age_education_level
         description: 'Education level classification (Pre-school, Nursery, Primary School, Secondary School - KS3/KS4, Secondary School - Sixth Form, Post-secondary)'
+
+      - name: is_early_years_age
+        description: 'Flag indicating early years age (ages 2-3, eligible for GP-based flu vaccination)'
+        tests:
+          - not_null
 
       - name: is_primary_school_age
         description: 'Flag indicating primary school age (Reception to Year 6)'


### PR DESCRIPTION
## Summary
- Adds `is_early_years_age` flag to `calculate_school_age_flags` macro for ages 2-3
- Updates `age_school_stage` in `dim_person_age` to include 'Early Years' for ages 2-3
- Sets age floor at 2 for 'Early Years (GP)' flu vaccination setting in dashboard
- Documents new columns in YAML files

Closes #63

## Test plan
- [x] Verify `dim_person_age` compiles and `age_school_stage` returns 'Early Years' for ages 2-3
- [x] Verify `covid_flu_dashboard_base` shows 'Early Years (GP)' only for ages 2-3 (not under 2)
- [x] Verify `is_early_years_age` flag is TRUE for ages 2-3, FALSE otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)