### PR TITLE
fix: not null on end date - issues with open spells

### DIFF
--- a/models/published/direct_care/C_LTCS/cltcs_events.yml
+++ b/models/published/direct_care/C_LTCS/cltcs_events.yml
@@ -36,8 +36,6 @@ models:
       - name: event_end_date
         data_type: date
         description: "End date of the event"
-        data_tests:
-          - not_null
 
       - name: event_type
         data_type: varchar


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Event end date field is now optional. Records can be created and updated without specifying an end date, providing greater flexibility in managing event records and supporting diverse operational scenarios. Users can now handle event information with fewer mandatory fields, improving overall data entry efficiency and better accommodating varied business processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->