### PR TITLE
feat: add auto author assign workflow

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,13 @@
+name: Auto Author Assign
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v3.0.1


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that automatically assigns the PR author as an assignee when a pull request is opened or reopened
- Uses the `toshimaru/auto-author-assign@v3.0.1` action

## Test plan
- [ ] Verify the workflow runs on the next PR opened or reopened
- [ ] Confirm the PR author is automatically assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated workflow for pull request author assignment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->