### PR TITLE
fix: filter null sk_patient_id in dim_person_pseudo

### DIFF
--- a/models/reporting/commissioning/person_level/fct_person_gp_recent.sql
+++ b/models/reporting/commissioning/person_level/fct_person_gp_recent.sql
@@ -11,7 +11,7 @@ base_encounters as (
         , code
         , display
     from {{ ref('int_gp_encounters_appt') }} gpa
-    left join {{ref('dim_person_pseudo')}} pp on pp.person_id = gpa.person_id
+    inner join {{ref('dim_person_pseudo')}} pp on pp.person_id = gpa.person_id
     where start_date between dateadd(month, -12, current_date()) and current_date()
 ), 
 gp_encounter_summary as(

--- a/models/reporting/olids/person_demographics/dim_person_pseudo.sql
+++ b/models/reporting/olids/person_demographics/dim_person_pseudo.sql
@@ -87,5 +87,5 @@ SELECT
      ) AS hx_flake
 
 FROM {{ ref('dim_person_birth_death') }} bd
-
+WHERE bd.sk_patient_id IS NOT NULL
 ORDER BY bd.person_id

--- a/models/reporting/olids/person_demographics/dim_person_pseudo.yml
+++ b/models/reporting/olids/person_demographics/dim_person_pseudo.yml
@@ -1,26 +1,21 @@
 version: 2
-
 models:
   - name: dim_person_pseudo
-    description: 'Person Pseudonym Dimension Table
+    description: 'Person Pseudonym Dimension Table.
 
       Provides pseudonymized hex keys for patient re-identification.
       Generates HxFlake format from sk_patient_id using standardized transformation.
 
       Key Features:
 
-      • One row per person_id
+      - One row per person_id
 
-      • HxFlake format: XX-XXX-XXX (10 characters total)
+      - HxFlake format: XX-XXX-XXX (10 characters total)
 
-      • Reversible transformation for re-identification
+      - Reversible transformation for re-identification
 
-      • Links to person and patient records
+      - Note: Multiple person_ids may share the same hx_flake when they share the same sk_patient_id'
 
-      • Note: Multiple person_ids may share the same hx_flake when they share the same sk_patient_id
-
-      Data Source: sk_patient_id from stg_olids_patient via person relationships'
-    
     columns:
       - name: person_id
         description: 'Unique person identifier'
@@ -34,6 +29,6 @@ models:
           - not_null
 
       - name: hx_flake
-        description: 'Pseudonymized hex key in format XX-XXX-XXX for patient re-identification. Note: Multiple person_ids may share the same hx_flake when they share the same sk_patient_id.'
+        description: 'Pseudonymized hex key in format XX-XXX-XXX for patient re-identification'
         tests:
           - not_null


### PR DESCRIPTION
## Summary
- Filter out rows with null `sk_patient_id` in `dim_person_pseudo` (hx_flake cannot be generated without it)
- Change `left join` to `inner join` in `fct_person_gp_recent` to exclude encounters for persons not in `dim_person_pseudo`
- Clean up yml file formatting (remove unicode bullets, fix line endings)

## Test plan
- [x] Run `dbt build -s +fct_person_gp_recent` and verify all tests pass