### PR TITLE
fix: correct yml indentation for childhood imms tests

### DIFF
--- a/models/modelling/olids/programme/childhood_imms/int_childhood_imms_dose_count_agg_child.yml
+++ b/models/modelling/olids/programme/childhood_imms/int_childhood_imms_dose_count_agg_child.yml
@@ -1,7 +1,6 @@
 models:
   - name: int_childhood_imms_dose_count_agg_child
     description: Intermediate table for aggregate counts of vaccinations by month for historical population aged under 10 years old.
-
-tests:
-    - dbt_expectations.expect_table_row_count_to_be_between:
+    tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 1


### PR DESCRIPTION
## Summary
- Fixes YAML syntax error in `int_childhood_imms_dose_count_agg_child.yml`
- Moves `tests` property under the model definition (was incorrectly at root level)

## Context
Small fix for an indentation issue introduced in #411 - the `tests` block was placed at the wrong level. Quick one to merge! 🙂