### PR TITLE
docs: changed feature to feat in example commands 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ Never work directly on main. Always create a new branch:
 
 ```bash
 # Create and switch to a new feature branch
-git switch -c feature/your-feature-name
+git switch -c feat/your-feature-name
 
 # Or for bug fixes
 git switch -c fix/your-bug-fix
@@ -269,7 +269,7 @@ git commit -m "docs: update setup instructions in CONTRIBUTING"
 
 1. **Push your branch:**
    ```bash
-   git push -u origin feature/your-feature-name
+   git push -u origin feat/your-feature-name
    ```
 
    The `-u origin branch-name` creates the branch on GitHub and links it to your local branch. After this first push, you can use just `git push` for subsequent updates.
@@ -294,7 +294,7 @@ git switch main
 git pull
 
 # Switch back to your feature branch
-git switch feature/your-feature-name
+git switch feat/your-feature-name
 
 # Merge main into your branch
 git merge main
@@ -320,7 +320,7 @@ git switch main
 git pull
 
 # Go back to your feature branch
-git switch feature/your-feature-name
+git switch feat/your-feature-name
 
 # Restore your saved changes
 git stash pop


### PR DESCRIPTION
for consistency with the style guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Standardised feature branch naming conventions in contribution guidelines by replacing all `feature/` prefix references with `feat/` across branch creation commands, git switch operations, push instructions, and stash/merge workflow examples to improve consistency and align with conventional development naming practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->