### PR TITLE
Revert PR #458: CKD breaking change

### DIFF
--- a/models/modelling/olids/diagnoses/qof/int_ckd_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_ckd_diagnoses_all.sql
@@ -7,8 +7,7 @@
 /*
 All chronic kidney disease (CKD) diagnosis observations from clinical records.
 Uses QOF CKD cluster IDs:
-- CKD_COD: CKD Stage 3-5 diagnoses (register inclusion)
-- CKD1AND2_COD: CKD Stage 1-2 diagnoses (downstaging exclusion)
+- CKD_COD: CKD diagnoses
 - CKDRES_COD: CKD resolved/remission codes
 
 Clinical Purpose:
@@ -17,10 +16,10 @@ Clinical Purpose:
 - CKD staging and progression tracking
 - Resolution status monitoring
 
-QOF Context (v50):
-CKD register includes persons aged 18+ with CKD Stage 3-5 diagnosis who have not:
-- Been resolved (CKDRES_COD after CKD_COD)
-- Been downstaged to Stage 1-2 (CKD1AND2_COD after CKD_COD)
+QOF Context:
+CKD register includes persons with CKD diagnosis codes who have not
+been resolved. Resolution logic applied in downstream fact models.
+Age restrictions typically ≥18 years applied in fact layer.
 
 Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
 This is OBSERVATION-LEVEL data - one row per CKD observation.
@@ -36,18 +35,16 @@ SELECT
     obs.cluster_id AS source_cluster_id,
 
     -- CKD-specific flags (observation-level only)
-    CASE WHEN obs.cluster_id = 'CKD_COD' THEN TRUE ELSE FALSE END AS is_stage_3_5_code,
-    CASE WHEN obs.cluster_id = 'CKD1AND2_COD' THEN TRUE ELSE FALSE END AS is_stage_1_2_code,
+    CASE WHEN obs.cluster_id = 'CKD_COD' THEN TRUE ELSE FALSE END AS is_diagnosis_code,
     CASE WHEN obs.cluster_id = 'CKDRES_COD' THEN TRUE ELSE FALSE END AS is_resolved_code,
 
     -- CKD observation type determination
     CASE
-        WHEN obs.cluster_id = 'CKD_COD' THEN 'CKD Stage 3-5'
-        WHEN obs.cluster_id = 'CKD1AND2_COD' THEN 'CKD Stage 1-2'
+        WHEN obs.cluster_id = 'CKD_COD' THEN 'CKD Diagnosis'
         WHEN obs.cluster_id = 'CKDRES_COD' THEN 'CKD Resolved'
         ELSE 'Unknown'
     END AS ckd_observation_type
 
-FROM ({{ get_observations("'CKD_COD', 'CKD1AND2_COD', 'CKDRES_COD'", source='PCD') }}) obs
+FROM ({{ get_observations("'CKD_COD', 'CKDRES_COD'", source='PCD') }}) obs
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/qof/int_ckd_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/qof/int_ckd_diagnoses_all.yml
@@ -1,13 +1,11 @@
 version: 2
 models:
   - name: int_ckd_diagnoses_all
-    description: >
-      Chronic kidney disease diagnosis and resolution observations for QOF register management.
-      One row per observation using CKD_COD (Stage 3-5), CKD1AND2_COD (Stage 1-2), and 
-      CKDRES_COD (resolved) clusters. Age restrictions ≥18 years applied downstream.
-      
-      QOF v50 register logic excludes patients who have been downstaged to Stage 1-2 or 
-      resolved after their latest Stage 3-5 diagnosis.
+    description: 'Chronic kidney disease diagnosis and resolution observations for
+      QOF register management.
+
+      One row per observation using CKD_COD (diagnosis) and CKDRES_COD (resolved)
+      clusters. Age restrictions ≥18 years typically applied downstream.'
     config:
       meta:
         owner:
@@ -26,28 +24,25 @@ models:
         description: 'Date when CKD observation was clinically effective'
 
       - name: concept_code
-        description: 'Clinical code for CKD diagnosis, staging, or resolution'
+        description: 'Clinical code for CKD diagnosis or resolution'
 
       - name: concept_display
         description: 'Human-readable description of the clinical code'
 
       - name: source_cluster_id
-        description: 'QOF cluster identifier (CKD_COD, CKD1AND2_COD, or CKDRES_COD)'
+        description: 'QOF cluster identifier (CKD_COD or CKDRES_COD)'
 
-      - name: is_stage_3_5_code
-        description: 'Flag indicating CKD Stage 3-5 diagnosis code (CKD_COD cluster)'
-
-      - name: is_stage_1_2_code
-        description: 'Flag indicating CKD Stage 1-2 code (CKD1AND2_COD cluster) - used for downstaging exclusion'
+      - name: is_diagnosis_code
+        description: 'Flag indicating CKD diagnosis code (CKD_COD cluster)'
 
       - name: is_resolved_code
         description: 'Flag indicating CKD resolution code (CKDRES_COD cluster)'
 
       - name: ckd_observation_type
-        description: 'Categorised CKD observation type (CKD Stage 3-5, CKD Stage 1-2, or CKD Resolved)'
+        description: 'Categorised CKD observation type (CKD Diagnosis or CKD Resolved)'
 
     tests:
       - dbt_utils.at_least_one:
           column_name: id
       - cluster_ids_exist:
-          cluster_ids: CKD_COD, CKD1AND2_COD, CKDRES_COD
+          cluster_ids: CKDRES_COD, CKD_COD

--- a/models/reporting/olids/disease_registers/qof/fct_person_ckd_register.sql
+++ b/models/reporting/olids/disease_registers/qof/fct_person_ckd_register.sql
@@ -4,59 +4,42 @@
         cluster_by=['person_id'])
 }}
 
-/*
-Chronic Kidney Disease (CKD) Register - QOF v50
-
-Business Logic:
-- Age ≥18 years
-- Has CKD Stage 3-5 diagnosis (CKD_COD)
-- NOT downstaged: no CKD Stage 1-2 code (CKD1AND2_COD) after latest Stage 3-5
-- NOT resolved: no resolved code (CKDRES_COD) after latest Stage 3-5
-
-Lab data available separately in intermediate tables for clinical monitoring.
-*/
+-- Chronic Kidney Disease (CKD) Register
+-- Business Logic: Age ≥18 + Active CKD diagnosis (latest CKD_COD > latest CKDRES_COD OR no resolution recorded)
+-- Lab data available separately in intermediate tables for clinical monitoring
 
 WITH ckd_diagnoses AS (
     SELECT
         person_id,
 
         -- Person-level aggregation from observation-level data
-        MIN(CASE WHEN is_stage_3_5_code THEN clinical_effective_date END)
+        MIN(CASE WHEN is_diagnosis_code THEN clinical_effective_date END)
             AS earliest_diagnosis_date,
-        MAX(CASE WHEN is_stage_3_5_code THEN clinical_effective_date END)
+        MAX(CASE WHEN is_diagnosis_code THEN clinical_effective_date END)
             AS latest_diagnosis_date,
-        MAX(CASE WHEN is_stage_1_2_code THEN clinical_effective_date END)
-            AS latest_stage_1_2_date,
         MAX(CASE WHEN is_resolved_code THEN clinical_effective_date END)
             AS latest_resolved_date,
 
-        -- QOF register logic: active Stage 3-5 diagnosis required
-        -- Excluded if downstaged to Stage 1-2 OR resolved after latest Stage 3-5
-        COALESCE(
-            -- Must have a Stage 3-5 diagnosis
-            MAX(CASE WHEN is_stage_3_5_code THEN clinical_effective_date END) IS NOT NULL
-            -- Must not have been downstaged to Stage 1-2 after latest Stage 3-5
-            AND (
-                MAX(CASE WHEN is_stage_1_2_code THEN clinical_effective_date END) IS NULL
-                OR MAX(CASE WHEN is_stage_3_5_code THEN clinical_effective_date END)
-                    > MAX(CASE WHEN is_stage_1_2_code THEN clinical_effective_date END)
+        -- QOF register logic: active diagnosis required
+        COALESCE(MAX(
+            CASE WHEN is_diagnosis_code THEN clinical_effective_date END
+        ) IS NOT NULL
+        AND (
+            MAX(
+                CASE WHEN is_resolved_code THEN clinical_effective_date END
+            ) IS NULL
+            OR MAX(
+                CASE WHEN is_diagnosis_code THEN clinical_effective_date END
             )
-            -- Must not have been resolved after latest Stage 3-5
-            AND (
-                MAX(CASE WHEN is_resolved_code THEN clinical_effective_date END) IS NULL
-                OR MAX(CASE WHEN is_stage_3_5_code THEN clinical_effective_date END)
-                    > MAX(CASE WHEN is_resolved_code THEN clinical_effective_date END)
-            ),
-            FALSE
-        ) AS has_active_ckd_diagnosis,
+            > MAX(
+                CASE WHEN is_resolved_code THEN clinical_effective_date END
+            )
+        ), FALSE) AS has_active_ckd_diagnosis,
 
         -- Traceability arrays
         ARRAY_AGG(
-            DISTINCT CASE WHEN is_stage_3_5_code THEN concept_code END
+            DISTINCT CASE WHEN is_diagnosis_code THEN concept_code END
         ) AS all_ckd_concept_codes,
-        ARRAY_AGG(
-            DISTINCT CASE WHEN is_stage_1_2_code THEN concept_code END
-        ) AS all_stage_1_2_concept_codes,
         ARRAY_AGG(
             DISTINCT CASE WHEN is_resolved_code THEN concept_code END
         ) AS all_resolved_concept_codes
@@ -68,42 +51,35 @@ WITH ckd_diagnoses AS (
 register_logic AS (
     SELECT
         diag.person_id,
-        age.age,
 
-        -- Clinical dates
+        -- Age restriction: ≥18 years for CKD register
         diag.earliest_diagnosis_date,
+
+        -- Diagnosis component (only requirement)
         diag.latest_diagnosis_date,
-        diag.latest_stage_1_2_date,
+
+        -- Final register inclusion: Age + Active diagnosis required
         diag.latest_resolved_date,
 
-        -- Traceability arrays
+        -- Clinical dates
         diag.all_ckd_concept_codes,
-        diag.all_stage_1_2_concept_codes,
         diag.all_resolved_concept_codes,
+        age.age,
 
-        -- Criteria flags for transparency
+        -- Traceability
         COALESCE(age.age >= 18, FALSE) AS meets_age_criteria,
         COALESCE(diag.has_active_ckd_diagnosis, FALSE) AS has_active_diagnosis,
 
-        -- Downstaging flag: TRUE if patient was downstaged to Stage 1-2 after Stage 3-5
-        COALESCE(
-            diag.latest_stage_1_2_date IS NOT NULL
-            AND diag.latest_stage_1_2_date > diag.latest_diagnosis_date,
-            FALSE
-        ) AS was_downstaged,
-
-        -- Final register inclusion: Age + Active diagnosis (not downstaged, not resolved)
+        -- Person demographics
         COALESCE(
             age.age >= 18
-            AND diag.has_active_ckd_diagnosis = TRUE,
-            FALSE
+            AND diag.has_active_ckd_diagnosis = TRUE, FALSE
         ) AS is_on_register
-
     FROM ckd_diagnoses AS diag
     INNER JOIN {{ ref('dim_person_age') }} AS age ON diag.person_id = age.person_id
 )
 
--- Final selection: Only individuals with active CKD Stage 3-5 diagnosis
+-- Final selection: Only individuals with active CKD diagnosis
 SELECT
     person_id,
     age,
@@ -112,18 +88,14 @@ SELECT
     -- Clinical diagnosis dates
     earliest_diagnosis_date,
     latest_diagnosis_date,
-    latest_stage_1_2_date,
     latest_resolved_date,
 
     -- Traceability for audit
     all_ckd_concept_codes,
-    all_stage_1_2_concept_codes,
     all_resolved_concept_codes,
 
     -- Criteria flags for transparency
     meets_age_criteria,
-    has_active_diagnosis,
-    was_downstaged
-
+    has_active_diagnosis
 FROM register_logic
 WHERE is_on_register = TRUE

--- a/models/reporting/olids/disease_registers/qof/fct_person_ckd_register.yml
+++ b/models/reporting/olids/disease_registers/qof/fct_person_ckd_register.yml
@@ -1,13 +1,11 @@
 version: 2
 models:
   - name: fct_person_ckd_register
-    description: >
-      QOF chronic kidney disease register for patients aged 18+ with active CKD Stage 3-5 diagnosis.
-      
-      One row per person meeting QOF v50 criteria:
-      - Has CKD Stage 3-5 diagnosis (CKD_COD)
-      - NOT downstaged to Stage 1-2 (no CKD1AND2_COD after latest CKD_COD)
-      - NOT resolved (no CKDRES_COD after latest CKD_COD)
+    description: 'QOF chronic kidney disease register for patients aged 18+ with active
+      CKD diagnosis.
+
+      One row per person with latest CKD_COD > latest CKDRES_COD or no resolution
+      recorded.'
 
     tests:
       - dbt_utils.at_least_one:
@@ -20,15 +18,6 @@ models:
           - unique
           - not_null
 
-      - name: latest_stage_1_2_date
-        description: Date of most recent CKD Stage 1-2 code (for downstaging tracking)
-
-      - name: all_stage_1_2_concept_codes
-        description: Array of all CKD Stage 1-2 concept codes for traceability
-
-      - name: was_downstaged
-        description: Flag indicating patient has Stage 1-2 code after latest Stage 3-5 (excluded from register)
-
     config:
       meta:
         indicator:
@@ -39,10 +28,11 @@ models:
           name_short: "Chronic Kidney Disease"
           description_short: "QOF chronic kidney disease register"
           description_long: >
-            Chronic kidney disease diagnosed using QOF v50 criteria: Age ≥18 years with
-            active CKD Stage 3-5 diagnosis where patient has not been downstaged to Stage 1-2
-            or resolved. Lab data available separately for clinical monitoring.
-            Maps to QOF indicator CKD005 (CKD Register).
+            Chronic kidney disease diagnosed using QOF criteria: Age ≥18 years with
+            active  CKD diagnosis where latest CKD code is more recent than any resolution
+            code, or  no resolution recorded. Lab data available separately for clinical
+            monitoring.  Maps to QOF indicator CKD005 (CKD Register). Uses CKD_COD
+            for diagnosis codes  and CKDRES_COD for resolution codes.
           is_qof: true
           qof_indicator: "CKD005"
           source_column: "is_on_register"
@@ -52,8 +42,6 @@ models:
           code_clusters:
             - cluster_id: "CKD_COD"
               category: "INCLUSION"
-            - cluster_id: "CKD1AND2_COD"
-              category: "EXCLUSION"
             - cluster_id: "CKDRES_COD"
               category: "RESOLUTION"
         owner:


### PR DESCRIPTION
Reverts #458 which broke the interface by renaming \is_diagnosis_code\ to \is_stage_3_5_code\ without maintaining backward compatibility.

**Broken models in prod:**
- \pit_ckd_register\
- \ct_person_condition_episodes\

Will re-submit with proper alias to maintain interface.