### PR TITLE
refactor: simplify sqlfluff to formatting-only rules

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,15 +1,12 @@
 [sqlfluff]
 dialect = snowflake
 templater = dbt
+max_line_length = 200
 # Formatting and capitalisation only - skip opinionated rules
 rules = layout, capitalisation
 
 [sqlfluff:templater:dbt]
 project_dir = .
-
-# Line length
-[sqlfluff:rules:layout.long_lines]
-max_line_length = 200
 
 # Indentation
 [sqlfluff:rules:layout.indent]
@@ -24,7 +21,7 @@ capitalisation_policy = lower
 capitalisation_policy = lower
 
 [sqlfluff:rules:capitalisation.functions]
-capitalisation_policy = lower
+extended_capitalisation_policy = lower
 
 [sqlfluff:rules:capitalisation.literals]
 capitalisation_policy = lower


### PR DESCRIPTION
## Summary
Simplifies SQLFluff config to focus on formatting and capitalisation only - no opinionated rules that conflict with dbt conventions.

## Changes
- Changed from `rules = core` to `rules = layout, capitalisation`
- All lowercase: keywords, identifiers, functions, literals, types
- Removed convention rules (trailing commas, `!=` vs `<>`, etc.)
- No `SELECT *` warnings (dbt convention)

## Usage
Run locally before committing:
```bash
sqlfluff fix models/path/to/file.sql
```

## What it catches
- Inconsistent indentation (4 spaces)
- Lines over 200 chars
- Spacing around operators/commas
- Mixed case → all lowercase

## What it ignores
- `SELECT *` (dbt convention)
- Trailing commas in SELECT
- `!=` vs `<>`
- Other style opinions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SQL formatting and linting configuration: increased maximum line length, standardised indentation to 4-space units, and enforced lower-case policies for SQL keywords, identifiers, functions, literals and types. Dialect and templating settings preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->