### PR TITLE
fix: correct qualify clause order in person_month_analysis_base

### DIFF
--- a/models/reporting/olids/person_analytics/person_month_analysis_base.sql
+++ b/models/reporting/olids/person_analytics/person_month_analysis_base.sql
@@ -25,6 +25,7 @@ WITH active_person_months AS (
         ds.month_end_date as analysis_month,
         hr.person_id,
         hr.practice_id,
+        hr.practice_code,
         hr.practice_name
     FROM {{ ref('dim_person_historical_practice') }} hr
     INNER JOIN {{ ref('int_date_spine') }} ds
@@ -34,7 +35,7 @@ WITH active_person_months AS (
         AND ds.month_end_date <= LAST_DAY(CURRENT_DATE)    -- Don't create future months
     QUALIFY ROW_NUMBER() OVER (
         PARTITION BY ds.month_end_date, hr.person_id
-        ORDER BY hr.registration_start_date DESC, hr.is_current_registration DESC
+        ORDER BY hr.is_current_registration DESC, hr.registration_start_date DESC
     ) = 1
 )
 
@@ -91,7 +92,7 @@ SELECT
     ) }},
     
     -- Practice and geography
-    d.practice_code,
+    apm.practice_code,
     d.borough_registered,
     d.practice_postcode,
     d.practice_lsoa,

--- a/models/reporting/olids/person_demographics/fct_person_months_active.sql
+++ b/models/reporting/olids/person_demographics/fct_person_months_active.sql
@@ -24,12 +24,12 @@ SELECT
     -- Include current practice for convenience (most recent if multiple)
     FIRST_VALUE(hr.practice_id) OVER (
         PARTITION BY ms.analysis_month, hr.person_id
-        ORDER BY hr.registration_start_date DESC, hr.is_current_registration DESC
+        ORDER BY hr.is_current_registration DESC, hr.registration_start_date DESC
         ROWS UNBOUNDED PRECEDING
     ) as current_practice_id,
     FIRST_VALUE(hr.practice_name) OVER (
         PARTITION BY ms.analysis_month, hr.person_id
-        ORDER BY hr.registration_start_date DESC, hr.is_current_registration DESC
+        ORDER BY hr.is_current_registration DESC, hr.registration_start_date DESC
         ROWS UNBOUNDED PRECEDING
     ) as current_practice_name
 
@@ -41,7 +41,7 @@ INNER JOIN {{ ref('dim_person_historical_practice') }} hr
 -- Ensure exactly one row per person-month
 QUALIFY ROW_NUMBER() OVER (
     PARTITION BY ms.analysis_month, hr.person_id
-    ORDER BY hr.registration_start_date DESC, hr.is_current_registration DESC
+    ORDER BY hr.is_current_registration DESC, hr.registration_start_date DESC
 ) = 1
 
 ORDER BY analysis_month, person_id


### PR DESCRIPTION
## Summary
- Swap ORDER BY in QUALIFY clause to prioritize `is_current_registration DESC` before `registration_start_date DESC`
- Aligns with the ordering used in `dim_person_demographics_historical`
- Fixes practice mismatches when patients have overlapping registrations

## Test plan
- [x] Run full refresh of `person_month_analysis_base`
- [x] Verify practice assignments match `dim_person_demographics_historical` for patients with multiple registrations