### PR TITLE
Add workflow: Project Status - In Progress

### DIFF
--- a/.github/workflows/project-status-in-progress.yml
+++ b/.github/workflows/project-status-in-progress.yml
@@ -161,24 +161,52 @@ jobs:
 
                 const itemId = addProjectV2ItemById.item.id;
 
-                // Set status to "In Progress"
-                await github.graphql(`
-                  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-                    updateProjectV2ItemFieldValue(input: {
-                      projectId: $projectId
-                      itemId: $itemId
-                      fieldId: $fieldId
-                      value: { singleSelectOptionId: $optionId }
-                    }) {
-                      projectV2Item { id }
+                // Check current status and start date before updating
+                const { node: itemNode } = await github.graphql(`
+                  query($itemId: ID!) {
+                    node(id: $itemId) {
+                      ... on ProjectV2Item {
+                        status: fieldValueByName(name: "Status") {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                          }
+                        }
+                        startDate: fieldValueByName(name: "Start Date") {
+                          ... on ProjectV2ItemFieldDateValue {
+                            date
+                          }
+                        }
+                      }
                     }
                   }
-                `, { projectId, itemId, fieldId: statusField.id, optionId: statusOption.id });
+                `, { itemId });
 
-                core.info(`Issue #${issueNumber} status set to "${targetStatus}"`);
+                const currentStatus = itemNode?.status?.name;
+                const currentStartDate = itemNode?.startDate?.date;
+                const eligibleStatuses = [undefined, null, '', 'Todo', 'Backlog'];
 
-                // Set start date if field exists
-                if (startDateField?.id) {
+                // Only update status if current status is eligible for transition
+                if (eligibleStatuses.includes(currentStatus)) {
+                  await github.graphql(`
+                    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                      updateProjectV2ItemFieldValue(input: {
+                        projectId: $projectId
+                        itemId: $itemId
+                        fieldId: $fieldId
+                        value: { singleSelectOptionId: $optionId }
+                      }) {
+                        projectV2Item { id }
+                      }
+                    }
+                  `, { projectId, itemId, fieldId: statusField.id, optionId: statusOption.id });
+
+                  core.info(`Issue #${issueNumber} status set to "${targetStatus}"`);
+                } else {
+                  core.info(`Issue #${issueNumber} status is "${currentStatus}" - skipping status update`);
+                }
+
+                // Set start date if field exists and not already set
+                if (startDateField?.id && !currentStartDate) {
                   await github.graphql(`
                     mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
                       updateProjectV2ItemFieldValue(input: {
@@ -193,6 +221,8 @@ jobs:
                   `, { projectId, itemId, fieldId: startDateField.id, date: today });
 
                   core.info(`Issue #${issueNumber} start date set to ${today}`);
+                } else if (currentStartDate) {
+                  core.info(`Issue #${issueNumber} already has start date ${currentStartDate} - skipping`);
                 }
 
               } catch (err) {


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow that automatically updates project status when work begins on an issue.

## Trigger

Fires on **push to any branch except main**.

## What it does

When commits or branch names reference issues (\#123\, \ixes #123\, \closes #123\, etc.), the workflow:

1. **Adds the issue to Project #3** (if not already present)
2. **Sets Status → In Progress**
3. **Sets Start Date → today**
4. **Assigns the pusher to the issue** (if not already assigned)

## Examples

These will all trigger updates to issue #405:

- Commit message: \Add staging model for referrals #405\
- Commit message: \ixes #405 - add missing column\
- Branch name: \eature/405-ltc-risk-stratification\

## Related workflows

- \project-status-blocked.yml\ - Sets status to Blocked when label added
- \project-status-review.yml\ - Sets status to Code Review on review request

## Requirements

Uses existing \PROJECT_TOKEN\ secret with project write access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated project management processes to enhance issue tracking and streamline status updates across the development workflow, improving visibility and organisation of work items during development activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->