### PR TITLE
fix: set sql file association to snowflake-sql and add extension

### DIFF
--- a/dbt-ncl-analytics.code-workspace
+++ b/dbt-ncl-analytics.code-workspace
@@ -40,13 +40,14 @@
 
         // dbt SQL files
         "files.associations": {
-            "*.sql": "jinja-sql"
+            "*.sql": "snowflake-sql"
         }
     },
     "extensions": {
         "recommendations": [
             "dbtLabsInc.dbt",
-            "ms-python.python"
+            "ms-python.python",
+            "snowflake.snowflake-vsc"
         ]
     }
 }


### PR DESCRIPTION
## Summary
- Change `*.sql` file association from `jinja-sql` to `snowflake-sql` so the Snowflake extension execute button appears on SQL files
- Add `snowflake.snowflake-vsc` to recommended workspace extensions

## Test plan
- [x] Open workspace in VS Code and verify Snowflake execute button appears on `.sql` files
- [x] Verify extension recommendation prompt appears for new users