### PR TITLE
feat: add demographics basic model updates

### DIFF
--- a/docs/model_documentation/dim_person_demographics_basic.md
+++ b/docs/model_documentation/dim_person_demographics_basic.md
@@ -1,0 +1,44 @@
+# dim_person_demographics_basic pipeline
+
+## Overview
+
+This documentation covers versioning for the prod state of the dim_person_demographics_basic model ([DIM_PERSON_DEMOGRAPHICS_BASIC | Table](https://app.snowflake.com/atkjncu/ncl/#/data/databases/REPORTING/schemas/COMMISSIONING_REPORTING/table/DIM_PERSON_DEMOGRAPHICS_BASIC)).
+
+A more raw view of the combined demographic data is available in the intermediate combined model ([INT_PERSON_PMI_COMBINED | Table](https://app.snowflake.com/atkjncu/ncl/#/data/databases/MODELLING/schemas/COMMISSIONING_MODELLING/table/INT_PERSON_PMI_COMBINED/data-preview)). This table contains the data source and event date for each patient used in the final table.
+
+Currently the following datasets are used in the Demographics Basic table:
+- PDS ([INT_PERSON_PMI_DATASET_PDS | Table](https://app.snowflake.com/atkjncu/ncl/#/data/databases/MODELLING/schemas/COMMISSIONING_MODELLING/table/INT_PERSON_PMI_DATASET_PDS))
+- SUS ([INT_PERSON_PMI_DATASET_SUS | Table](https://app.snowflake.com/atkjncu/ncl/#/data/databases/MODELLING/schemas/COMMISSIONING_MODELLING/table/INT_PERSON_PMI_DATASET_SUS))
+- Ethnicity National Data Sets ([INT_PERSON_PMI_DATASET_ETHNICITY_NATIONAL_DATA_SETS | Table](https://app.snowflake.com/atkjncu/ncl/#/data/databases/MODELLING/schemas/COMMISSIONING_MODELLING/table/INT_PERSON_PMI_DATASET_ETHNICITY_NATIONAL_DATA_SETS))
+
+Note that the logic for the PDS Snapshot table largely follows the same logic as the Demographics Basic table but is limited to data available in PDS only (with ethnicity data supplemented using Ethnicity National Data Sets) ([DIM_SNAPSHOT_PERSON_PDS_DEMOGRAPHICS | Table](https://app.snowflake.com/atkjncu/ncl/#/data/databases/REPORTING/schemas/COMMISSIONING_REPORTING/table/DIM_SNAPSHOT_PERSON_PDS_DEMOGRAPHICS)).
+
+## Version History
+### V1.0 - 22/01/2026
+* Initial version of dim_person_demographics_basic created.
+* Initial data sources included:
+    - PDS
+    - SUS
+    - Ethnicity National Data Sets ([ETHNICITY_NATIONAL_DATA_SETS | Table](https://app.snowflake.com/atkjncu/ncl/#/data/databases/MODELLING/schemas/LOOKUP_NCL/table/ETHNICITY_NATIONAL_DATA_SETS))
+* Core demographic attributes (note these core fields are expanded using joins to lookup tables in the final table):
+    - SK Patient ID (Pseudonymised NHS Number)
+    - Gender
+    - Date of Birth
+    - Date of Death
+    - Ethnicity Code (BK Ethnic)
+    - Preferred Language (PDS only)
+    - Interpreter Required Flag (PDS only)
+    - LSOA 2021 Code of Residence
+    - GP Practice Code of Registration
+    - NCL Registered Flag (At time of refresh)
+    - NCL Resident Flag (At time of refresh)
+
+### V1.1 - 26/01/2026
+* The logic to determine which dataset to pull from is more advanced:
+  * Previous logic: Use PDS where it exists otherwise SUS (expect for ethnicity data where ETHNICITY_NATIONAL_DATA_SETS | Table is used when possible)
+  * New logic: Custom per field but typically:
+    * Use detailed values over unknowns/nulls (i.e. for gender, use 'Male' 'Female', 'Not specified' over 'Unknown' or NULL if possible) 
+    * Use the most recent record across the datasets (2024 SUS data > 2022 PDS data)
+* Cleaned up some of the ethnicity codes in the ethnicity data set and truncated to 1 digit (as 95% of codes only used 1 digit simplified ethnicity codes so why mix and match)
+* Renamed resident fields to all include residence_ as a prefix for consistency
+* Added some logic for registered borough and neighbourhood to replace NULLs with more informative values like 'Non-NCL' or 'Unknown due to practice closure'

--- a/models/modelling/commissioning/demographics/int_person_pmi_dataset_ethnicity_national_data_sets.sql
+++ b/models/modelling/commissioning/demographics/int_person_pmi_dataset_ethnicity_national_data_sets.sql
@@ -1,7 +1,15 @@
 select
-    sk_patientid as eth_sk_patient_id,
+    'eth' as dataset_source,
+    sk_patientid as sk_patient_id,
     --Trim to fix records with trailing spaces
-    trim(ethnicity_code) as eth_ethnicity_code,
-    cast(record_date as date) as eth_ethnicity_event_date
+    left(
+        case 
+            when trim(ethnicity_code) = '' then null
+            when right(ethnicity_code, 1) = '*' then left(ethnicity_code, length(ethnicity_code) - 1)
+            else trim(ethnicity_code) 
+        end, 
+        1
+    ) as ethnicity_code,
+    cast(record_date as date) as ethnicity_event_date
     
 from {{ ref('stg_reference_lookup_ncl_ethnicity_national_data_sets') }}

--- a/models/modelling/commissioning/demographics/int_person_pmi_dataset_ethnicity_national_data_sets.yml
+++ b/models/modelling/commissioning/demographics/int_person_pmi_dataset_ethnicity_national_data_sets.yml
@@ -10,14 +10,16 @@ models:
         owner:
           name: Jake Kealey
     columns:
-      - name: eth_sk_patient_id
+      - name: dataset_source
+        description: Source dataset name (eth)
+      - name: sk_patient_id
         description: Surrogate key for patient
         data_tests:
           - not_null
           - unique
 
-      - name: eth_ethnicity_code
+      - name: ethnicity_code
         description: Ethnicity code from national data sets
 
-      - name: eth_ethnicity_event_date
+      - name: ethnicity_event_date
         description: Date of record in source dataset

--- a/models/modelling/commissioning/demographics/int_person_pmi_dataset_pds.sql
+++ b/models/modelling/commissioning/demographics/int_person_pmi_dataset_pds.sql
@@ -1,19 +1,20 @@
 --Script to get key information from pds data
 select
-    sk_patient_id as pds_sk_patient_id,
-    gender_code as pds_gender_code,
-    coalesce(record_person_end_date, current_date()) as pds_gender_event_date,
-    year_month_of_birth as pds_date_of_birth,
-    coalesce(record_person_end_date, current_date()) as pds_dob_event_date,
-    date_of_death as pds_date_of_death,
-    coalesce(record_person_end_date, current_date()) as pds_death_event_date,
-    preferred_language_code as pds_preferred_language_code,
-    coalesce(record_person_end_date, current_date()) as pds_preferred_language_event_date,
-    interpreter_required as pds_interpreter_required,
-    coalesce(record_person_end_date, current_date()) as pds_interpreter_event_date,
-    lsoa_21 as pds_lsoa_21,
-    coalesce(record_residence_end_date, current_date()) as pds_residence_event_date,
-    practice_code as pds_practice_code,
-    coalesce(record_registered_end_date, current_date()) as pds_registered_event_date
+    'pds' as dataset_source,
+    sk_patient_id,
+    gender_code,
+    coalesce(record_person_end_date, current_date()) as gender_event_date,
+    year_month_of_birth as date_of_birth,
+    coalesce(record_person_end_date, current_date()) as dob_event_date,
+    date_of_death,
+    coalesce(record_person_end_date, current_date()) as death_event_date,
+    preferred_language_code,
+    coalesce(record_person_end_date, current_date()) as preferred_language_event_date,
+    interpreter_required,
+    coalesce(record_person_end_date, current_date()) as interpreter_event_date,
+    lsoa_21 as lsoa21_code,
+    coalesce(record_residence_end_date, current_date()) as lsoa_event_date,
+    practice_code,
+    coalesce(record_registered_end_date, current_date()) as registered_event_date
     
 from {{ref('int_person_pds_latest_record')}}

--- a/models/modelling/commissioning/demographics/int_person_pmi_dataset_pds.yml
+++ b/models/modelling/commissioning/demographics/int_person_pmi_dataset_pds.yml
@@ -1,63 +1,61 @@
 version: 2
 models:
-  - name: int_person_pmi_dataset_pds
-    description: Intermediate table containing the demographic dimensions from 
-      the PDS dataset, one per patient based on most recent information
-    config:
+- name: int_person_pmi_dataset_pds
+  description: Intermediate table containing the demographic dimensions from the PDS dataset, one per patient based on most recent information
+  config:
       meta:
         owner:
           name: Jake Kealey
+  tests:
+  - dbt_utils.at_least_one:
+      column_name: sk_patient_id
+  columns:
+  - name: dataset_source
+    description: Source dataset name (pds)
+  - name: sk_patient_id
+    description: Surrogate key patient identifier (pseudonymised NHS number)
     tests:
-      - dbt_utils.at_least_one:
-          column_name: pds_sk_patient_id
-    columns:
-      - name: pds_sk_patient_id
-        description: Surrogate key patient identifier (pseudonymised NHS number)
-        tests:
-          - not_null
-          - unique
-      - name: pds_gender_code
-        data_type: varchar
-        description: Gender code
-      - name: pds_gender_event_date
-        data_type: date
-        description: Record date from the PDS person table
-      - name: pds_date_of_birth
-        data_type: date
-        description: The month the person was born, set to the 1st of the month
-      - name: pds_dob_event_date
-        data_type: date
-        description: Record date from the PDS person table
-      - name: pds_date_of_death
-        data_type: date
-        description: Date the person died, NULL if no record of death
-      - name: pds_death_event_date
-        data_type: date
-        description: Record date from the pds person table
-      - name: pds_preferred_language_code
-        data_type: varchar
-        description: Shorthand code for preferred language if on record
-      - name: pds_preferred_language_event_date
-        data_type: date
-        description: Record date from the PDS person table
-      - name: pds_interpreter_required
-        data_type: varchar
-        description: Flag variable if the person requires an interpreter for 
-          appointments
-      - name: pds_interpreter_event_date
-        data_type: date
-        description: Record date from the PDS person table
-      - name: pds_lsoa_21
-        data_type: varchar
-        description: LSOA code of residence using the 2021 LSOA definitions, 
-          NULL implies no known residence or no residence
-      - name: pds_residence_event_date
-        data_type: date
-        description: Record date from the PDS address table
-      - name: pds_practice_code
-        data_type: varchar
-        description: Organisation code of the person's registered GP Practice, 
-          NULL implies not registered to any practice
-      - name: pds_registered_event_date
-        data_type: date
-        description: Record date from the PDS patient care practice table
+    - not_null
+    - unique
+  - name: gender_code
+    data_type: varchar
+    description: Gender code
+  - name: gender_event_date
+    data_type: date
+    description: Record date from the PDS person table
+  - name: date_of_birth
+    data_type: date
+    description: The month the person was born, set to the 1st of the month
+  - name: dob_event_date
+    data_type: date
+    description: Record date from the PDS person table
+  - name: date_of_death
+    data_type: date
+    description: Date the person died, NULL if no record of death
+  - name: death_event_date
+    data_type: date
+    description: Record date from the pds person table
+  - name: preferred_language_code
+    data_type: varchar
+    description: Shorthand code for preferred language if on record
+  - name: preferred_language_event_date
+    data_type: date
+    description: Record date from the PDS person table
+  - name: interpreter_required
+    data_type: varchar
+    description: Flag variable if the person requires an interpreter for appointments
+  - name: interpreter_event_date
+    data_type: date
+    description: Record date from the PDS person table
+  - name: lsoa21_code
+    data_type: varchar
+    description: LSOA code of residence using the 2021 LSOA definitions, NULL implies no known residence or no residence
+  - name: lsoa_event_date
+    data_type: date
+    description: Record date from the PDS address table
+  - name: practice_code
+    data_type: varchar
+    description: Organisation code of the person's registered GP Practice, NULL implies not registered to any practice
+  - name: registered_event_date
+    data_type: date
+    description: Record date from the PDS patient care practice table

--- a/models/modelling/commissioning/demographics/int_person_pmi_dataset_sus.sql
+++ b/models/modelling/commissioning/demographics/int_person_pmi_dataset_sus.sql
@@ -124,7 +124,7 @@ lsoa_event as (
     select
         sk_patient_id,
         lsoa21_cd as lsoa_21,
-        code_date::date as residence_event_date,
+        code_date::date as lsoa_event_date,
         
         --Rank rows for this field to identify which to use
         row_number() over (
@@ -179,17 +179,18 @@ registered_event as (
 )
 
 select
-    base.sk_patient_id as sus_sk_patient_id,
-    gen.gender_code as sus_gender_code,
-    gen.gender_event_date as sus_gender_event_date,
-    age.date_of_birth as sus_date_of_birth,
-    age.dob_event_date as sus_dob_event_date,
-    eth.ethnicity_code as sus_ethnicity_code,
-    eth.ethnicity_event_date as sus_ethnicity_event_date,
-    res.lsoa_21 as sus_lsoa_21,
-    res.residence_event_date as sus_residence_event_date,
-    reg.practice_code as sus_practice_code,
-    reg.registered_event_date as sus_registered_event_date
+    'sus' as dataset_source,
+    base.sk_patient_id,
+    gen.gender_code,
+    gen.gender_event_date,
+    age.date_of_birth,
+    age.dob_event_date,
+    eth.ethnicity_code,
+    eth.ethnicity_event_date,
+    res.lsoa_21 as lsoa21_code,
+    res.lsoa_event_date,
+    reg.practice_code,
+    reg.registered_event_date
     
 from (select distinct sk_patient_id from base) as base
 

--- a/models/modelling/commissioning/demographics/int_person_pmi_dataset_sus.yml
+++ b/models/modelling/commissioning/demographics/int_person_pmi_dataset_sus.yml
@@ -1,52 +1,49 @@
 version: 2
 models:
-  - name: int_person_pmi_dataset_sus
-    description: Intermediate table containing the demographic dimensions from 
-      the SUS dataset, one per patient
-    config:
+- name: int_person_pmi_dataset_sus
+  description: Intermediate table containing the demographic dimensions from the SUS dataset, one per patient
+  config:
       meta:
         owner:
           name: Jake Kealey
+  tests:
+  - dbt_utils.at_least_one:
+      column_name: sk_patient_id
+  columns:
+  - name: dataset_source
+    description: Source dataset name (sus)
+  - name: sk_patient_id
+    description: Surrogate key patient identifier (pseudonymised NHS number)
     tests:
-      - dbt_utils.at_least_one:
-          column_name: sus_sk_patient_id
-    columns:
-      - name: sus_sk_patient_id
-        description: Surrogate key patient identifier (pseudonymised NHS number)
-        tests:
-          - not_null
-          - unique
-      - name: sus_gender_code
-        data_type: varchar
-        description: Gender code, prioritising non-unknown and more recent 
-          values
-      - name: sus_gender_event_date
-        data_type: date
-        description: Date of the event that this field value was taken from
-      - name: sus_date_of_birth
-        data_type: date
-        description: Estimated (month of) date of birth by using the date of the
-          earliest record at the patient's current age
-      - name: sus_dob_event_date
-        data_type: date
-        description: Date of the event that this field value was taken from
-      - name: sus_ethnicity_code
-        data_type: varchar
-        description: Code for the person's ethnicity
-      - name: sus_ethnicity_event_date
-        data_type: date
-        description: Date of the event that this field value was taken from
-      - name: sus_lsoa_21
-        data_type: varchar
-        description: LSOA code of residence using the 2021 LSOA definitions, 
-          NULL implies no known residence
-      - name: sus_residence_event_date
-        data_type: date
-        description: Date of the event that this field value was taken from
-      - name: sus_practice_code
-        data_type: varchar
-        description: Organisation code of the person's registered GP Practice, 
-          NULL implies not registered to any practice
-      - name: sus_registered_event_date
-        data_type: date
-        description: Date of the event that this field value was taken from
+    - not_null
+    - unique
+  - name: gender_code
+    data_type: varchar
+    description: Gender code, prioritising non-unknown and more recent values
+  - name: gender_event_date
+    data_type: date
+    description: Date of the event that this field value was taken from
+  - name: date_of_birth
+    data_type: date
+    description: Estimated (month of) date of birth by using the date of the earliest record at the patient's current age
+  - name: dob_event_date
+    data_type: date
+    description: Date of the event that this field value was taken from
+  - name: ethnicity_code
+    data_type: varchar
+    description: Code for the person's ethnicity
+  - name: ethnicity_event_date
+    data_type: date
+    description: Date of the event that this field value was taken from
+  - name: lsoa21_code
+    data_type: varchar
+    description: LSOA code of residence using the 2021 LSOA definitions, NULL implies no known residence
+  - name: lsoa_event_date
+    data_type: date
+    description: Date of the event that this field value was taken from
+  - name: practice_code
+    data_type: varchar
+    description: Organisation code of the person's registered GP Practice, NULL implies not registered to any practice
+  - name: registered_event_date
+    data_type: date
+    description: Date of the event that this field value was taken from

--- a/models/reporting/commissioning/demographics/dim_person_demographics_basic.sql
+++ b/models/reporting/commissioning/demographics/dim_person_demographics_basic.sql
@@ -14,9 +14,10 @@ select
         --Residence information
         pmi.flag_current_ncl_residence,
         pmi.record_residence_start_date,
-        pmi.lsoa_21,
-        geo.ward_2025_code,
-        geo.ward_2025_name,
+        geo.lsoa_2021_code as residence_lsoa_2021_code,
+        geo.lsoa_2021_name as residence_lsoa_2021_name,
+        geo.ward_2025_code as residence_ward_2025_code,
+        geo.ward_2025_name as residence_ward_2025_name,
         geo.local_authority_2025_name as residence_borough,
         nb_res.neighbourhood_code as residence_neighbourhood_code,
         nb_res.neighbourhood_name as residence_neighbourhood_name,
@@ -32,9 +33,16 @@ select
         dict_pcn.stp_code as icb_code,
         dict_pcn.stp_name as icb_name,
         ----Note NCL only for fields below----
-        gp_lu.borough as registered_borough,
-        gp_lu.neighbourhood_code as registered_neighbourhood_code,
-        gp_lu.neighbourhood_name as registered_neighbourhood_name,
+        case 
+            when (icb_code != 'QMJ' and gp_lu.borough is null) then 'Non-NCL Borough'
+            when (icb_code = 'QMJ' and dict_gp.end_date is not null) then 'Unknown due to closed practice'
+            else coalesce(gp_lu.borough, reg_bor_backup.borough, 'Unknown')
+        end as registered_borough,
+        nb_reg.neighbourhood_code as registered_neighbourhood_code,
+        case
+            when (icb_code != 'QMJ' and nb_reg.neighbourhood_code is null) then 'Non-NCL Neighbourhood'
+            else coalesce(nb_reg.neighbourhood_name, 'Unknown')
+        end as registered_neighbourhood_name,
         --------------------------------------
 
         --Language information
@@ -53,13 +61,13 @@ left join {{ref('stg_reference_lookup_ncl_interpreter_required')}} as dict_ir
 on pmi.interpreter_required = dict_ir.interpreter_required
 
 left join {{ref('stg_reference_lookup_ncl_lsoa_2021_ward_2025_local_authority_2025')}} geo
-on pmi.lsoa_21 = geo.lsoa_2021_code
+on pmi.lsoa21_code = geo.lsoa_2021_code
 
 left join {{ref('stg_reference_lookup_ncl_ncl_neighbourhood_lsoa_2021')}} nb_res
-on pmi.lsoa_21 = nb_res.lsoa_2021_code
+on pmi.lsoa21_code = nb_res.lsoa_2021_code
 
 left join {{ref('stg_reference_lookup_ncl_imd_2025')}} imd
-on pmi.lsoa_21 = imd.lsoa_code_2021
+on pmi.lsoa21_code = imd.lsoa_code_2021
 
 left join {{ref('stg_dictionary_dbo_organisation')}} dict_gp
 on pmi.practice_code = dict_gp.organisation_code
@@ -69,6 +77,15 @@ on dict_gp.sk_organisation_id = dict_pcn.sk_organisation_id_practice
 
 left join {{ref('stg_reference_lookup_ncl_gp_practice')}} gp_lu
 on pmi.practice_code = gp_lu.gp_practice_code
+
+left join (
+        select distinct pcn_code, borough
+        from {{ref('stg_reference_lookup_ncl_gp_practice')}} 
+) reg_bor_backup
+on gp_lu.pcn_code = reg_bor_backup.pcn_code
+
+left join {{ref('stg_reference_lookup_ncl_ncl_gp_practice_neighbourhood')}} nb_reg
+on pmi.practice_code = nb_reg.practice_code
 
 left join (
     select distinct

--- a/models/reporting/commissioning/demographics/dim_person_demographics_basic.yml
+++ b/models/reporting/commissioning/demographics/dim_person_demographics_basic.yml
@@ -2,14 +2,16 @@ version: 2
 
 models:
   - name: dim_person_demographics_basic
-    description: >
-      Dimensional table providing comprehensive demographic information for persons,
-      including gender, ethnicity, residence and registration details enriched with
-      reference data lookups.
     config:
       meta:
         owner:
           name: Jake Kealey
+    description: >
+      Dimensional table providing comprehensive demographic information for persons,
+      including gender, ethnicity, residence and registration details enriched with
+      reference data lookups.
+
+      Documentation available: https://github.com/ncl-icb-analytics/dbt-ncl-analytics/blob/main/docs/model_documentation/dim_person_demographics_basic.md
     columns:
       - name: sk_patient_id
         description: Surrogate key for patient
@@ -49,8 +51,11 @@ models:
       - name: record_residence_start_date
         description: Start date of current residence record
 
-      - name: lsoa_21
+      - name: lsoa_2021_code
         description: Lower Super Output Area code (2021 Census)
+
+      - name: lsoa_2021_name
+        description: Lower Super Output Area name (2021 Census)
 
       - name: ward_2025_code
         description: Ward code (2025)

--- a/models/reporting/commissioning/demographics/dim_snapshot_person_pds_demographics.sql
+++ b/models/reporting/commissioning/demographics/dim_snapshot_person_pds_demographics.sql
@@ -34,9 +34,16 @@ select
         dict_pcn.network_name as pcn_name,
         dict_pcn.stp_code as icb_code,
         dict_pcn.stp_name as icb_name,
-        gp_lu.borough as registered_borough,
-        gp_lu.neighbourhood_code as registered_neighbourhood_code,
-        gp_lu.neighbourhood_name as registered_neighbourhood_name,
+        case 
+            when (icb_code != 'QMJ' and gp_lu.borough is null) then 'Non-NCL Borough'
+            when (icb_code = 'QMJ' and dict_gp.end_date is not null) then 'Unknown due to closed practice'
+            else coalesce(gp_lu.borough, reg_bor_backup.borough, 'Unknown')
+        end as registered_borough,
+        nb_reg.neighbourhood_code as registered_neighbourhood_code,
+        case
+            when (icb_code != 'QMJ' and nb_reg.neighbourhood_code is null) then 'Non-NCL Neighbourhood'
+            else coalesce(nb_reg.neighbourhood_name, 'Unknown')
+        end as registered_neighbourhood_name,
 
         --Resident information
         (
@@ -46,10 +53,11 @@ select
                 pds.date_of_death is null
         ) as ncl_resident_flag,
         pds.record_residence_end_date,
-        pds.postcode_sector,
-        pds.lsoa_21,
-        geo.ward_2025_code,
-        geo.ward_2025_name,
+        pds.postcode_sector as residence_postcode_sector,
+        geo.lsoa_2021_code as residence_lsoa_2021_code,
+        geo.lsoa_2021_name as residence_lsoa_2021_name,
+        geo.ward_2025_code as residence_ward_2025_code,
+        geo.ward_2025_name as residence_ward_2025_name,
         geo.local_authority_2025_name as residence_borough,
         nb_res.neighbourhood_code as residence_neighbourhood_code,
         nb_res.neighbourhood_name as residence_neighbourhood_name,
@@ -89,6 +97,15 @@ on dict_gp.sk_organisation_id = dict_pcn.sk_organisation_id_practice
 
 left join {{ref('stg_reference_lookup_ncl_gp_practice')}} gp_lu
 on pds.practice_code = gp_lu.gp_practice_code
+
+left join (
+        select distinct pcn_code, borough
+        from {{ref('stg_reference_lookup_ncl_gp_practice')}} 
+) reg_bor_backup
+on gp_lu.pcn_code = reg_bor_backup.pcn_code
+
+left join {{ref('stg_reference_lookup_ncl_ncl_gp_practice_neighbourhood')}} nb_reg
+on pds.practice_code = nb_reg.practice_code
 
 left join {{ref('stg_reference_lookup_ncl_ethnicity_national_data_sets')}} eth
 ON pds.sk_patient_id = eth.sk_patientid

--- a/models/reporting/commissioning/demographics/dim_snapshot_person_pds_demographics.yml
+++ b/models/reporting/commissioning/demographics/dim_snapshot_person_pds_demographics.yml
@@ -1,111 +1,122 @@
 version: 2
 models:
 - name: dim_snapshot_person_pds_demographics
-  description: Annual snapshots to create a demographic lookup table for the population based on the PDS dataset. Includes ethnicity data from dev__modelling.lookup_ncl.ethnicity_national_data_sets.
+  config:
+      meta:
+        owner:
+          name: Jake Kealey
+  description: >
+    Annual snapshots to create a demographic lookup table for the population based on the PDS dataset. 
+    Includes ethnicity data from dev__modelling.lookup_ncl.ethnicity_national_data_sets.
+
+    Documentation available: https://github.com/ncl-icb-analytics/dbt-ncl-analytics/blob/main/docs/model_documentation/dim_person_demographics_basic.md
   tests:
   - dbt_utils.at_least_one:
       column_name: sk_patient_id
   - dbt_utils.unique_combination_of_columns:
       combination_of_columns:
-      - snapshot_date
-      - sk_patient_id
+        - snapshot_date
+        - sk_patient_id
   columns:
-  - name: snapshot_year
-    description: Financial year that the record corresponds to
-    tests:
-    - not_null
-  - name: snapshot_date
-    description: Date of the snapshot the record corresponds to
-    tests:
-    - not_null
-  - name: sk_patient_id
-    description: Surrogate key patient identifier (pseudonymised NHS number)
-    tests:
-    - not_null
-  - name: current_ncl_person_flag
-    data_type: boolean
-    description: TRUE if the person appears in DATA_LAKE.PDS.PDS_PERSON with no defined end date
-  - name: record_person_end_date
-    data_type: date
-    description: Date that the latest record from the PDS Person table is valid until, NULL otherwise
-  - name: year_month_of_birth
-    data_type: date
-    description: The month the person was born, set to the 1st of the month to save as a DATE variable
-  - name: gender
-    data_type: varchar
-    description: Gender name of person
-  - name: date_of_death
-    data_type: date
-    description: Date the person died, NULL if no record of death
-  - name: preferred_language
-    data_type: varchar
-    description: Preferred language if on record
-  - name: interpreter_required
-    data_type: varchar
-    description: Flag variable if the person requires an intepreter for appointments
-  - name: ncl_registered_flag
-    data_type: boolean
-    description: TRUE if the patient is registered to a NCL practice, the patient id has no record of death, and the registered practice organisation was open on the date of the snapshot
-  - name: record_registered_end_date
-    data_type: date
-    description: Date that the latest record from the PDS Practice table is valid until, NULL otherwise
-  - name: practice_code
-    data_type: varchar
-    description: Organisation code of the person's registered GP Practice, NULL implies not registered to any practice
-  - name: practice_name
-    data_type: varchar
-    description: Organisation name of the person's registered GP Practice, NULL implies not registered to any practice
-  - name: pcn_code
-    data_type: varchar
-    description: PCN code of listed practice
-  - name: pcn_name
-    data_type: varchar
-    description: PCN name of listed practice
-  - name: icb_code
-    data_type: varchar
-    description: ICB code of listed practice
-  - name: icb_name
-    data_type: varchar
-    description: ICB name of listed practice
-  - name: registered_borough
-    data_type: varchar
-    description: Borough of listed practice (based on practice postcode)
-  - name: registered_neighbourhood_code
-    data_type: varchar
-    description: Neighbourhood code of listed practice (based on practice postcode)
-  - name: registered_neighbourhood_name
-    data_type: varchar
-    description: Neighbourhood name of listed practice (based on practice postcode)
-  - name: ncl_resident_flag
-    data_type: boolean
-    description: TRUE if the patient has a NCL address and the patient id has no record of death
-  - name: postcode_sector
-    data_type: varchar
-    description: First half of the postcode for the person's residence, NULL implies no known residence
-  - name: lsoa_21
-    data_type: varchar
-    description: LSOA code of residence using the 2021 LSOA definitions, NULL implies no known residence
-  - name: ward_2025_code
-    data_type: varchar
-    description: Ward code of residence using the 2025 ward definitions
-  - name: ward_2025_name
-    data_type: varchar
-    description: Ward name of residence using the 2025 ward definitions
-  - name: residence_borough
-    data_type: varchar
-    description: Borough name of residence
-  - name: residence_neighbourhood_code
-    data_type: varchar
-    description: Neighbourhood code of residence using latest available neighbourhood definitions in the NCL_LOOKUP schema
-  - name: residence_neighbourhood_name
-    data_type: varchar
-    description: Neighbourhood name of residence using latest available neighbourhood definitions in the NCL_LOOKUP schema
-  - name: residence_imd_decile
-    data_type: number
-    description: IMD Decile of the record's listed LSOA 2021 code using the latest available IMD data in the NCL_LOOKUP schema
-  - name: residence_imd_score
-    data_type: number
-    description: IMD Score of the record's listed LSOA 2021 code using the latest available IMD data in the NCL_LOOKUP schema
-  - name: _timestamp
-    data_type: datetime
-    description: Timestamp of when the row was created, indication of when the refresh process for this table was last ran
+    - name: snapshot_year
+      description: Financial year that the record corresponds to
+      tests:
+        - not_null
+    - name: snapshot_date
+      description: Date of the snapshot the record corresponds to
+      tests:
+        - not_null
+    - name: sk_patient_id
+      description: Surrogate key patient identifier (pseudonymised NHS number)
+      tests:
+        - not_null
+    - name: current_ncl_person_flag
+      data_type: boolean
+      description: TRUE if the person appears in DATA_LAKE.PDS.PDS_PERSON with no defined end date
+    - name: record_person_end_date
+      data_type: date
+      description: Date that the latest record from the PDS Person table is valid until, NULL otherwise
+    - name: year_month_of_birth
+      data_type: date
+      description: The month the person was born, set to the 1st of the month to save as a DATE variable
+    - name: gender
+      data_type: varchar
+      description: Gender name of person
+    - name: date_of_death
+      data_type: date
+      description: Date the person died, NULL if no record of death
+    - name: preferred_language
+      data_type: varchar
+      description: Preferred language if on record
+    - name: interpreter_required
+      data_type: varchar
+      description: Flag variable if the person requires an intepreter for appointments
+    - name: ncl_registered_flag
+      data_type: boolean
+      description: TRUE if the patient is registered to a NCL practice, the patient id has no record of death, and the registered practice organisation was open on the date of the snapshot
+    - name: record_registered_end_date
+      data_type: date
+      description: Date that the latest record from the PDS Practice table is valid until, NULL otherwise
+    - name: practice_code
+      data_type: varchar
+      description: Organisation code of the person's registered GP Practice, NULL implies not registered to any practice
+    - name: practice_name
+      data_type: varchar
+      description: Organisation name of the person's registered GP Practice, NULL implies not registered to any practice
+    - name: pcn_code
+      data_type: varchar
+      description: PCN code of listed practice
+    - name: pcn_name
+      data_type: varchar
+      description: PCN name of listed practice
+    - name: icb_code
+      data_type: varchar
+      description: ICB code of listed practice
+    - name: icb_name
+      data_type: varchar
+      description: ICB name of listed practice
+    - name: registered_borough
+      data_type: varchar
+      description: Borough of listed practice (based on practice postcode)
+    - name: registered_neighbourhood_code
+      data_type: varchar
+      description: Neighbourhood code of listed practice (based on practice postcode)
+    - name: registered_neighbourhood_name
+      data_type: varchar
+      description: Neighbourhood name of listed practice (based on practice postcode)
+    - name: ncl_resident_flag
+      data_type: boolean
+      description: TRUE if the patient has a NCL address and the patient id has no record of death
+    - name: postcode_sector
+      data_type: varchar
+      description: First half of the postcode for the person's residence, NULL implies no known residence
+    - name: lsoa_2021_code
+      data_type: varchar
+      description: LSOA code of residence using the 2021 LSOA definitions, NULL implies no known residence
+    - name: lsoa_2021_name
+      data_type: varchar
+      description: LSOA name of residence using the 2021 LSOA definitions, NULL implies no known residence
+    - name: ward_2025_code
+      data_type: varchar
+      description: Ward code of residence using the 2025 ward definitions
+    - name: ward_2025_name
+      data_type: varchar
+      description: Ward name of residence using the 2025 ward definitions
+    - name: residence_borough
+      data_type: varchar
+      description: Borough name of residence
+    - name: residence_neighbourhood_code
+      data_type: varchar
+      description: Neighbourhood code of residence using latest available neighbourhood definitions in the NCL_LOOKUP schema
+    - name: residence_neighbourhood_name
+      data_type: varchar
+      description: Neighbourhood name of residence using latest available neighbourhood definitions in the NCL_LOOKUP schema
+    - name: residence_imd_decile
+      data_type: number
+      description: IMD Decile of the record's listed LSOA 2021 code using the latest available IMD data in the NCL_LOOKUP schema
+    - name: residence_imd_score
+      data_type: number
+      description: IMD Score of the record's listed LSOA 2021 code using the latest available IMD data in the NCL_LOOKUP schema
+    - name: _timestamp
+      data_type: datetime
+      description: Timestamp of when the row was created, indication of when the refresh process for this table was last ran


### PR DESCRIPTION
## Summary
Re-applies demographics changes from #439 cleanly, without the tangled commit history from the rebase issues.

- Add `int_person_pmi_combined` and dataset intermediate tables
- Add `dim_person_demographics_basic` reporting model
- Add `dim_snapshot_person_pds_demographics` snapshot model
- Add model documentation

## Context
PR #439 was merged but contained old versions of unrelated files due to rebase conflicts. It was reverted in #450. This PR re-applies only the demographics changes.

## Test plan
- [x] dbt compile passes
- [ ] dbt build on demographics models