### PR TITLE
fix(ci): queue PR validation runs globally

### DIFF
--- a/.github/workflows/dbt-pr-validation.yml
+++ b/.github/workflows/dbt-pr-validation.yml
@@ -44,8 +44,8 @@ jobs:
         contains(github.event.pull_request.labels.*.name, '❄️snowflake-ci')
       ))
     concurrency:
-      group: snowflake-ci-${{ github.head_ref || github.ref }}
-      cancel-in-progress: true
+      group: snowflake-dbt-project
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Changes CI concurrency from per-branch to global queue. The Snowflake dbt project (DBT_NCL_ANALYTICS__CI) cannot run concurrently, so all PR validation runs must wait for previous runs to complete.