### PR TITLE
Fix CI/deploy to detect models when .yml files change

### DIFF
--- a/.github/workflows/dbt-deploy.yml
+++ b/.github/workflows/dbt-deploy.yml
@@ -48,8 +48,31 @@ jobs:
         id: changes
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
-            # --diff-filter=d excludes deleted files (only include added/modified/renamed)
-            CHANGED=$(git diff --name-only --diff-filter=d ${{ github.event.before }} ${{ github.sha }} -- 'models/**/*.sql' | tr '\n' ' ')
+            # Get changed .sql files directly
+            SQL_FILES=$(git diff --name-only --diff-filter=d ${{ github.event.before }} ${{ github.sha }} -- 'models/**/*.sql')
+            
+            # Get changed .yml/.yaml files and find associated .sql models
+            YML_FILES=$(git diff --name-only --diff-filter=d ${{ github.event.before }} ${{ github.sha }} -- 'models/**/*.yml' 'models/**/*.yaml')
+            
+            # For each yml file, find corresponding sql file(s) in same directory
+            YML_DERIVED_SQL=""
+            for yml in $YML_FILES; do
+              dir=$(dirname "$yml")
+              # Check if a .sql file with same base name exists
+              base=$(basename "$yml" .yml)
+              base=$(basename "$base" .yaml)
+              if [ -f "$dir/$base.sql" ]; then
+                YML_DERIVED_SQL="$YML_DERIVED_SQL $dir/$base.sql"
+              fi
+              # Also include all .sql files in same directory (yml may define multiple models)
+              for sql in "$dir"/*.sql; do
+                [ -f "$sql" ] && YML_DERIVED_SQL="$YML_DERIVED_SQL $sql"
+              done
+            done
+            
+            # Combine and deduplicate
+            CHANGED=$(echo "$SQL_FILES $YML_DERIVED_SQL" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+            [ -n "$YML_FILES" ] && echo "YML changes detected - included associated models"
           else
             CHANGED=""  # Manual trigger = full build
           fi

--- a/.github/workflows/dbt-pr-validation.yml
+++ b/.github/workflows/dbt-pr-validation.yml
@@ -60,12 +60,35 @@ jobs:
       - name: Get changed models
         id: changes
         run: |
-          # --diff-filter=d excludes deleted files (only include added/modified/renamed)
-          CHANGED=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD -- 'models/**/*.sql' | tr '\n' ' ')
+          # Get changed .sql files directly
+          SQL_FILES=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD -- 'models/**/*.sql')
+          
+          # Get changed .yml/.yaml files and find associated .sql models
+          YML_FILES=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD -- 'models/**/*.yml' 'models/**/*.yaml')
+          
+          # For each yml file, find corresponding sql file(s) in same directory
+          YML_DERIVED_SQL=""
+          for yml in $YML_FILES; do
+            dir=$(dirname "$yml")
+            # Check if a .sql file with same base name exists
+            base=$(basename "$yml" .yml)
+            base=$(basename "$base" .yaml)
+            if [ -f "$dir/$base.sql" ]; then
+              YML_DERIVED_SQL="$YML_DERIVED_SQL $dir/$base.sql"
+            fi
+            # Also include all .sql files in same directory (yml may define multiple models)
+            for sql in "$dir"/*.sql; do
+              [ -f "$sql" ] && YML_DERIVED_SQL="$YML_DERIVED_SQL $sql"
+            done
+          done
+          
+          # Combine and deduplicate
+          CHANGED=$(echo "$SQL_FILES $YML_DERIVED_SQL" | tr ' ' '\n' | sort -u | tr '\n' ' ')
           COUNT=$(echo "$CHANGED" | wc -w)
           echo "changed_files=$CHANGED" >> $GITHUB_OUTPUT
           echo "file_count=$COUNT" >> $GITHUB_OUTPUT
           echo "Found $COUNT changed model files"
+          [ -n "$YML_FILES" ] && echo "YML changes detected - included associated models"
 
       - name: Setup Snowflake credentials
         if: steps.changes.outputs.file_count != '0'


### PR DESCRIPTION
## Problem

When only \.yml\ files change (e.g., adding tests), the CI workflow triggers but finds 0 models to build because it only looks at \.sql\ file changes.

Example: PR #456 added grain tests to 24 models via \.yml\ changes - CI passed in 20 seconds without actually validating anything.

## Solution

Updated both \dbt-pr-validation.yml\ and \dbt-deploy.yml\ to:
1. Detect changed \.yml\/\.yaml\ files in \models/\
2. Find associated \.sql\ models in the same directory
3. Include those models in the dbt build

## Changes

- \dbt-pr-validation.yml\: Updated \Get changed models\ step
- \dbt-deploy.yml\: Updated \Get changed models\ step

Both now detect yml changes and include all \.sql\ files in the same directory (since a single yml can define multiple models).