### PR TITLE
fix: align LTC LCS valueset references to new hash-based numbering

### DIFF
--- a/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_dm_pg1_hrc.sql
+++ b/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_dm_pg1_hrc.sql
@@ -47,16 +47,16 @@ rule_5_hba1c_prerequisite as (
 -- Rule 6: Cardiac conditions (inclusion)
 rule_6_cardiac as (
     select person_id
-    from ({{ get_ltc_lcs_observations_latest("on_dm_reg_pg1_hrc_vs6") }})
+    from ({{ get_ltc_lcs_observations_latest("on_dm_reg_pg1_hrc_vs5") }})
 ),
 
 -- Rule 6: Diabetes medications in last 6 months (inclusion)
--- GLP-1 agonists (vs8) or Insulins
--- Note: vs7 is empty (EMIS DRUG Group didn't resolve to SNOMED codes)
+-- GLP-1 agonists (vs7) or Insulins
+-- Note: vs6 is empty (EMIS DRUG Group didn't resolve to SNOMED codes)
 -- Using BNF code 060101 (Insulins) instead
 rule_6_medications as (
     select person_id
-    from ({{ get_ltc_lcs_medication_orders_latest("on_dm_reg_pg1_hrc_vs8") }})
+    from ({{ get_ltc_lcs_medication_orders_latest("on_dm_reg_pg1_hrc_vs7") }})
     where order_date >= dateadd(month, -6, current_date())
     union
     select person_id

--- a/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_dm_pg1_hrc.yml
+++ b/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_dm_pg1_hrc.yml
@@ -22,8 +22,8 @@ models:
             - on_dm_reg_pg1_hrc_vs2
             - on_dm_reg_pg1_hrc_vs3
             - on_dm_reg_pg1_hrc_vs4
-            - on_dm_reg_pg1_hrc_vs6
-            - on_dm_reg_pg1_hrc_vs8
+            - on_dm_reg_pg1_hrc_vs5
+            - on_dm_reg_pg1_hrc_vs7
     columns:
       - name: person_id
         tests:

--- a/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_dm_pg3b_mrb.sql
+++ b/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_dm_pg3b_mrb.sql
@@ -5,13 +5,13 @@
 -- - Rule 1: Exclude PG1, PG2, or PG3A
 -- - Rule 2: HbA1c 58-75 (include directly)
 -- - Rule 3: HbA1c 48-58 (cascade - go to next rule if passed, exclude if failed)
--- - Rule 4: Erectile dysfunction (vs3) OR diabetic retinopathy (vs4) OR BMI >35 (vs5)
---           OR diabetic neuropathy (vs6) OR diabetic foot moderate/high risk (vs7)
---           OR heart failure first episode (vs8) OR GLP-1/insulin in last 6 months (vs10, BNF 060101)
---           OR claudication/atherosclerosis (vs11) (include)
---   Note: vs9 (Insulins) has no SNOMED mapping, using BNF 060101 fallback
--- - Rule 5: eGFR 45-49 (vs12) (include)
--- - Rule 6: ACR 3-30 (vs13) (include)
+-- - Rule 4: Erectile dysfunction (vs2) OR diabetic retinopathy (vs3) OR BMI >35 (vs4)
+--           OR diabetic neuropathy (vs5) OR diabetic foot moderate/high risk (vs6)
+--           OR heart failure first episode (vs7) OR GLP-1/insulin in last 6 months (vs9, BNF 060101)
+--           OR claudication/atherosclerosis (vs10) (include)
+--   Note: vs8 (Insulins) has no SNOMED mapping, using BNF 060101 fallback
+-- - Rule 5: eGFR 45-49 (vs11) (include)
+-- - Rule 6: ACR 3-30 (vs12) (include)
 -- - Rule 7: ABPM BP ≥140/90 (include, if failed → exclude)
 
 with
@@ -46,60 +46,60 @@ rule_2_hba1c_58_75 as (
 ),
 
 -- Rule 3: HbA1c 48-58 (cascade prerequisite for rules 4-7)
--- vs2 = HbA1c codes
+-- vs1 = HbA1c codes (same valueset as Rule 2, different threshold)
 rule_3_hba1c_48_58 as (
     select person_id
-    from ({{ get_ltc_lcs_observations_latest("on_dm_reg_priority_group_3b_mrb_vs2") }})
+    from ({{ get_ltc_lcs_observations_latest("on_dm_reg_priority_group_3b_mrb_vs1") }})
     where result_value > 48 and result_value <= 58
 ),
 
 -- Rule 4 components (any one qualifies if Rule 3 passed):
 
--- vs3 = Erectile dysfunction
+-- vs2 = Erectile dysfunction
 rule_4_erectile_dysfunction as (
+    select distinct person_id
+    from ({{ get_ltc_lcs_observations("on_dm_reg_priority_group_3b_mrb_vs2") }})
+),
+
+-- vs3 = Diabetic retinopathy
+rule_4_diabetic_retinopathy as (
     select distinct person_id
     from ({{ get_ltc_lcs_observations("on_dm_reg_priority_group_3b_mrb_vs3") }})
 ),
 
--- vs4 = Diabetic retinopathy
-rule_4_diabetic_retinopathy as (
-    select distinct person_id
-    from ({{ get_ltc_lcs_observations("on_dm_reg_priority_group_3b_mrb_vs4") }})
-),
-
--- vs5 = BMI > 35
+-- vs4 = BMI > 35
 rule_4_bmi_high as (
     select person_id
-    from ({{ get_ltc_lcs_observations_latest("on_dm_reg_priority_group_3b_mrb_vs5") }})
+    from ({{ get_ltc_lcs_observations_latest("on_dm_reg_priority_group_3b_mrb_vs4") }})
     where result_value > 35
 ),
 
--- vs6 = Diabetic neuropathy
+-- vs5 = Diabetic neuropathy
 rule_4_diabetic_neuropathy as (
+    select distinct person_id
+    from ({{ get_ltc_lcs_observations("on_dm_reg_priority_group_3b_mrb_vs5") }})
+),
+
+-- vs6 = Diabetic foot at moderate/high risk
+rule_4_diabetic_foot_risk as (
     select distinct person_id
     from ({{ get_ltc_lcs_observations("on_dm_reg_priority_group_3b_mrb_vs6") }})
 ),
 
--- vs7 = Diabetic foot at moderate/high risk
-rule_4_diabetic_foot_risk as (
-    select distinct person_id
-    from ({{ get_ltc_lcs_observations("on_dm_reg_priority_group_3b_mrb_vs7") }})
-),
-
--- vs8 = Heart failure (first episode, excluding review/end)
+-- vs7 = Heart failure (first episode, excluding review/end)
 rule_4_heart_failure as (
     select distinct person_id
-    from ({{ get_ltc_lcs_observations("on_dm_reg_priority_group_3b_mrb_vs8") }})
+    from ({{ get_ltc_lcs_observations("on_dm_reg_priority_group_3b_mrb_vs7") }})
     where is_problem = true
       and coalesce(is_review, false) = false
 ),
 
--- GLP-1 medications (vs10) and Insulins in last 6 months
--- Note: vs9 (Insulins drug group) has no SNOMED mapping from terminology server,
+-- GLP-1 medications (vs9) and Insulins in last 6 months
+-- Note: vs8 (Insulins drug group) has no SNOMED mapping from terminology server,
 -- using BNF 060101 as fallback instead
 rule_4_glp1_medications as (
     select person_id
-    from ({{ get_ltc_lcs_medication_orders_latest("on_dm_reg_priority_group_3b_mrb_vs10") }})
+    from ({{ get_ltc_lcs_medication_orders_latest("on_dm_reg_priority_group_3b_mrb_vs9") }})
     where order_date >= dateadd(month, -6, current_date())
     union
     select person_id
@@ -108,10 +108,10 @@ rule_4_glp1_medications as (
     qualify row_number() over (partition by person_id order by order_date desc) = 1
 ),
 
--- vs11 = Claudication/atherosclerosis
+-- vs10 = Claudication/atherosclerosis
 rule_4_claudication as (
     select distinct person_id
-    from ({{ get_ltc_lcs_observations("on_dm_reg_priority_group_3b_mrb_vs11") }})
+    from ({{ get_ltc_lcs_observations("on_dm_reg_priority_group_3b_mrb_vs10") }})
 ),
 
 -- Combine all Rule 4 components
@@ -134,18 +134,18 @@ rule_4_combined as (
 ),
 
 -- Rule 5: eGFR 45-49 (latest value)
--- vs12 = eGFR codes
+-- vs11 = eGFR codes
 rule_5_egfr_range as (
     select person_id
-    from ({{ get_ltc_lcs_observations_latest("on_dm_reg_priority_group_3b_mrb_vs12") }})
+    from ({{ get_ltc_lcs_observations_latest("on_dm_reg_priority_group_3b_mrb_vs11") }})
     where result_value >= 45 and result_value < 49
 ),
 
 -- Rule 6: ACR 3-30 (latest value)
--- vs13 = ACR codes
+-- vs12 = ACR codes
 rule_6_acr_range as (
     select person_id
-    from ({{ get_ltc_lcs_observations_latest("on_dm_reg_priority_group_3b_mrb_vs13") }})
+    from ({{ get_ltc_lcs_observations_latest("on_dm_reg_priority_group_3b_mrb_vs12") }})
     where result_value >= 3 and result_value <= 30
 ),
 

--- a/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_dm_pg3b_mrb.yml
+++ b/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_dm_pg3b_mrb.yml
@@ -31,12 +31,11 @@ models:
             - on_dm_reg_priority_group_3b_mrb_vs5
             - on_dm_reg_priority_group_3b_mrb_vs6
             - on_dm_reg_priority_group_3b_mrb_vs7
-            - on_dm_reg_priority_group_3b_mrb_vs8
-            # vs9 excluded - Insulins drug group has no SNOMED mapping, using BNF 060101 fallback
+            # vs8 excluded - Insulins drug group has no SNOMED mapping, using BNF 060101 fallback
+            - on_dm_reg_priority_group_3b_mrb_vs9
             - on_dm_reg_priority_group_3b_mrb_vs10
             - on_dm_reg_priority_group_3b_mrb_vs11
             - on_dm_reg_priority_group_3b_mrb_vs12
-            - on_dm_reg_priority_group_3b_mrb_vs13
     columns:
       - name: person_id
         tests:


### PR DESCRIPTION
## Summary
- Realigns valueset ID references in `dm_pg1_hrc` and `dm_pg3b_mrb` after the LTC LCS codelist numbering changed from sequential indexing to hash-based enumeration
- `dm_pg1_hrc`: cardiac conditions shifted vs6→vs5, GLP-1 medications vs8→vs7 (empty drug group gap removed)
- `dm_pg3b_mrb`: old vs1/vs2 (both HbA1c) deduplicated to vs1, all subsequent valuesets shifted down by 1
- Verified dm_pg2_hr, dm_pg3a_mra, and CKD models are unaffected (valueset content confirmed via Snowflake queries)

## Test plan
- [x] Run `dbt build` for LTC LCS risk stratification models and confirm `valuesets_have_codes` tests pass
- [ ] Verify patient counts are consistent with previous runs

Closes #587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Reorganised internal data source mappings and identifiers across diabetes programme rule sets for improved data consistency and organisation.
* Updated value-set references to align with new data source configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->