### PR TITLE
fix(bowel-screening): exclude 368481000000103 from completed screening

### DIFF
--- a/models/modelling/olids/programme/bowel_screening/int_bowel_screening_all.sql
+++ b/models/modelling/olids/programme/bowel_screening/int_bowel_screening_all.sql
@@ -35,7 +35,9 @@ SELECT
     obs.cluster_id AS source_cluster_id,
 
     -- Screening type classification
+    -- 368481000000103 is an observable entity recorded without result data; reclassify as Screening Recorded (No Result)
     CASE
+        WHEN obs.cluster_id in ('COLCANSCREV_COD','COLCANSCR_COD') AND obs.mapped_concept_code = '368481000000103' THEN 'Screening Recorded (No Result)'
         WHEN obs.cluster_id in ('COLCANSCREV_COD','COLCANSCR_COD') THEN 'Bowel Screening Completed'
         WHEN obs.cluster_id = 'COLCANSCRDEC_COD' THEN 'Screening Declined'
         ELSE 'Unknown'
@@ -43,7 +45,11 @@ SELECT
     --no PCD refsets for either invitation non reposnse or unsuitable for bowel screening
 
     -- Simple screening type flags based on core cluster codes
-    CASE WHEN obs.cluster_id in ('COLCANSCREV_COD','COLCANSCR_COD') THEN TRUE ELSE FALSE END AS is_completed_screening,
+    -- Exclude 368481000000103 (observable entity "BCSP: FOB result") which is recorded
+    -- without actual result data and inflates the screening numerator vs Fingertips
+    CASE WHEN obs.cluster_id in ('COLCANSCREV_COD','COLCANSCR_COD')
+              AND obs.mapped_concept_code != '368481000000103'
+         THEN TRUE ELSE FALSE END AS is_completed_screening,
     CASE WHEN obs.cluster_id = 'COLCANSCRDEC_COD' THEN TRUE ELSE FALSE END AS is_declined_screening
     --no PCD refsets for either invitation non reposnse or unsuitable for bowel screening
 


### PR DESCRIPTION
## Summary

Excludes SNOMED code `368481000000103` ("BCSP: faecal occult blood result") from the bowel cancer screening completed numerator in `int_bowel_screening_all`.

## Problem

This observable entity code is recorded in clinical systems without actual result data (`result_value` and `result_text` are both NULL). Because it falls within the `COLCANSCR_COD` cluster, it was being counted as a completed screening, inflating coverage rates compared to Fingertips reference data (~65%).

## Changes

- `int_bowel_screening_all.sql`:
  - `is_completed_screening` now excludes `368481000000103`
  - `screening_observation_type` reclassifies it as `Screening Recorded (No Result)`
- No changes needed to downstream models (`int_bowel_screening_latest`, `fct_bowel_screening_status`) as they derive from `int_bowel_screening_all`

## Evidence

Investigation via one-off analysis queries confirmed:
- Code 368481000000103 carries no `result_value` or `result_text`
- Persons with ONLY this code (no other completed screening codes) were being counted as "Up to Date"
- Excluding it aligns OLIDS coverage with Fingertips reference rates

## Test plan

- [ ] `dbt build --select int_bowel_screening_all+ --full-refresh`
- [ ] Compare `fct_bowel_screening_status` coverage rates before/after vs Fingertips


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification of bowel screening observations to more accurately handle cases where no test result is recorded, ensuring they are correctly identified and marked appropriately.
  * Refined screening completion detection logic to provide more precise identification of completed screenings whilst excluding cases where test results were not recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->