### PR TITLE
fix: use uv venv instead of system Python

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -26,11 +26,14 @@ jobs:
           version: "0.6.x"
 
       - name: Install dependencies
-        run: uv pip install --system --break-system-packages pyyaml
+        run: |
+          uv venv
+          uv pip install pyyaml
 
       - name: Check test coverage
         id: coverage
         run: |
+          source .venv/bin/activate
           python << 'EOF'
           import os
           from pathlib import Path


### PR DESCRIPTION
## Summary
- Use `uv venv` to create isolated environment instead of installing to system Python
- Avoids PEP 668 permission issues on Ubuntu runners

## Test plan
- [x] Test Coverage workflow passes