### PR TITLE
Rs pr

### DIFF
--- a/models/staging/commissioning/stg_mhsds_spell.yml
+++ b/models/staging/commissioning/stg_mhsds_spell.yml
@@ -12,6 +12,10 @@ models:
         tests:
           - not_null
           - unique
+
+      - name: person_id
+        description: MHSDS Person Identifier
+            
     tests:
       - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 1


### PR DESCRIPTION
Added a description for the person_id column in the stg_mhsds_spell table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Person Identifier field to the staging data schema for Mental Health Services datasets, enhancing data organisation and tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->