### PR TITLE
fix: correct yml indentation for childhood imms dm tests

### DIFF
--- a/models/published/direct_care/olids/childhood_imms/childhood_imms_dose_count_child_dm.yml
+++ b/models/published/direct_care/olids/childhood_imms/childhood_imms_dose_count_child_dm.yml
@@ -1,10 +1,6 @@
-version: 1
-
 models:
   - name: childhood_imms_dose_count_child_dm
     description: Final view holding historical imms population (in the last 48 mths) under the age of 10 and any vaccinations associated with them.
-     
-tests:
-  - dbt_expectations.expect_table_row_count_to_be_between:
+    tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 1
-    


### PR DESCRIPTION
## Summary
- Move tests property under model definition where it belongs in `childhood_imms_dose_count_child_dm.yml`

## Test plan
- [x] Verify dbt can parse the yml file correctly