### PR TITLE
fix: exclude patients without valid demographics from LTC/LCS dashboard

### DIFF
--- a/models/published/direct_care/olids/ltc_lcs/ltc_lcs_cf_dashboard_base.sql
+++ b/models/published/direct_care/olids/ltc_lcs/ltc_lcs_cf_dashboard_base.sql
@@ -95,7 +95,7 @@ base_data AS (
         cond.has_severe_mental_illness,
         COALESCE(preg.is_currently_pregnant, FALSE) AS is_currently_pregnant
     FROM {{ ref('dim_ltc_lcs_cf_summary') }} cf
-    LEFT JOIN {{ ref('dim_person_demographics') }} d ON cf.person_id = d.person_id
+    INNER JOIN {{ ref('dim_person_demographics') }} d ON cf.person_id = d.person_id
     LEFT JOIN {{ ref('dim_person_conditions') }} cond ON cf.person_id = cond.person_id
     LEFT JOIN {{ ref('fct_person_pregnancy_status') }} preg ON cf.person_id = preg.person_id
 ),


### PR DESCRIPTION
## Summary
- Change LEFT JOIN to INNER JOIN when joining to `dim_person_demographics` in `ltc_lcs_cf_dashboard_base`
- Excludes ~1,358 patients with null age bands caused by missing birth dates or registration history
- Secondary use version inherits fix automatically as it references the base model

## Test plan
- [x] Run `dbt build -s ltc_lcs_cf_dashboard_base+` to rebuild dashboard and downstream models
- [x] Verify no null values in `age_band_10y` column
- [x] Confirm row count reduction matches expected ~1,358 invalid patients