### PR TITLE
fix: Update QOF PIT register macros for v50

### DIFF
--- a/models/reporting/olids/disease_registers/qof_pit/pit_ckd_register.sql
+++ b/models/reporting/olids/disease_registers/qof_pit/pit_ckd_register.sql
@@ -5,6 +5,16 @@
     )
 }}
 
+/*
+CKD Register - Point in Time (PIT)
+
+QOF v50 Business Logic (via calculate_ckd_register macro):
+- Age ≥18 at reference date
+- Has CKD Stage 3-5 diagnosis (CKD_COD)
+- NOT downstaged to Stage 1-2 (CKD1AND2_COD) after latest Stage 3-5
+- NOT resolved (CKDRES_COD) after latest Stage 3-5
+*/
+
 WITH register_data AS (
     {{ calculate_ckd_register(reference_date_expr=get_reference_date()) }}
 )

--- a/models/reporting/olids/disease_registers/qof_pit/pit_ckd_register.yml
+++ b/models/reporting/olids/disease_registers/qof_pit/pit_ckd_register.yml
@@ -3,7 +3,8 @@ version: 2
 models:
   - name: pit_ckd_register
     description: >
-      Ckd register calculated as of reference date {{ var('qof_reference_date') }}.
+      CKD register calculated as of reference date {{ var('qof_reference_date') }}.
+      QOF v50: Stage 3-5 diagnosis, excluding downstaged (Stage 1-2) and resolved patients.
       Override with: dbt build --vars '{"qof_reference_date": "YYYY-MM-DD"}'
     config:
       meta:
@@ -20,7 +21,7 @@ models:
           - unique
           - not_null
       - name: register_name
-        description: Register name (e.g., 'Chronic Kidney Disease')
+        description: Register name (CKD)
       - name: is_on_register
         description: Whether person qualifies for register at reference date
       - name: reference_date

--- a/models/reporting/olids/disease_registers/qof_pit/pit_copd_register.sql
+++ b/models/reporting/olids/disease_registers/qof_pit/pit_copd_register.sql
@@ -5,6 +5,16 @@
     )
 }}
 
+/*
+COPD Register - Point in Time (PIT)
+
+QOF v50 Business Logic (via calculate_copd_register macro):
+- Rule 1: EUNRESCOPD_DAT < 01/04/2023 → automatic inclusion
+- Rule 2: EUNRESCOPD_DAT >= 01/04/2023 + spirometry <0.7 within timeframe
+- Rule 3: Newly registered + spirometry within timeframe
+- Rule 4: All remaining post-April 2023 patients (no SPIRPU_COD required)
+*/
+
 WITH register_data AS (
     {{ calculate_copd_register(reference_date_expr=get_reference_date()) }}
 )

--- a/models/reporting/olids/disease_registers/qof_pit/pit_learning_disability_register.sql
+++ b/models/reporting/olids/disease_registers/qof_pit/pit_learning_disability_register.sql
@@ -5,6 +5,15 @@
     )
 }}
 
+/*
+Learning Disability Register - Point in Time (PIT)
+
+QOF v50 Business Logic (via calculate_learning_disability_register macro):
+- Has learning disability diagnosis (LD_COD)
+- NOT excluded (LDREM_COD) after latest diagnosis
+- No age restriction (all ages included per QOF v50)
+*/
+
 WITH register_data AS (
     {{ calculate_learning_disability_register(reference_date_expr=get_reference_date()) }}
 )


### PR DESCRIPTION
## Summary
Updates the QOF Point-in-Time (PIT) register macros to align with the v50 specification changes made in PRs #457, #458, #459, and #477.

## Changes

### CKD Register (\calculate_ckd_register\)
- Use \is_stage_3_5_code\ instead of generic \is_diagnosis_code\ for CKD_COD
- Add downstaging exclusion: Stage 1-2 code (\CKD1AND2_COD\) after Stage 3-5 excludes from register
- Maintains resolved logic with \is_resolved_code\ (CKDRES_COD)

### Learning Disability Register (\calculate_learning_disability_register\)
- Add \LDREM_COD\ exclusion logic via \is_exclusion_code\
- Remove age ≥14 restriction (QOF v50 includes all ages)
- Exclusion code after diagnosis removes from register

### COPD Register (\calculate_copd_register\)
- Rule 4 no longer requires \SPIRPU_COD\ (unable to spirometry code)
- Per QOF v50 spec, Rule 4 states: 'If EUNRESCOPD_DAT >= 01/04/2023 → Select'
- All remaining post-April 2023 patients included automatically

## Related PRs
- #457, #458: CKD Stage 1-2 downstaging exclusion
- #459: LD LDREM_COD + all ages
- #477: CKD interface backward compatibility fix

## Testing
The PIT models (\pit_ckd_register\, \pit_learning_disability_register\, \pit_copd_register\) use these macros and will automatically inherit the updated logic.