### PR TITLE
fix: enable elementary artifacts for snowflake-prod target

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -46,10 +46,10 @@ vars:
   covid_audit_end_date: "2025-06-30"    
   
   # Elementary configuration - disable upload of artifacts on run end for non-prod targets
-  disable_dbt_artifacts_autoupload: "{{ target.name != 'prod' }}"
-  disable_run_results: "{{ target.name != 'prod' }}"
-  disable_tests_results: "{{ target.name != 'prod' }}"
-  disable_dbt_invocation_autoupload: "{{ target.name != 'prod' }}"       # End of last completed campaign (spring 2025)
+  disable_dbt_artifacts_autoupload: "{{ target.name not in ['prod', 'snowflake-prod'] }}"
+  disable_run_results: "{{ target.name not in ['prod', 'snowflake-prod'] }}"
+  disable_tests_results: "{{ target.name not in ['prod', 'snowflake-prod'] }}"
+  disable_dbt_invocation_autoupload: "{{ target.name not in ['prod', 'snowflake-prod'] }}"
 
 # Configure test failure storage (only for failures)
 tests:


### PR DESCRIPTION
## Summary
- Update elementary config to enable artifact uploads for both `prod` and `snowflake-prod` targets
- Change condition from `!= 'prod'` to `not in ['prod', 'snowflake-prod']`

## Test plan
- [x] Verify elementary artifacts are uploaded when running with `snowflake-prod` target

🤖 Generated with [Claude Code](https://claude.ai/code)