### PR TITLE
fix: add --break-system-packages for PEP 668

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -26,7 +26,7 @@ jobs:
           version: "0.6.x"
 
       - name: Install dependencies
-        run: uv pip install --system pyyaml
+        run: uv pip install --system --break-system-packages pyyaml
 
       - name: Check test coverage
         id: coverage


### PR DESCRIPTION
## Summary
- Add `--break-system-packages` flag to uv pip install
- Required because Ubuntu's Python is externally managed (PEP 668)

## Test plan
- [x] Test Coverage workflow passes