### PR TITLE
feat: add row count logging post-hook for observability

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -11,6 +11,7 @@ flags:
 on-run-start:
   - "{{ log('🔗 DBT CONNECTION: Role=' ~ target.role ~ ', Warehouse=' ~ target.warehouse ~ ', Database=' ~ target.database ~ ', Schema=' ~ target.schema ~ ', Target=' ~ target.name, info=True) }}"
   - "{% if flags.WHICH in ['run', 'build'] %}{{ ensure_governance_tags() }}{% endif %}"
+  - "{% if flags.WHICH in ['run', 'build'] %}{{ create_row_count_log_table() }}{% endif %}"
 
 target-path: "target"
 clean-targets:
@@ -88,7 +89,9 @@ models:
       +materialized: table
       +database: "MODELLING"
       +tags: ["modelling"]
-      +post-hook: ["{{ add_model_comment() }}"]
+      +post-hook:
+        - "{{ add_model_comment() }}"
+        - "{{ log_row_count() }}"
       commissioning:
         +schema: "COMMISSIONING_MODELLING"
       olids:
@@ -101,7 +104,9 @@ models:
       +materialized: table
       +database: "REPORTING"
       +tags: ["reporting"]
-      +post-hook: ["{{ add_model_comment() }}"]
+      +post-hook:
+        - "{{ add_model_comment() }}"
+        - "{{ log_row_count() }}"
       commissioning:
         +schema: "COMMISSIONING_REPORTING"
       olids:
@@ -116,7 +121,9 @@ models:
       +enabled: true
       +materialized: table
       +tags: ["published_reporting"]
-      +post-hook: ["{{ add_model_comment() }}"]
+      +post-hook:
+        - "{{ add_model_comment() }}"
+        - "{{ log_row_count() }}"
       direct_care:
         +database: "PUBLISHED_REPORTING__DIRECT_CARE"
         olids:
@@ -136,6 +143,7 @@ models:
           +post-hook:
             - "{{ add_model_comment() }}"
             - "{{ apply_snowflake_tag_if_tagged('secondary_use_opt_out', 'DATA_CATEGORY', 'PRIMARY_CARE_SECONDARY_USE') }}"
+            - "{{ log_row_count() }}"
 
   # Elementary observability configuration
   elementary:

--- a/macros/create_row_count_log_table.sql
+++ b/macros/create_row_count_log_table.sql
@@ -1,0 +1,13 @@
+{% macro create_row_count_log_table() %}
+  {% if target.name in ['prod', 'snowflake-prod'] %}
+    CREATE TABLE IF NOT EXISTS DATA_LAKE__NCL.DBT_OBSERVABILITY.ROW_COUNT_LOG (
+      model_name VARCHAR,
+      database_name VARCHAR,
+      schema_name VARCHAR,
+      row_count NUMBER,
+      run_started_at TIMESTAMP_NTZ,
+      invocation_id VARCHAR,
+      recorded_at TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP()
+    )
+  {% endif %}
+{% endmacro %}

--- a/macros/log_row_count.sql
+++ b/macros/log_row_count.sql
@@ -1,0 +1,19 @@
+{% macro log_row_count() %}
+  {% if execute %}
+    {% set materialization = config.get('materialized') %}
+    {% if target.name in ['prod', 'snowflake-prod'] and materialization in ('table', 'incremental') %}
+      INSERT INTO DATA_LAKE__NCL.DBT_OBSERVABILITY.ROW_COUNT_LOG
+        (model_name, database_name, schema_name, row_count, run_started_at, invocation_id)
+      SELECT
+        '{{ this.identifier }}',
+        '{{ this.database }}',
+        '{{ this.schema }}',
+        COUNT(*),
+        '{{ run_started_at }}'::TIMESTAMP_NTZ,
+        '{{ invocation_id }}'
+      FROM {{ this }}
+    {% else %}
+      SELECT 1 WHERE FALSE
+    {% endif %}
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
## Summary
- Adds post-hook to log row counts for all table materializations to `DATA_LAKE__NCL.DBT_OBSERVABILITY.ROW_COUNT_LOG`
- Only fires on `prod` and `snowflake-prod` targets (like dbt-elementary)
- Creates log table on-run-start if it doesn't exist

## Changes
- New macro `create_row_count_log_table()` - creates the logging table if not exists
- New macro `log_row_count()` - inserts row count after each table model runs
- Updated `dbt_project.yml` with on-run-start hook and post-hooks for modelling, reporting, and published layers

## Test plan
- [x] Verify `dbt compile` succeeds
- [x] Run model in dev target - should no-op (returns `SELECT 1 WHERE FALSE`)
- [x] Run model in prod target - should create table and log row count