### PR TITLE
fix: workflow detects macro changes and runs dependent models

### DIFF
--- a/.github/workflows/dbt-deploy.yml
+++ b/.github/workflows/dbt-deploy.yml
@@ -54,6 +54,9 @@ jobs:
             # Get changed .yml/.yaml files and find associated .sql models
             YML_FILES=$(git diff --name-only --diff-filter=d ${{ github.event.before }} ${{ github.sha }} -- 'models/**/*.yml' 'models/**/*.yaml')
             
+            # Get changed macro files
+            MACRO_FILES=$(git diff --name-only --diff-filter=d ${{ github.event.before }} ${{ github.sha }} -- 'macros/**/*.sql')
+            
             # For each yml file, find corresponding sql file(s) in same directory
             YML_DERIVED_SQL=""
             for yml in $YML_FILES; do
@@ -70,9 +73,24 @@ jobs:
               done
             done
             
+            # For each changed macro, find models that reference it
+            MACRO_DERIVED_SQL=""
+            for macro_file in $MACRO_FILES; do
+              # Extract macro name from filename (e.g., calculate_ckd_register.sql -> calculate_ckd_register)
+              macro_name=$(basename "$macro_file" .sql)
+              echo "Searching for models using macro: $macro_name"
+              # Find models that call this macro (search for {{ macro_name( pattern)
+              matching_models=$(grep -rl "{{ *$macro_name(" models/ --include="*.sql" 2>/dev/null || true)
+              if [ -n "$matching_models" ]; then
+                MACRO_DERIVED_SQL="$MACRO_DERIVED_SQL $matching_models"
+                echo "  Found: $matching_models"
+              fi
+            done
+            
             # Combine and deduplicate
-            CHANGED=$(echo "$SQL_FILES $YML_DERIVED_SQL" | tr ' ' '\n' | sort -u | tr '\n' ' ')
-            [ -n "$YML_FILES" ] && echo "YML changes detected - included associated models"
+            CHANGED=$(echo "$SQL_FILES $YML_DERIVED_SQL $MACRO_DERIVED_SQL" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+            [ -n "$YML_FILES" ] && echo "YML changes detected - included associated models" || true
+            [ -n "$MACRO_FILES" ] && echo "Macro changes detected - included models that use them" || true
           else
             CHANGED=""  # Manual trigger = full build
           fi

--- a/.github/workflows/dbt-pr-validation.yml
+++ b/.github/workflows/dbt-pr-validation.yml
@@ -76,6 +76,9 @@ jobs:
           # Get changed .yml/.yaml files and find associated .sql models
           YML_FILES=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD -- 'models/**/*.yml' 'models/**/*.yaml')
           
+          # Get changed macro files
+          MACRO_FILES=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD -- 'macros/**/*.sql')
+          
           # For each yml file, find corresponding sql file(s) in same directory
           YML_DERIVED_SQL=""
           for yml in $YML_FILES; do
@@ -92,13 +95,28 @@ jobs:
             done
           done
           
+          # For each changed macro, find models that reference it
+          MACRO_DERIVED_SQL=""
+          for macro_file in $MACRO_FILES; do
+            # Extract macro name from filename (e.g., calculate_ckd_register.sql -> calculate_ckd_register)
+            macro_name=$(basename "$macro_file" .sql)
+            echo "Searching for models using macro: $macro_name"
+            # Find models that call this macro (search for {{ macro_name( pattern)
+            matching_models=$(grep -rl "{{ *$macro_name(" models/ --include="*.sql" 2>/dev/null || true)
+            if [ -n "$matching_models" ]; then
+              MACRO_DERIVED_SQL="$MACRO_DERIVED_SQL $matching_models"
+              echo "  Found: $matching_models"
+            fi
+          done
+          
           # Combine and deduplicate
-          CHANGED=$(echo "$SQL_FILES $YML_DERIVED_SQL" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+          CHANGED=$(echo "$SQL_FILES $YML_DERIVED_SQL $MACRO_DERIVED_SQL" | tr ' ' '\n' | sort -u | tr '\n' ' ')
           COUNT=$(echo "$CHANGED" | wc -w)
           echo "changed_files=$CHANGED" >> $GITHUB_OUTPUT
           echo "file_count=$COUNT" >> $GITHUB_OUTPUT
           echo "Found $COUNT changed model files"
-          [ -n "$YML_FILES" ] && echo "YML changes detected - included associated models"
+          [ -n "$YML_FILES" ] && echo "YML changes detected - included associated models" || true
+          [ -n "$MACRO_FILES" ] && echo "Macro changes detected - included models that use them" || true
 
       - name: Setup Snowflake credentials
         if: steps.changes.outputs.file_count != '0'


### PR DESCRIPTION
## Summary
Fixes a bash script bug in both workflow files that caused false failures when only SQL files changed (no yml changes).

## Problem
Both `dbt-pr-validation.yml` and `dbt-deploy.yml` had this line:
```bash
[ -n "$YML_FILES" ] && echo "YML changes detected - included associated models"
```

When `$YML_FILES` is empty (only SQL files changed, no yml), the `[ -n "$YML_FILES" ]` test fails and returns exit code 1, causing the entire step to fail - even though the workflow correctly found the changed SQL files.

## Fix
Added `|| true` to ensure the command always succeeds:
```bash
[ -n "$YML_FILES" ] && echo "YML changes detected - included associated models" || true
```

## Files Changed
- `.github/workflows/dbt-pr-validation.yml`
- `.github/workflows/dbt-deploy.yml`
