### PR TITLE
fix(start_dbt): use POSIX-compatible syntax for zsh support

### DIFF
--- a/start_dbt.sh
+++ b/start_dbt.sh
@@ -76,8 +76,11 @@ if [ -f ".env" ]; then
     while IFS= read -r line || [ -n "$line" ]; do
         # Skip comments and empty lines
         [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
-        if [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then
-            export "${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"
+        # Extract key=value (compatible with both bash and zsh)
+        if [[ "$line" == *"="* ]]; then
+            key="${line%%=*}"
+            value="${line#*=}"
+            export "$key=$value"
             ((env_count++))
         fi
     done < ".env"


### PR DESCRIPTION
## Summary
- Replaces `BASH_REMATCH` with POSIX-compatible parameter expansion (`${var%%=*}` and `${var#*=}`) for parsing .env files
- Adds execute permission to the script

## Problem
When VS Code sources `start_dbt.sh` with zsh (the default for WSL), the script fails with exit code 126 because `BASH_REMATCH` is bash-specific.

## Test plan
- [ ] Open a new terminal in VS Code on (zsh)
- [ ] Verify the script runs without errors
- [ ] Confirm environment variables are loaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)