### PR TITLE
fix: align practice registration source in person_month_analysis_base

### DIFF
--- a/models/reporting/olids/person_analytics/person_month_analysis_base.sql
+++ b/models/reporting/olids/person_analytics/person_month_analysis_base.sql
@@ -23,10 +23,7 @@ WITH active_person_months AS (
     -- date ranges to determine temporal activity, not the point-in-time registration_status
     SELECT DISTINCT
         ds.month_end_date as analysis_month,
-        hr.person_id,
-        hr.practice_id,
-        hr.practice_code,
-        hr.practice_name
+        hr.person_id
     FROM {{ ref('dim_person_historical_practice') }} hr
     INNER JOIN {{ ref('int_date_spine') }} ds
         ON hr.registration_start_date <= ds.month_end_date
@@ -43,8 +40,7 @@ SELECT
     -- Core identifiers
     apm.analysis_month,
     apm.person_id,
-    apm.practice_id,
-    apm.practice_name,
+    d.practice_name,
     
     -- Date components for filtering
     ds.year_number,
@@ -92,7 +88,7 @@ SELECT
     ) }},
     
     -- Practice and geography
-    apm.practice_code,
+    d.practice_code,
     d.borough_registered,
     d.practice_postcode,
     d.practice_lsoa,

--- a/models/reporting/olids/person_analytics/person_month_analysis_base.yml
+++ b/models/reporting/olids/person_analytics/person_month_analysis_base.yml
@@ -52,9 +52,6 @@ models:
       - name: person_id
         description: Unique person identifier
 
-      - name: practice_id
-        description: Practice identifier where person was registered
-
       - name: practice_name
         description: Practice name where person was registered
 


### PR DESCRIPTION
## Summary
- Sourced `practice_code` and `practice_name` from `dim_person_demographics_historical` instead of `dim_person_historical_practice` in `person_month_analysis_base`
- Removed unused `practice_id` column
- All practice-related fields now come from the same source, matching `dim_person_demographics`

## Root cause
The `active_person_months` CTE used a range-overlap temporal join (from `dim_person_historical_practice`), while practice geography fields came from `dim_person_demographics_historical` which uses a point-in-time temporal join. These different join strategies could assign different practices for the same person/month.

## Test plan
- [ ] `dbt build --select person_month_analysis_base --full-refresh`
- [ ] `dbt test --select person_month_analysis_base`
- [ ] Spot-check: for any person, `practice_code` in `person_month_analysis_base` should now match `practice_code` in `dim_person_demographics`

Closes #506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Restructured practice data references in the person analytics reporting model. The `practice_id` field has been removed and is no longer available for analysis. Practice name and code remain accessible through an updated data source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->