### PR TITLE
fix: hide problem decorations for dbt fusion false positives

### DIFF
--- a/dbt-ncl-analytics.code-workspace
+++ b/dbt-ncl-analytics.code-workspace
@@ -5,7 +5,8 @@
         }
     ],
     "settings": {
-        // dbt warnings filter - dbt0102 deprecation warnings are false positives for Snowflake
+        // dbt fusion flags yml files as false positive errors; hide error decorations in explorer
+        "problems.decorations.enabled": false,
         "problems.defaultSeverityFilter": "warning",
 
         // Windows: auto-run start_dbt.ps1 when opening a terminal


### PR DESCRIPTION
## Summary
- Disable `problems.decorations.enabled` in workspace settings to hide the red error circles in the explorer
- dbt fusion currently flags every yml file as an error (false positives), making the entire project appear red

## Test plan
- [x] Open workspace and verify red error circles no longer appear on yml files in the explorer
Requires a vs code restart to see changes take effect