### PR TITLE
feat: add VS Code workspace for easier venv loading

### DIFF
--- a/dbt-ncl-analytics.code-workspace
+++ b/dbt-ncl-analytics.code-workspace
@@ -1,0 +1,52 @@
+{
+    "folders": [
+        {
+            "path": "."
+        }
+    ],
+    "settings": {
+        // dbt warnings filter - dbt0102 deprecation warnings are false positives for Snowflake
+        "problems.defaultSeverityFilter": "warning",
+
+        // Windows: auto-run start_dbt.ps1 when opening a terminal
+        "terminal.integrated.profiles.windows": {
+            "dbt": {
+                "source": "PowerShell",
+                "args": ["-NoExit", "-File", "${workspaceFolder}/start_dbt.ps1"]
+            }
+        },
+        "terminal.integrated.defaultProfile.windows": "dbt",
+
+        // macOS: auto-run start_dbt.sh when opening a terminal
+        "terminal.integrated.profiles.osx": {
+            "dbt": {
+                "path": "zsh",
+                "args": ["-c", "source ${workspaceFolder}/start_dbt.sh && exec zsh"]
+            }
+        },
+        "terminal.integrated.defaultProfile.osx": "dbt",
+
+        // Linux: auto-run start_dbt.sh when opening a terminal
+        "terminal.integrated.profiles.linux": {
+            "dbt": {
+                "path": "bash",
+                "args": ["-c", "source ${workspaceFolder}/start_dbt.sh && exec bash"]
+            }
+        },
+        "terminal.integrated.defaultProfile.linux": "dbt",
+
+        // Python - let the extension auto-detect the .venv (works cross-platform)
+        "python.venvPath": "${workspaceFolder}",
+
+        // dbt SQL files
+        "files.associations": {
+            "*.sql": "jinja-sql"
+        }
+    },
+    "extensions": {
+        "recommendations": [
+            "dbtLabsInc.dbt",
+            "ms-python.python"
+        ]
+    }
+}

--- a/start_dbt.sh
+++ b/start_dbt.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# start_dbt.sh - macOS/Linux equivalent of start_dbt.ps1
+
+# Configure Git hooks
+echo "Configuring Git hooks..."
+current_hooks_path=$(git config core.hooksPath)
+if [ "$current_hooks_path" != ".githooks" ]; then
+    git config core.hooksPath .githooks
+    echo "[OK] Git hooks configured to use .githooks directory"
+    echo "  Pre-commit hook will warn before committing profiles.yml"
+else
+    echo "[OK] Git hooks already configured"
+fi
+echo ""
+
+# Check if profiles.yml exists
+echo "Checking profiles.yml configuration..."
+if [ ! -f "profiles.yml" ]; then
+    echo "[WARNING] No profiles.yml found"
+    echo "  Copy profiles.yml.template to profiles.yml and configure your credentials"
+    echo "  For Snowflake native execution, profiles.yml is not required"
+else
+    echo "[OK] profiles.yml found"
+fi
+echo ""
+
+# Activate virtual environment
+echo "Activating Python virtual environment..."
+if [ -f ".venv/bin/activate" ]; then
+    source .venv/bin/activate
+elif [ -f "venv/bin/activate" ]; then
+    source venv/bin/activate
+else
+    echo "[ERROR] No virtual environment found"
+    echo "  Run 'uv sync' or 'python -m venv venv' to create one"
+    return 1 2>/dev/null || exit 1
+fi
+echo "[OK] Virtual environment activated"
+echo "  Python: $(python --version 2>&1)"
+echo ""
+
+# Disable AWS metadata service checks (prevents connection pool warnings on Azure)
+export AWS_EC2_METADATA_DISABLED=true
+
+# Load project-specific environment variables
+echo "Loading environment variables from .env..."
+if [ -f ".env" ]; then
+    env_count=0
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Skip comments and empty lines
+        [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+        if [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then
+            export "${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"
+            ((env_count++))
+        fi
+    done < ".env"
+    echo "[OK] Loaded $env_count environment variables"
+
+    # Show key variables (without exposing sensitive values)
+    [ -n "$SNOWFLAKE_ACCOUNT" ] && echo "  SNOWFLAKE_ACCOUNT: ${SNOWFLAKE_ACCOUNT:0:10}..."
+    [ -n "$SNOWFLAKE_USER" ] && echo "  SNOWFLAKE_USER: $SNOWFLAKE_USER"
+    [ -n "$SNOWFLAKE_ROLE" ] && echo "  SNOWFLAKE_ROLE: $SNOWFLAKE_ROLE"
+    [ -n "$SNOWFLAKE_WAREHOUSE" ] && echo "  SNOWFLAKE_WAREHOUSE: $SNOWFLAKE_WAREHOUSE"
+else
+    echo "[WARNING] No .env file found"
+    echo "  Copy env.example to .env and add your credentials"
+fi
+echo ""
+
+echo "Ready! You can now run dbt commands."
+echo "Try: dbt debug (to test your connection)"


### PR DESCRIPTION
## Summary
- Adds `dbt-ncl-analytics.code-workspace` with cross-platform terminal profiles that auto-run the startup script when opening a terminal
- Adds `start_dbt.sh` as the macOS/Linux equivalent of `start_dbt.ps1`
- Recommends the official dbt Labs and Python extensions

## Usage
Open via **File > Open Workspace from File** and select `dbt-ncl-analytics.code-workspace`. Every new terminal will automatically activate the venv and load `.env` variables.

## Test plan
- [ ] Open workspace, open terminal — confirm `start_dbt.ps1` runs
- [ ] Verify extension recommendations prompt on first open