### PR TITLE
fix(ckd): add backward-compatible is_diagnosis_code alias

### DIFF
--- a/models/modelling/olids/diagnoses/qof/int_ckd_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/qof/int_ckd_diagnoses_all.sql
@@ -39,6 +39,9 @@ SELECT
     CASE WHEN obs.cluster_id = 'CKD_COD' THEN TRUE ELSE FALSE END AS is_stage_3_5_code,
     CASE WHEN obs.cluster_id = 'CKD1AND2_COD' THEN TRUE ELSE FALSE END AS is_stage_1_2_code,
     CASE WHEN obs.cluster_id = 'CKDRES_COD' THEN TRUE ELSE FALSE END AS is_resolved_code,
+    
+    -- Backward compatibility alias (used by calculate_ckd_register macro and fct_person_condition_episodes)
+    CASE WHEN obs.cluster_id = 'CKD_COD' THEN TRUE ELSE FALSE END AS is_diagnosis_code,
 
     -- CKD observation type determination
     CASE


### PR DESCRIPTION
Adds backward-compatible alias for \is_diagnosis_code\ that mirrors \is_stage_3_5_code\.

**Why:** PR #458 renamed the column, breaking:
- \calculate_ckd_register\ macro
- \ct_person_condition_episodes\
- \pit_ckd_register\

**Fix:** Keep both column names - new semantic name + old interface.

**Alternative to PR #476 (revert):** This is faster to fix prod - just merge this instead of the revert.