### PR TITLE
fix: use VIRTUAL_ENV check instead of LASTEXITCODE for venv activation

### DIFF
--- a/start_dbt.ps1
+++ b/start_dbt.ps1
@@ -57,7 +57,7 @@ if (Test-Path ".venv\Scripts\Activate.ps1") {
 }
 & $venvPath
 
-if ($LASTEXITCODE -eq 0) {
+if ($env:VIRTUAL_ENV) {
     Write-Host "[OK] Virtual environment activated" -ForegroundColor Green
     $pythonVersion = python --version 2>&1
     Write-Host "  Python: $pythonVersion" -ForegroundColor Gray


### PR DESCRIPTION
## Summary
- Fixed virtual environment activation check in `start_dbt.ps1` that was failing for some users
- Changed from checking `$LASTEXITCODE` to checking `$env:VIRTUAL_ENV`

## Problem
`$LASTEXITCODE` is only set by native executables (like `git`, `uv`, etc.), not by PowerShell scripts. The `Activate.ps1` script doesn't set it, so the check was using a stale value from previous commands (like `uv sync` or `git config`), causing false "Failed to activate virtual environment" errors even when activation succeeded.

## Solution
Check `$env:VIRTUAL_ENV` instead, which is the environment variable that `Activate.ps1` actually sets when activation succeeds. This directly verifies the virtual environment is active.

## Test plan
- [ ] Run `start_dbt.ps1` on Windows with PowerShell 5.1
- [ ] Run `start_dbt.ps1` on Windows with PowerShell 7.x
- [ ] Verify venv activates correctly when `.venv` exists
- [ ] Verify venv is created and activates when running fresh (no `.venv`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)