### PR TITLE
fix: filter null person_ids in blood pressure base model

### DIFF
--- a/models/modelling/olids/observations/int_blood_pressure_observations_base.sql
+++ b/models/modelling/olids/observations/int_blood_pressure_observations_base.sql
@@ -35,6 +35,7 @@ WITH base_observations AS (
         obs.cluster_id AS source_cluster_id
     FROM ({{ get_observations("'BP_COD', 'SYSBP_COD', 'DIASBP_COD', 'HOMEAMBBP_COD', 'ABPM_COD', 'HOMEBP_COD'") }}) obs
     WHERE obs.result_value IS NOT NULL
+      AND obs.person_id IS NOT NULL
     {% if is_incremental() %}
       AND obs.lds_start_date_time > (SELECT MAX(lds_start_date_time) FROM {{ this }})
     {% endif %}


### PR DESCRIPTION
## Summary

Filters out observations with null `person_id` in `int_blood_pressure_observations_base`.

881k rows in upstream data have null person_ids - these can't be linked to patients and were failing the `not_null` test.

## Test plan

- [x] `dbt build --select int_blood_pressure_observations_base` passes