### PR TITLE
fix(ci): add pull_request triggers for snowflake-ci label

### DIFF
--- a/.github/workflows/dbt-pr-validation.yml
+++ b/.github/workflows/dbt-pr-validation.yml
@@ -19,17 +19,28 @@ name: dbt PR Validation
 
 on:
   workflow_dispatch:
-  # TODO: Enable after permissions granted:
-  # pull_request:
-  #   branches: [main]
-  #   paths:
-  #     - 'models/**'
-  #     - 'macros/**'
+  pull_request:
+    types: [labeled, review_requested, synchronize]
+    branches: [main]
+
+concurrency:
+  group: snowflake-ci-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   validate-models:
     name: Validate Changed Models
     runs-on: ubuntu-latest
+    # Run on: manual dispatch, reviewer assigned, snowflake-ci label added,
+    # or new commits when reviewer/label already present
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.action == 'review_requested' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'snowflake-ci') ||
+      (github.event.action == 'synchronize' && (
+        github.event.pull_request.requested_reviewers[0] != null ||
+        contains(github.event.pull_request.labels.*.name, 'snowflake-ci')
+      ))
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

Adds missing `pull_request` event triggers to the PR validation workflow.

## Problem

The `snowflake-ci` label trigger from #460 wasn't working because the workflow only had `workflow_dispatch` - the `pull_request` event with `labeled` type was never added.

## Changes

- Add `pull_request` trigger with `labeled`, `review_requested`, `synchronize` types
- Add concurrency control to cancel in-progress runs on new commits
- Add job-level condition to only run Snowflake validation when appropriate