### PR TITLE
Add performance analysis scripts

### DIFF
--- a/analyses/performance/incremental_candidates.sql
+++ b/analyses/performance/incremental_candidates.sql
@@ -1,0 +1,81 @@
+/*
+  Incremental Candidates Analysis
+  
+  Identifies table-materialized models that could benefit from incremental materialization.
+  
+  Good candidates:
+  - Slow build times (>60s average)
+  - Low row growth (<10% change)
+  - Has timestamp columns for incremental logic
+  
+  Uses:
+  - Elementary model_run_results for execution times
+  - Custom row_count_log for row count trends
+  - Elementary dbt_columns for timestamp column detection
+*/
+
+WITH model_stats AS (
+  SELECT
+    name AS model_name,
+    AVG(execution_time) AS avg_runtime_secs,
+    MAX(execution_time) AS max_runtime_secs,
+    COUNT(*) AS run_count
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.MODEL_RUN_RESULTS
+  WHERE generated_at > DATEADD('day', -14, CURRENT_DATE)
+    AND status = 'success'
+  GROUP BY 1
+),
+
+row_counts AS (
+  SELECT
+    model_name,
+    MAX(row_count) AS latest_row_count,
+    MAX(row_count) - MIN(row_count) AS row_growth_14d,
+    DIV0(MAX(row_count) - MIN(row_count), NULLIF(MAX(row_count), 0)) AS growth_pct
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.ROW_COUNT_LOG
+  WHERE recorded_at > DATEADD('day', -14, CURRENT_DATE)
+  GROUP BY 1
+),
+
+-- Check if model has timestamp columns (good incremental candidates)
+model_columns AS (
+  SELECT DISTINCT
+    SPLIT_PART(parent_unique_id, '.', 3) AS model_name,
+    TRUE AS has_timestamp_column
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.DBT_COLUMNS
+  WHERE LOWER(name) LIKE ANY ('%_date', '%_at', '%_timestamp', '%updated%', '%created%', '%loaded%')
+    AND resource_type = 'model'
+),
+
+table_models AS (
+  SELECT 
+    name AS model_name,
+    materialization
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.DBT_MODELS
+  WHERE materialization = 'table'
+)
+
+SELECT
+  t.model_name,
+  t.materialization,
+  ROUND(s.avg_runtime_secs, 1) AS avg_runtime_secs,
+  ROUND(s.max_runtime_secs, 1) AS max_runtime_secs,
+  r.latest_row_count,
+  ROUND(r.growth_pct * 100, 1) AS growth_pct,
+  COALESCE(c.has_timestamp_column, FALSE) AS has_timestamp_column,
+  CASE
+    WHEN s.avg_runtime_secs > 60 
+     AND COALESCE(r.growth_pct, 0) < 0.1 
+     AND c.has_timestamp_column 
+    THEN '🔥 Strong candidate'
+    WHEN s.avg_runtime_secs > 30 
+     AND c.has_timestamp_column 
+    THEN '⚠️ Worth investigating'
+    ELSE 'ℹ️ Probably fine as table'
+  END AS recommendation
+FROM table_models t
+LEFT JOIN model_stats s ON t.model_name = s.model_name
+LEFT JOIN row_counts r ON t.model_name = r.model_name
+LEFT JOIN model_columns c ON t.model_name = c.model_name
+WHERE s.avg_runtime_secs > 30  -- Only models taking >30s
+ORDER BY s.avg_runtime_secs DESC NULLS LAST

--- a/analyses/performance/slow_models_report.sql
+++ b/analyses/performance/slow_models_report.sql
@@ -1,0 +1,54 @@
+/*
+  Slow Models Report
+  
+  Quick overview of models exceeding time thresholds.
+  Useful for identifying optimization priorities.
+  
+  Uses:
+  - Elementary model_run_results for execution times
+*/
+
+WITH run_stats AS (
+  SELECT
+    name AS model_name,
+    materialization,
+    database_name,
+    schema_name,
+    AVG(execution_time) AS avg_runtime_secs,
+    MAX(execution_time) AS max_runtime_secs,
+    MIN(execution_time) AS min_runtime_secs,
+    STDDEV(execution_time) AS stddev_runtime,
+    COUNT(*) AS run_count,
+    SUM(execution_time) AS total_runtime_secs
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.MODEL_RUN_RESULTS
+  WHERE generated_at > DATEADD('day', -14, CURRENT_DATE)
+    AND status = 'success'
+  GROUP BY 1, 2, 3, 4
+)
+
+SELECT
+  model_name,
+  materialization,
+  database_name || '.' || schema_name AS location,
+  ROUND(avg_runtime_secs, 1) AS avg_secs,
+  ROUND(max_runtime_secs, 1) AS max_secs,
+  ROUND(min_runtime_secs, 1) AS min_secs,
+  ROUND(stddev_runtime, 1) AS stddev_secs,
+  run_count AS runs_14d,
+  ROUND(total_runtime_secs / 60, 1) AS total_mins_14d,
+  CASE
+    WHEN avg_runtime_secs > 300 THEN '🔴 Critical (>5min)'
+    WHEN avg_runtime_secs > 120 THEN '🟠 High (>2min)'
+    WHEN avg_runtime_secs > 60 THEN '🟡 Medium (>1min)'
+    WHEN avg_runtime_secs > 30 THEN '🟢 Low (>30s)'
+    ELSE '✅ Fast'
+  END AS severity,
+  CASE
+    WHEN materialization = 'table' AND avg_runtime_secs > 60 THEN 'Consider incremental'
+    WHEN materialization = 'view' AND avg_runtime_secs > 30 THEN 'Consider table'
+    WHEN stddev_runtime / NULLIF(avg_runtime_secs, 0) > 0.5 THEN 'Inconsistent - investigate'
+    ELSE 'Review query optimization'
+  END AS suggestion
+FROM run_stats
+WHERE avg_runtime_secs > 30  -- Only show models taking >30s on average
+ORDER BY avg_runtime_secs DESC

--- a/analyses/performance/table_to_view_candidates.sql
+++ b/analyses/performance/table_to_view_candidates.sql
@@ -1,0 +1,83 @@
+/*
+  Table to View Candidates Analysis
+  
+  Identifies table-materialized models with NO downstream dependencies
+  that could potentially be converted to views.
+  
+  Good candidates:
+  - No downstream dbt models depend on them (leaf nodes)
+  - Fast build time (<30s) - won't hurt end users
+  - Rarely queried by end users
+  
+  Caution:
+  - If heavily queried by BI tools, keep as table
+  - If build time is long, keep as table (don't punish users)
+  
+  Uses:
+  - Elementary dbt_models for dependencies
+  - Elementary model_run_results for build times
+  - Snowflake ACCESS_HISTORY for query frequency (optional - requires ACCOUNTADMIN)
+*/
+
+WITH table_models AS (
+  SELECT 
+    unique_id,
+    name AS model_name,
+    database_name,
+    schema_name,
+    materialization
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.DBT_MODELS
+  WHERE materialization = 'table'
+),
+
+-- Find all models that ARE dependencies of other models
+upstream_models AS (
+  SELECT DISTINCT
+    dep.value::STRING AS unique_id
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.DBT_MODELS m,
+       LATERAL FLATTEN(input => TRY_PARSE_JSON(m.depends_on_nodes)) dep
+  WHERE dep.value::STRING LIKE 'model.%'
+),
+
+-- Get build time statistics
+run_stats AS (
+  SELECT
+    name AS model_name,
+    AVG(execution_time) AS avg_build_secs,
+    COUNT(*) AS builds_last_14d
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.MODEL_RUN_RESULTS
+  WHERE generated_at > DATEADD('day', -14, CURRENT_DATE)
+    AND status = 'success'
+  GROUP BY 1
+),
+
+-- Get row counts for context
+row_counts AS (
+  SELECT
+    model_name,
+    MAX(row_count) AS latest_row_count
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.ROW_COUNT_LOG
+  WHERE recorded_at > DATEADD('day', -7, CURRENT_DATE)
+  GROUP BY 1
+)
+
+SELECT
+  t.model_name,
+  t.database_name || '.' || t.schema_name AS location,
+  ROUND(COALESCE(r.avg_build_secs, 0), 1) AS avg_build_secs,
+  COALESCE(rc.latest_row_count, 0) AS row_count,
+  CASE
+    WHEN u.unique_id IS NOT NULL THEN '❌ Has downstream deps - keep as table'
+    WHEN COALESCE(r.avg_build_secs, 0) > 120 THEN '⚠️ Slow build - view would hurt users'
+    WHEN COALESCE(r.avg_build_secs, 0) > 60 THEN 'ℹ️ Moderate build time - review manually'
+    WHEN COALESCE(r.avg_build_secs, 0) < 30 
+      THEN '🔥 Fast leaf node - good candidate for view'
+    ELSE 'ℹ️ Review manually'
+  END AS recommendation,
+  CASE WHEN u.unique_id IS NULL THEN TRUE ELSE FALSE END AS is_leaf_node
+FROM table_models t
+LEFT JOIN upstream_models u ON t.unique_id = u.unique_id
+LEFT JOIN run_stats r ON t.model_name = r.model_name
+LEFT JOIN row_counts rc ON t.model_name = rc.model_name
+WHERE u.unique_id IS NULL  -- Only leaf nodes (no downstream dependencies)
+ORDER BY r.avg_build_secs ASC NULLS LAST

--- a/analyses/performance/view_to_table_candidates.sql
+++ b/analyses/performance/view_to_table_candidates.sql
@@ -1,0 +1,75 @@
+/*
+  View to Table Candidates Analysis
+  
+  Identifies view-materialized models that might benefit from table materialization.
+  
+  Good candidates:
+  - Many downstream dependencies (>5 models depend on it)
+  - Heavily queried by end users
+  - Complex logic that gets recomputed each time
+  
+  Uses:
+  - Elementary dbt_models for materialization and dependencies
+  - Snowflake QUERY_HISTORY for user query patterns (optional)
+*/
+
+WITH view_models AS (
+  SELECT 
+    unique_id,
+    name AS model_name,
+    database_name,
+    schema_name,
+    materialization,
+    depends_on_nodes
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.DBT_MODELS
+  WHERE materialization = 'view'
+),
+
+-- Parse depends_on_nodes to count downstream dependencies
+all_models AS (
+  SELECT 
+    unique_id,
+    name AS model_name,
+    depends_on_nodes
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.DBT_MODELS
+),
+
+-- Flatten dependencies to find downstream counts
+downstream_counts AS (
+  SELECT
+    dep.value::STRING AS upstream_unique_id,
+    COUNT(DISTINCT m.unique_id) AS downstream_count
+  FROM all_models m,
+       LATERAL FLATTEN(input => TRY_PARSE_JSON(m.depends_on_nodes)) dep
+  WHERE dep.value::STRING LIKE 'model.%'
+  GROUP BY 1
+),
+
+-- Get average execution time for views (from their runs as dependencies)
+view_run_stats AS (
+  SELECT
+    name AS model_name,
+    AVG(execution_time) AS avg_runtime_secs,
+    COUNT(*) AS run_count
+  FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.MODEL_RUN_RESULTS
+  WHERE generated_at > DATEADD('day', -14, CURRENT_DATE)
+    AND status = 'success'
+  GROUP BY 1
+)
+
+SELECT
+  v.model_name,
+  v.database_name || '.' || v.schema_name AS location,
+  COALESCE(d.downstream_count, 0) AS downstream_models,
+  ROUND(COALESCE(r.avg_runtime_secs, 0), 1) AS avg_runtime_secs,
+  CASE
+    WHEN COALESCE(d.downstream_count, 0) >= 5 THEN '🔥 Many dependents - consider table'
+    WHEN COALESCE(d.downstream_count, 0) >= 3 AND COALESCE(r.avg_runtime_secs, 0) > 10 THEN '⚠️ Multiple deps + slow - consider table'
+    WHEN COALESCE(r.avg_runtime_secs, 0) > 30 THEN '⚠️ Very slow view - consider table'
+    ELSE 'ℹ️ Probably fine as view'
+  END AS recommendation
+FROM view_models v
+LEFT JOIN downstream_counts d ON v.unique_id = d.upstream_unique_id
+LEFT JOIN view_run_stats r ON v.model_name = r.model_name
+WHERE COALESCE(d.downstream_count, 0) >= 1  -- Only views with at least 1 dependent
+ORDER BY COALESCE(d.downstream_count, 0) DESC, r.avg_runtime_secs DESC NULLS LAST


### PR DESCRIPTION
## Summary
- Add SQL analyses for identifying dbt model optimization opportunities
- Scripts query Elementary observability tables to identify slow models, incremental candidates, and view/table conversion opportunities
- Uses hardcoded table references to `DATA_LAKE__NCL.DBT_OBSERVABILITY` schema

## Scripts
- `incremental_candidates.sql` - tables that could benefit from incremental materialization
- `slow_models_report.sql` - models exceeding time thresholds with severity ratings
- `table_to_view_candidates.sql` - leaf node tables that could become views
- `view_to_table_candidates.sql` - views with many dependents that should be tables

## Test plan
- [x] Run each script against Snowflake to verify queries execute
- [x] Validate output recommendations make sense for known models