### PR TITLE
test: add tests to disease register models

### DIFF
--- a/models/modelling/olids/diagnoses/int_anxiety_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_anxiety_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -33,6 +36,8 @@ models:
         description: 'Categorised anxiety observation type (Anxiety Diagnosis or Anxiety Resolved)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: ANX_COD, ANXRES_COD
 

--- a/models/modelling/olids/diagnoses/int_autism_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_autism_diagnoses_all.yml
@@ -17,11 +17,16 @@ models:
 
       Purpose: Provide observation-level data for autism tracking and complex needs identification.'
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: AUTISM_COD
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/int_cerebral_palsy_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_cerebral_palsy_diagnoses_all.yml
@@ -15,11 +15,16 @@ models:
 
       Purpose: Provide observation-level data for cerebral palsy tracking and support services planning.'
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: CEREBRALP_COD
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/int_familial_hypercholesterolaemia_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_familial_hypercholesterolaemia_diagnoses_all.yml
@@ -15,11 +15,16 @@ models:
 
       Purpose: Provide observation-level data for FH monitoring and intensive cholesterol management.'
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: FHYP_COD
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/int_frailty_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_frailty_diagnoses_all.yml
@@ -15,11 +15,16 @@ models:
 
       Purpose: Provide observation-level data for frailty assessment and intervention tracking.'
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: FRAILTY_DX
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/int_gestational_diabetes_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_gestational_diabetes_diagnoses_all.yml
@@ -16,9 +16,17 @@ models:
       • No resolution codes as condition is pregnancy-specific
 
       Purpose: Provide observation-level data for gestational diabetes monitoring and future diabetes prevention planning.'
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: id
+      - cluster_ids_exist:
+          cluster_ids: GESTDIAB_COD
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/int_hypothyroidism_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_hypothyroidism_diagnoses_all.yml
@@ -15,11 +15,16 @@ models:
 
       Purpose: Provide observation-level data for hypothyroidism tracking and medication management.'
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: THY_COD
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/int_mnd_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_mnd_diagnoses_all.yml
@@ -15,11 +15,16 @@ models:
 
       Purpose: Provide observation-level data for motor neurone disease tracking and palliative care planning.'
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: MND_COD
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/int_ms_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_ms_diagnoses_all.yml
@@ -15,11 +15,16 @@ models:
 
       Purpose: Provide observation-level data for multiple sclerosis tracking and disease-modifying therapy monitoring.'
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: MS_COD
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/int_nafld_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_nafld_diagnoses_all.yml
@@ -14,9 +14,15 @@ models:
       • Potential for future QOF register development
 
       Purpose: Provide observation-level data for NAFLD tracking until proper cluster ID becomes available.'
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: id
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/int_parkinsons_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_parkinsons_diagnoses_all.yml
@@ -15,11 +15,16 @@ models:
 
       Purpose: Provide observation-level data for Parkinsons disease tracking and care management.'
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: PD_COD
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/qof/int_asthma_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_asthma_diagnoses_all.yml
@@ -17,11 +17,16 @@ models:
 
       Purpose: Provide observation-level data for asthma register inclusion and respiratory care pathway monitoring.'
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: AST_COD, ASTRES_COD
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/qof/int_atrial_fibrillation_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_atrial_fibrillation_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -33,5 +36,7 @@ models:
         description: 'Categorised AF observation type (AF Diagnosis or AF Resolved)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: AFIBRES_COD, AFIB_COD

--- a/models/modelling/olids/diagnoses/qof/int_cancer_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_cancer_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -30,5 +33,7 @@ models:
         description: 'Categorised cancer observation type (Cancer Diagnosis)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: CAN_COD

--- a/models/modelling/olids/diagnoses/qof/int_chd_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_chd_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -27,5 +30,7 @@ models:
         description: 'Flag indicating CHD diagnosis code (CHD_COD cluster)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: CHD_COD

--- a/models/modelling/olids/diagnoses/qof/int_ckd_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_ckd_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -33,5 +36,7 @@ models:
         description: 'Categorised CKD observation type (CKD Diagnosis or CKD Resolved)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: CKDRES_COD, CKD_COD

--- a/models/modelling/olids/diagnoses/qof/int_copd_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_copd_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -33,5 +36,7 @@ models:
         description: 'Categorised COPD observation type (COPD Diagnosis or COPD Resolved)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: COPDRES_COD, COPD_COD

--- a/models/modelling/olids/diagnoses/qof/int_dementia_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_dementia_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -30,5 +33,7 @@ models:
         description: 'Categorised dementia observation type (Dementia Diagnosis)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: DEM_COD

--- a/models/modelling/olids/diagnoses/qof/int_depression_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_depression_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -33,5 +36,7 @@ models:
         description: 'Categorised depression observation type (Depression Diagnosis or Depression Resolved)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: DEPRES_COD, DEPR_COD

--- a/models/modelling/olids/diagnoses/qof/int_diabetes_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_diabetes_diagnoses_all.yml
@@ -19,11 +19,16 @@ models:
 
       Purpose: Provide observation-level data with comprehensive diabetes type classification for QOF register and disease progression tracking.'
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: DM_COD,DMTYPE1_COD,DMTYPE2_COD,DMRES_COD
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
       - name: person_id
         description: 'Unique identifier for the person'
       - name: clinical_effective_date

--- a/models/modelling/olids/diagnoses/qof/int_epilepsy_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_epilepsy_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -33,5 +36,7 @@ models:
         description: 'Categorised epilepsy observation type (Epilepsy Diagnosis or Epilepsy Resolved)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: EPIL_COD, EPILRES_COD

--- a/models/modelling/olids/diagnoses/qof/int_heart_failure_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_heart_failure_diagnoses_all.yml
@@ -6,7 +6,9 @@ models:
       One row per observation using HF_COD, HFRES_COD, HFLVSD_COD, and REDEJCFRAC_COD clusters with ejection fraction tracking.'
     columns:
       - name: id
-        description: 'Unique identifier for the clinical observation'
+        description: 'Observation identifier (not unique - same observation may appear for multiple cluster matches)'
+        tests:
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -39,5 +41,7 @@ models:
         description: 'Categorised heart failure observation type (diagnosis, LVSD, reduced EF, or resolved)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: HFLVSD_COD, HFRES_COD, HF_COD, REDEJCFRAC_COD

--- a/models/modelling/olids/diagnoses/qof/int_hypertension_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_hypertension_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -33,5 +36,7 @@ models:
         description: 'Categorised hypertension observation type (Hypertension Diagnosis or Hypertension Resolved)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: HYPRES_COD, HYP_COD

--- a/models/modelling/olids/diagnoses/qof/int_learning_disability_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_learning_disability_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -30,5 +33,7 @@ models:
         description: 'Categorised learning disability observation type (Learning Disability Diagnosis)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: LD_COD

--- a/models/modelling/olids/diagnoses/qof/int_ndh_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_ndh_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -39,5 +42,7 @@ models:
         description: 'Flag indicating any NDH/IGT/pre-diabetes diagnosis code'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: IGT_COD, NDH_COD, PRD_COD

--- a/models/modelling/olids/diagnoses/qof/int_osteoporosis_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_osteoporosis_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -30,5 +33,7 @@ models:
         description: 'Categorised osteoporosis observation type (Osteoporosis Diagnosis)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: OSTEO_COD

--- a/models/modelling/olids/diagnoses/qof/int_pad_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_pad_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -30,5 +33,7 @@ models:
         description: 'Categorised PAD observation type (PAD Diagnosis)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: PAD_COD

--- a/models/modelling/olids/diagnoses/qof/int_palliative_care_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_palliative_care_diagnoses_all.yml
@@ -8,8 +8,10 @@ models:
       - name: person_id
         description: 'Patient identifier'
 
-      - name: id
+      - name: observation_id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - not_null
 
       - name: clinical_effective_date
         description: 'Date when palliative care observation was clinically effective'
@@ -36,5 +38,7 @@ models:
         description: 'Flag indicating palliative care resolution code'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: observation_id
       - cluster_ids_exist:
           cluster_ids: PALCARENI_COD, PALCARE_COD

--- a/models/modelling/olids/diagnoses/qof/int_rheumatoid_arthritis_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_rheumatoid_arthritis_diagnoses_all.yml
@@ -7,6 +7,9 @@ models:
     columns:
       - name: id
         description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -30,5 +33,7 @@ models:
         description: 'Categorised RA observation type (Rheumatoid Arthritis Diagnosis)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: RARTH_COD

--- a/models/modelling/olids/diagnoses/qof/int_smi_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_smi_diagnoses_all.yml
@@ -6,7 +6,9 @@ models:
       One row per observation using MH_COD (diagnosis) and MHREM_COD (remission) clusters. Age restrictions ≥18 years typically applied downstream.'
     columns:
       - name: id
-        description: 'Unique identifier for the clinical observation'
+        description: 'Observation identifier (not unique - same observation may appear for multiple cluster matches)'
+        tests:
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -33,5 +35,7 @@ models:
         description: 'Categorised SMI observation type (SMI Diagnosis or SMI Resolved)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: MH_COD, MHREM_COD

--- a/models/modelling/olids/diagnoses/qof/int_stroke_tia_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_stroke_tia_diagnoses_all.yml
@@ -6,7 +6,9 @@ models:
       One row per stroke or TIA diagnosis observation using STRK_COD and TIA_COD clusters with permanent cardiovascular event tracking and no age restrictions.'
     columns:
       - name: id
-        description: 'Unique identifier for the clinical observation'
+        description: 'Observation identifier (not unique - same observation may appear for multiple cluster matches)'
+        tests:
+          - not_null
 
       - name: person_id
         description: 'Patient identifier'
@@ -36,5 +38,7 @@ models:
         description: 'Categorised stroke/TIA observation type (Stroke Diagnosis or TIA Diagnosis)'
 
     tests:
+      - dbt_utils.at_least_one:
+          column_name: id
       - cluster_ids_exist:
           cluster_ids: STRK_COD, TIA_COD

--- a/models/reporting/olids/disease_registers/fct_person_anxiety_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_anxiety_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'Anxiety register for patients with active anxiety diagnosis.
 
       One row per person with latest ANX_COD > latest ANXRES_COD (non-QOF).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -33,3 +37,9 @@ models:
             - cluster_id: "ANXRES_COD"
               category: "RESOLUTION"
 
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/fct_person_autism_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_autism_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'Autism spectrum disorder register for patients with autism diagnosis.
 
       One row per person with AUTISM_COD present (non-QOF).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -31,3 +35,9 @@ models:
             - cluster_id: "AUTISM_COD"
               category: "INCLUSION"
 
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/fct_person_cerebral_palsy_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_cerebral_palsy_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'Cerebral palsy register for patients with cerebral palsy diagnosis.
 
       One row per person with CEREBRALP_COD present (non-QOF).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -30,3 +34,9 @@ models:
             - cluster_id: "CEREBRALP_COD"
               category: "INCLUSION"
 
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/fct_person_cyp_asthma_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_cyp_asthma_register.yml
@@ -3,7 +3,11 @@ models:
     description: 'Children and young people asthma register for paediatric asthma management.
 
       One row per person under 18 years with latest AST_COD > latest ASTRES_COD and asthma medication prescribed within last 12 months.'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -32,3 +36,10 @@ models:
               category: "RESOLUTION"
             - cluster_id: "ASTTRT_COD"
               category: "INCLUSION"
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/fct_person_familial_hypercholesterolaemia_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_familial_hypercholesterolaemia_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'Familial hypercholesterolaemia register for patients with genetic lipid disorder diagnosed at age 20+.
 
       One row per active patient with FHYP_COD present and age at first diagnosis 20+ years (genetic condition is lifelong).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -29,3 +33,10 @@ models:
           code_clusters:
             - cluster_id: "FHYP_COD"
               category: "INCLUSION"
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/fct_person_frailty_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_frailty_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'Frailty register for patients with frailty diagnosis tracking latest severity levels.
 
       One row per person with FRAILTY_DX present including severity classification (mild, moderate, severe).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -30,3 +34,10 @@ models:
           code_clusters:
             - cluster_id: "FRAILTY_DX"
               category: "INCLUSION"
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/fct_person_gestational_diabetes_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_gestational_diabetes_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'Gestational diabetes register for patients with pregnancy-related diabetes diagnosis history.
 
       One row per active patient with GESTDIAB_COD present (permanent record for postpartum diabetes risk monitoring).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -30,3 +34,10 @@ models:
           code_clusters:
             - cluster_id: "GESTDIAB_COD"
               category: "INCLUSION"
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/fct_person_hypothyroidism_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_hypothyroidism_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'Hypothyroidism register for patients with hypothyroidism diagnosis.
 
       One row per person with THY_COD present (non-QOF).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -29,3 +33,9 @@ models:
             - cluster_id: "THY_COD"
               category: "INCLUSION"
 
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/fct_person_learning_disability_register_all_ages.yml
+++ b/models/reporting/olids/disease_registers/fct_person_learning_disability_register_all_ages.yml
@@ -13,7 +13,11 @@ models:
       • Active diagnosis required (not historical)
 
       Purpose: Supports comprehensive learning disability population analysis across all age groups, complementing the age-restricted QOF register.'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -44,7 +48,10 @@ models:
     columns:
       - name: person_id
         description: Unique person identifier
-        
+        tests:
+          - unique
+          - not_null
+
       - name: is_on_register
         description: Whether person is on the learning disability register
         

--- a/models/reporting/olids/disease_registers/fct_person_mnd_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_mnd_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'Motor neurone disease register for patients with MND diagnosis.
 
       One row per person with MND_COD present (non-QOF).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -30,3 +34,9 @@ models:
             - cluster_id: "MND_COD"
               category: "INCLUSION"
 
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/fct_person_ms_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_ms_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'Multiple sclerosis register for patients with MS diagnosis.
 
       One row per person with MS_COD present (non-QOF).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -30,3 +34,9 @@ models:
             - cluster_id: "MS_COD"
               category: "INCLUSION"
 
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/fct_person_nafld_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_nafld_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'Non-alcoholic fatty liver disease register for patients with NAFLD diagnosis.
 
       One row per active patient with NAFLD diagnosis (currently using hardcoded SNOMED codes - awaiting NAFLD_COD cluster).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -31,3 +35,10 @@ models:
           code_clusters:
             - cluster_id: "HARDCODED_NAFLD"
               category: "INCLUSION"
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/fct_person_parkinsons_register.yml
+++ b/models/reporting/olids/disease_registers/fct_person_parkinsons_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'Parkinsons disease register for patients with Parkinsons diagnosis.
 
       One row per person with PD_COD present (non-QOF).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -30,3 +34,9 @@ models:
             - cluster_id: "PD_COD"
               category: "INCLUSION"
 
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null

--- a/models/reporting/olids/disease_registers/qof/fct_person_asthma_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_asthma_register.yml
@@ -3,7 +3,18 @@ models:
     description: 'QOF asthma register for patients aged 6+ with active asthma diagnosis.
 
       One row per person with latest AST_COD > latest ASTRES_COD and asthma medication prescribed within last 12 months.'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_atrial_fibrillation_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_atrial_fibrillation_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'QOF atrial fibrillation register for patients with active AF diagnosis.
 
       One row per person with latest AFIB_COD > latest AFIBRES_COD or no resolution recorded.'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -35,6 +39,9 @@ models:
     columns:
       - name: person_id
         description: 'Patient identifier'
+        tests:
+          - unique
+          - not_null
 
       - name: age
         description: 'Current age of the patient'

--- a/models/reporting/olids/disease_registers/qof/fct_person_cancer_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_cancer_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF cancer register for patients with cancer diagnosis from 1 April 2003 onwards.
 
       One row per person with CAN_COD diagnosis (excludes non-melanotic skin cancers).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_chd_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_chd_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF coronary heart disease register for patients with CHD diagnosis.
 
       One row per person with CHD_COD present (includes MI, angina, coronary atherosclerosis).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_ckd_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_ckd_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF chronic kidney disease register for patients aged 18+ with active CKD diagnosis.
 
       One row per person with latest CKD_COD > latest CKDRES_COD or no resolution recorded.'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_copd_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_copd_register.yml
@@ -5,6 +5,10 @@ models:
 
       One row per person with unresolved COPD diagnosis, requiring spirometry confirmation (FEV1/FVC < 0.7) for diagnoses after 01/04/2023.'
 
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     columns:
       - name: person_id
         description: Unique identifier for the person

--- a/models/reporting/olids/disease_registers/qof/fct_person_dementia_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_dementia_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF dementia register for patients with dementia diagnosis.
 
       One row per person with DEM_COD present (dementia is permanent condition).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_depression_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_depression_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF depression register for patients aged 18+ with active depression diagnosis.
 
       One row per person with latest DEP_COD > latest DEPRES_COD or no resolution recorded.'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_diabetes_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_diabetes_register.yml
@@ -13,7 +13,11 @@ models:
       • Type classification: Type 1, Type 2, or Unknown (Type 1 takes precedence)
 
       Purpose: Supports QOF reporting and diabetes care management with accurate type classification for treatment planning.'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -49,7 +53,10 @@ models:
     columns:
       - name: person_id
         description: Unique person identifier
-        
+        tests:
+          - unique
+          - not_null
+
       - name: is_on_register
         description: Whether person meets QOF diabetes register criteria
         

--- a/models/reporting/olids/disease_registers/qof/fct_person_epilepsy_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_epilepsy_register.yml
@@ -3,7 +3,18 @@ models:
     description: 'QOF epilepsy register for patients aged 18+ with active epilepsy diagnosis.
 
       One row per person with latest EPIL_COD > latest EPILRES_COD and epilepsy medication prescribed within last 6 months.'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_heart_failure_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_heart_failure_register.yml
@@ -3,7 +3,18 @@ models:
     description: 'QOF heart failure register for patients with active heart failure diagnosis.
 
       One row per person with latest HF_COD > latest HFRES_COD or no resolution, including subtype classification (General HF vs HF with LVSD/Reduced EF).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_hypertension_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_hypertension_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'QOF hypertension register for patients aged 18+ with active hypertension diagnosis.
 
       One row per person with latest HTN_COD > latest HTNRES_COD, including clinical staging based on NICE-aligned BP thresholds.'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:
@@ -35,6 +39,9 @@ models:
     columns:
       - name: person_id
         description: 'Patient identifier'
+        tests:
+          - unique
+          - not_null
 
       - name: age
         description: 'Current age of the patient'

--- a/models/reporting/olids/disease_registers/qof/fct_person_learning_disability_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_learning_disability_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF learning disability register for patients aged 14+ with learning disability diagnosis.
 
       One row per person with LD_COD present (learning disability is permanent condition).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_ndh_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_ndh_register.yml
@@ -3,7 +3,18 @@ models:
     description: 'QOF non-diabetic hyperglycaemia register for patients with pre-diabetes diagnosis.
 
       One row per person with NDH_COD present (elevated glucose but not diabetic), excluding those with diabetes diagnosis.'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_obesity_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_obesity_register.yml
@@ -4,7 +4,11 @@ models:
     description: 'QOF obesity register for patients aged 18+ using ethnicity-specific BMI thresholds.
 
       One row per person with BMI ≥30 (all ethnicities) or BMI ≥27.5 (BAME populations).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_osteoporosis_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_osteoporosis_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF osteoporosis register for fracture prevention in at-risk patients aged 50-74.
 
       One row per person with fragility fracture after April 2012, OSTEO_COD present, and DXA confirmation (DXA scan or T-score ≤ -2.5).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_pad_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_pad_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF peripheral arterial disease register for patients with peripheral vascular disease.
 
       One row per person with PAD_COD present (PAD is permanent condition).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_palliative_care_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_palliative_care_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF palliative care register for patients receiving end-of-life care.
 
       One row per person with PALLCARE_COD present (palliative care status maintained).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_rheumatoid_arthritis_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_rheumatoid_arthritis_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF rheumatoid arthritis register for patients with rheumatoid arthritis diagnosis.
 
       One row per person with RA_COD present (RA is lifelong condition).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_smi_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_smi_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF serious mental illness register for patients with active mental health diagnosis or lithium therapy.
 
       One row per person with MH_COD not in remission (latest diagnosis > latest remission) or lithium therapy in last 6 months.'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:

--- a/models/reporting/olids/disease_registers/qof/fct_person_stroke_tia_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_stroke_tia_register.yml
@@ -4,7 +4,18 @@ models:
     description: 'QOF stroke and TIA register for patients with stroke or transient ischaemic attack history.
 
       One row per person with STIA_COD present and not resolved by STIARES_COD (lifelong condition for secondary prevention).'
-    
+
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+
+    columns:
+      - name: person_id
+        description: Unique identifier for the person
+        tests:
+          - unique
+          - not_null
+
     config:
       meta:
         indicator:


### PR DESCRIPTION
## Summary
- Add `unique`/`not_null` tests on `person_id` for all fct_person_* register models
- Add `unique`/`not_null` tests on `id` for int_*_diagnoses_all models (where id is unique)
- Add `dbt_utils.at_least_one` tests to ensure tables are not empty (catches broken cluster_ids)
- Add `cluster_ids_exist` tests where get_observations/get_medications macros are used

## Fixes
Models where `id` is not unique due to multiple cluster matches now correctly omit the unique test:
- `int_heart_failure_diagnoses_all` (4 clusters)
- `int_smi_diagnoses_all` (2 clusters)
- `int_stroke_tia_diagnoses_all` (2 clusters)
- `int_palliative_care_diagnoses_all` (uses `observation_id` column, 2 clusters)

## Test plan
- [x] Run `dbt test` - 223 tests pass

Closes #338