### PR TITLE
fix: prevent arithmetic exit code 1 in coverage script

### DIFF
--- a/scripts/ci/check_test_coverage.sh
+++ b/scripts/ci/check_test_coverage.sh
@@ -59,13 +59,13 @@ while IFS= read -r -d '' file; do
     [[ "$file" == *dbt_packages* ]] && continue
     [[ "$file" == */raw/* ]] && continue
 
-    ((total++))
+    ((total++)) || true
 
     model_name=$(basename "$file" .sql)
     model_dir=$(dirname "$file")
 
     if model_has_tests "$model_name" "$model_dir"; then
-        ((with_tests++))
+        ((with_tests++)) || true
     else
         missing+=("$file")
     fi
@@ -85,7 +85,7 @@ if [[ ${#missing[@]} -gt 0 ]]; then
     count=0
     for file in "${missing[@]}"; do
         echo "  - $file"
-        ((count++))
+        ((count++)) || true
         if [[ $count -ge 20 ]]; then
             remaining=$((${#missing[@]} - 20))
             if [[ $remaining -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Add `|| true` to arithmetic increments to prevent exit code 1 with `set -e`
- In bash, `((0))` returns exit code 1, causing the script to fail on first iteration

## Test plan
- [x] Test Coverage workflow passes