### PR TITLE
feat: add project status automation workflows

### DIFF
--- a/.github/workflows/project-status-blocked.yml
+++ b/.github/workflows/project-status-blocked.yml
@@ -1,0 +1,90 @@
+name: Project Status - Blocked
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  update-project-status:
+    name: Set Project Status to Blocked
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'Blocked'
+    steps:
+      - name: Update project status to Blocked
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const projectNumber = 3;
+            const org = 'ncl-icb-analytics';
+            const targetStatus = 'Blocked';
+            const issueNodeId = context.payload.issue.node_id;
+
+            // Get project ID
+            const { organization } = await github.graphql(`
+              query($org: String!, $number: Int!) {
+                organization(login: $org) {
+                  projectV2(number: $number) {
+                    id
+                  }
+                }
+              }
+            `, { org, number: projectNumber });
+
+            const projectId = organization.projectV2.id;
+
+            // Get Status field and "Blocked" option
+            const { node: project } = await github.graphql(`
+              query($projectId: ID!) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    field(name: "Status") {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        options { id name }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { projectId });
+
+            const statusField = project.field;
+            if (!statusField?.id) {
+              core.setFailed('Status field not found in project');
+              return;
+            }
+
+            const option = statusField.options.find(o => o.name === targetStatus);
+            if (!option) {
+              const available = statusField.options.map(o => o.name).join(', ');
+              core.setFailed(`"${targetStatus}" option not found. Available: ${available}`);
+              return;
+            }
+
+            // Add issue to project (idempotent)
+            const { addProjectV2ItemById } = await github.graphql(`
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                  item { id }
+                }
+              }
+            `, { projectId, contentId: issueNodeId });
+
+            const itemId = addProjectV2ItemById.item.id;
+
+            // Set status to "Blocked"
+            await github.graphql(`
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $optionId }
+                }) {
+                  projectV2Item { id }
+                }
+              }
+            `, { projectId, itemId, fieldId: statusField.id, optionId: option.id });
+
+            core.info(`Issue #${context.payload.issue.number} status set to "${targetStatus}"`);

--- a/.github/workflows/project-status-review.yml
+++ b/.github/workflows/project-status-review.yml
@@ -1,0 +1,102 @@
+name: Project Status - Code Review
+
+on:
+  pull_request_target:
+    types: [review_requested, ready_for_review]
+
+jobs:
+  update-project-status:
+    name: Set Project Status to Code Review
+    runs-on: ubuntu-latest
+    # Skip draft PRs. For ready_for_review, only proceed if reviewers exist.
+    if: |
+      !github.event.pull_request.draft &&
+      (
+        github.event.action == 'review_requested' ||
+        (
+          github.event.action == 'ready_for_review' &&
+          (
+            github.event.pull_request.requested_reviewers[0] != null ||
+            github.event.pull_request.requested_teams[0] != null
+          )
+        )
+      )
+    steps:
+      - name: Update project status to Code Review
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const projectNumber = 3;
+            const org = 'ncl-icb-analytics';
+            const targetStatus = 'Code Review';
+            const prNodeId = context.payload.pull_request.node_id;
+
+            // Get project ID
+            const { organization } = await github.graphql(`
+              query($org: String!, $number: Int!) {
+                organization(login: $org) {
+                  projectV2(number: $number) {
+                    id
+                  }
+                }
+              }
+            `, { org, number: projectNumber });
+
+            const projectId = organization.projectV2.id;
+
+            // Get Status field and "Code Review" option
+            const { node: project } = await github.graphql(`
+              query($projectId: ID!) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    field(name: "Status") {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        options { id name }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { projectId });
+
+            const statusField = project.field;
+            if (!statusField?.id) {
+              core.setFailed('Status field not found in project');
+              return;
+            }
+
+            const option = statusField.options.find(o => o.name === targetStatus);
+            if (!option) {
+              const available = statusField.options.map(o => o.name).join(', ');
+              core.setFailed(`"${targetStatus}" option not found. Available: ${available}`);
+              return;
+            }
+
+            // Add PR to project (idempotent — returns existing item if already present)
+            const { addProjectV2ItemById } = await github.graphql(`
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                  item { id }
+                }
+              }
+            `, { projectId, contentId: prNodeId });
+
+            const itemId = addProjectV2ItemById.item.id;
+
+            // Set status to "Code Review"
+            await github.graphql(`
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $optionId }
+                }) {
+                  projectV2Item { id }
+                }
+              }
+            `, { projectId, itemId, fieldId: statusField.id, optionId: option.id });
+
+            core.info(`PR #${context.payload.pull_request.number} status set to "${targetStatus}"`);


### PR DESCRIPTION
## Summary
- Adds workflow to set project status to "Code Review" when a reviewer is added to a non-draft PR (or a draft with reviewers becomes active)
- Adds workflow to set project status to "Blocked" when an issue is labelled "Blocked"
- Both interact with org project #3 via GraphQL using the org-level `PROJECT_TOKEN` secret

## Test plan
- [ ] Request a reviewer on a non-draft PR → verify status changes to "Code Review"
- [ ] Create a draft PR, add a reviewer, mark as ready → verify status changes
- [ ] Add "Blocked" label to an issue → verify status changes to "Blocked"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated GitHub Actions workflows to enhance project status management. Issues marked with the "Blocked" label automatically update their project status field immediately. Pull requests receiving review requests or marked as ready-for-review automatically transition to "Code Review" status. Both workflows include comprehensive error handling, field validation, and detailed activity logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->