### PR TITLE
chore: convert staging views with dedup logic to tables

### DIFF
--- a/models/staging/commissioning/stg_csds_cyp101referral.sql
+++ b/models/staging/commissioning/stg_csds_cyp101referral.sql
@@ -1,6 +1,6 @@
 
 {{
-    config(materialized = 'view')
+    config(materialized = 'table')
 }}
 
 WITH deduplicated AS (

--- a/models/staging/commissioning/stg_csds_cyp201carecontact.sql
+++ b/models/staging/commissioning/stg_csds_cyp201carecontact.sql
@@ -1,5 +1,5 @@
 {{
-    config(materialized = 'view')
+    config(materialized = 'table')
 }}
 
 WITH deduplicated AS (

--- a/models/staging/commissioning/stg_csds_cyp202careactivity.sql
+++ b/models/staging/commissioning/stg_csds_cyp202careactivity.sql
@@ -1,5 +1,5 @@
 {{
-    config(materialized = 'view')
+    config(materialized = 'table')
 }}
 
 WITH deduplicated AS (

--- a/models/staging/commissioning/stg_mhsds_carecontact.sql
+++ b/models/staging/commissioning/stg_mhsds_carecontact.sql
@@ -1,5 +1,5 @@
 {{
-    config(materialized = 'view')
+    config(materialized = 'table')
 }}
 
 select 

--- a/models/staging/commissioning/stg_mhsds_spell.sql
+++ b/models/staging/commissioning/stg_mhsds_spell.sql
@@ -1,5 +1,5 @@
 {{
-    config(materialized = 'view')
+    config(materialized = 'table')
 }}
 
 select 

--- a/models/staging/commissioning/stg_sus_apc_spell.sql
+++ b/models/staging/commissioning/stg_sus_apc_spell.sql
@@ -1,5 +1,5 @@
 {{
-    config(materialized = 'view')
+    config(materialized = 'table')
 }}
 
 with core_data as(
@@ -58,7 +58,6 @@ select core.primarykey_id
     , core.spell_patient_identity_ethnic_category
     , core.spell_patient_registration_general_practice
     , core.spell_patient_identity_spell_age
-    , core.spell_patient_identity_age_on_admission
     , core.spell_patient_identity_birth_year
     , core.spell_patient_identity_birth_month
 

--- a/models/staging/commissioning/stg_sus_apc_spell_episodes.sql
+++ b/models/staging/commissioning/stg_sus_apc_spell_episodes.sql
@@ -1,5 +1,5 @@
 {{
-    config(materialized = 'view')
+    config(materialized = 'table')
 }}
 
 select primarykey_id

--- a/models/staging/commissioning/stg_wl_wl_openpathways_data.sql
+++ b/models/staging/commissioning/stg_wl_wl_openpathways_data.sql
@@ -1,5 +1,5 @@
 {{
-    config(materialized = 'view')
+    config(materialized = 'table')
 }}
 
 WITH deduplication AS ( -- looks for expected unique columns and finds the maximum submission id for said unique columns

--- a/models/staging/olids/stg_olids_patient_person.sql
+++ b/models/staging/olids/stg_olids_patient_person.sql
@@ -1,3 +1,7 @@
+{{
+    config(materialized = 'table')
+}}
+
 select
     -- Primary key
     id,

--- a/models/staging/shared/stg_dictionary_ecds_comorbidity.sql
+++ b/models/staging/shared/stg_dictionary_ecds_comorbidity.sql
@@ -1,3 +1,7 @@
+{{
+    config(materialized = 'table')
+}}
+
 select
     ecds_unique_id,
     refset_unique_id,

--- a/models/staging/shared/stg_dictionary_ecds_diagnosis.sql
+++ b/models/staging/shared/stg_dictionary_ecds_diagnosis.sql
@@ -1,3 +1,7 @@
+{{
+    config(materialized = 'table')
+}}
+
 select
     ecds_unique_id,
     refset_unique_id,

--- a/models/staging/shared/stg_dictionary_ecds_treatment.sql
+++ b/models/staging/shared/stg_dictionary_ecds_treatment.sql
@@ -1,3 +1,7 @@
+{{
+    config(materialized = 'table')
+}}
+
 select
     ecds_unique_id,
     refset_unique_id,

--- a/models/staging/shared/stg_dictionary_ip_sourceofadmissions.sql
+++ b/models/staging/shared/stg_dictionary_ip_sourceofadmissions.sql
@@ -1,3 +1,7 @@
+{{
+    config(materialized = 'table')
+}}
+
 select
     sk_source_of_admission_id,
     bk_source_of_admission_code,

--- a/models/staging/shared/stg_pds_pds_address.sql
+++ b/models/staging/shared/stg_pds_pds_address.sql
@@ -1,3 +1,7 @@
+{{
+    config(materialized = 'table')
+}}
+
 --CTE to get all invalid row ids
 with invalid_residence_rows as (
     select

--- a/models/staging/shared/stg_reference_combined_codesets.sql
+++ b/models/staging/shared/stg_reference_combined_codesets.sql
@@ -5,4 +5,3 @@ select
     code_description,
     source
 from {{ ref('raw_reference_combined_codesets') }}
-qualify row_number() over (partition by cluster_id, code, source order by code_description) = 1

--- a/models/staging/shared/stg_reference_ethnicity_codes.sql
+++ b/models/staging/shared/stg_reference_ethnicity_codes.sql
@@ -1,3 +1,7 @@
+{{
+    config(materialized = 'table')
+}}
+
 select
     code,
     term,

--- a/models/staging/shared/stg_reference_lsoa2011_lsoa2021.sql
+++ b/models/staging/shared/stg_reference_lsoa2011_lsoa2021.sql
@@ -1,3 +1,7 @@
+{{
+    config(materialized = 'table')
+}}
+
 select
     lsoa11_cd,
     lsoa11_nm,

--- a/models/staging/shared/stg_reference_valproate_prog_codes.sql
+++ b/models/staging/shared/stg_reference_valproate_prog_codes.sql
@@ -1,3 +1,7 @@
+{{
+    config(materialized = 'table')
+}}
+
 select
     code,
     code_category,


### PR DESCRIPTION
## Summary
- Convert 17 staging models from views to tables for better query performance
- These models contain ROW_NUMBER/GROUP BY deduplication logic that was recalculating on every downstream query and test run
- Also fixes duplicate column `spell_patient_identity_age_on_admission` in stg_sus_apc_spell
- Simplifies `stg_reference_combined_codesets` to a passthrough view (dedup moved upstream)

## Models converted to tables

| Model | Downstream refs | Build time |
|-------|-----------------|------------|
| stg_reference_valproate_prog_codes | 7 | 3s |
| stg_olids_patient_person | 5 | 19s |
| stg_sus_apc_spell_episodes | 3 | 38s |
| stg_wl_wl_openpathways_data | 3 | 144s |
| stg_csds_cyp101referral | 3 | 53s |
| stg_csds_cyp201carecontact | 3 | 49s |
| stg_sus_apc_spell | 2 | 17s |
| stg_dictionary_ecds_diagnosis | 2 | 3s |
| stg_dictionary_ecds_treatment | 2 | 3s |
| stg_reference_ethnicity_codes | 2 | 3s |
| stg_reference_lsoa2011_lsoa2021 | 2 | 4s |
| stg_mhsds_spell | 1 | 4s |
| stg_mhsds_carecontact | 1 | 40s |
| stg_dictionary_ecds_comorbidity | 1 | 3s |
| stg_csds_cyp202careactivity | 1 | 49s |
| stg_pds_pds_address | 1 | 58s |
| stg_dictionary_ip_sourceofadmissions | 1 | 3s |

## Test plan
- [x] All 17 models built successfully
- [x] All tests pass

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)