### PR TITLE
Fix CI concurrency: use turnstyle for cross-PR queuing

### DIFF
--- a/.github/workflows/dbt-pr-validation.yml
+++ b/.github/workflows/dbt-pr-validation.yml
@@ -44,14 +44,24 @@ jobs:
         contains(github.event.pull_request.labels.*.name, '❄️snowflake-ci')
       ))
     concurrency:
-      group: snowflake-dbt-project
-      cancel-in-progress: false
+      # Per-PR concurrency: new commits to same PR cancel old runs
+      group: pr-validation-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       contents: read
+      actions: read  # Required for turnstyle to check workflow runs
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+
+      # Queue across different PRs - Snowflake dbt project can only run one branch at a time
+      - name: Wait for other PR validations
+        uses: softprops/turnstyle@v2
+        with:
+          same-branch-only: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
         with:


### PR DESCRIPTION
## Problem

GitHub's built-in concurrency with `cancel-in-progress: false` still cancels running jobs when a 'higher priority' request enters the queue:

```
Canceling since a higher priority waiting request for snowflake-dbt-project exists
```

## Solution

Two-level concurrency:

1. **Per-PR concurrency group** with `cancel-in-progress: true`
   - New commits to the same PR cancel old runs ✓

2. **Turnstyle action** for cross-PR queuing
   - Different PRs wait in queue for Snowflake access ✓
   - Snowflake dbt project can only sync one branch at a time

## Changes

- `dbt-pr-validation.yml`: Updated concurrency + added turnstyle step
- Added `actions: read` permission (required for turnstyle)
