### PR TITLE
fix: change hard_deletes in snapshots to invalidate 

### DIFF
--- a/snapshots/fct_person_myria_control_group_published_snapshot.yml
+++ b/snapshots/fct_person_myria_control_group_published_snapshot.yml
@@ -59,4 +59,4 @@ snapshots:
                     'is_on_pds']
       unique_key: [patient_id]
       updated_at: table_refresh_date
-      hard_deletes: new_record
+      hard_deletes: invalidate

--- a/snapshots/fct_person_myria_high_risk_patients_published_snapshot.yml
+++ b/snapshots/fct_person_myria_high_risk_patients_published_snapshot.yml
@@ -61,4 +61,4 @@ snapshots:
                     'is_on_pds']
       unique_key: [patient_id]
       updated_at: table_refresh_date
-      hard_deletes: new_record
+      hard_deletes: invalidate


### PR DESCRIPTION
was previously new_record, but there is a known bug in dbt that causes this to fail when adding new columns.
hard_deletes: invalidate also makes the snapshot table easier to work with (in my opinion) as don't have to worry about the interaction between periods and deleted rows

Closes: #531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated snapshot configurations with revised handling for deleted records in two published data snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->