### PR TITLE
fix: protect DEV models from orphaned object cleanup

### DIFF
--- a/scripts/snowflake/cleanup_orphaned_dbt_objects.sql
+++ b/scripts/snowflake/cleanup_orphaned_dbt_objects.sql
@@ -61,6 +61,13 @@ DECLARE
                 UPPER(alias) AS table_name
             FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.DBT_MODELS
             WHERE package_name = 'ncl_analytics'
+            UNION ALL
+            SELECT
+                'DEV__' || UPPER(database_name) AS database_name,
+                UPPER(schema_name) AS schema_name,
+                UPPER(alias) AS table_name
+            FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.DBT_MODELS
+            WHERE package_name = 'ncl_analytics'
         )
         SELECT
             s.table_catalog,

--- a/scripts/snowflake/preview_orphaned_dbt_objects.sql
+++ b/scripts/snowflake/preview_orphaned_dbt_objects.sql
@@ -36,6 +36,13 @@ current_dbt_models AS (
         UPPER(alias) AS table_name
     FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.DBT_MODELS
     WHERE package_name = 'ncl_analytics'
+    UNION ALL
+    SELECT
+        'DEV__' || UPPER(database_name) AS database_name,
+        UPPER(schema_name) AS schema_name,
+        UPPER(alias) AS table_name
+    FROM DATA_LAKE__NCL.DBT_OBSERVABILITY.DBT_MODELS
+    WHERE package_name = 'ncl_analytics'
 )
 SELECT
     s.table_catalog,


### PR DESCRIPTION
## Summary

- DEV models were being incorrectly purged by the weekly orphaned object cleanup task
- The cleanup script checks objects against Elementary's `dbt_models` table to identify orphans, but Elementary only runs in prod — so it only records prod database names (`MODELLING`, `REPORTING`, etc.)
- DEV objects use `DEV__`-prefixed databases (`DEV__MODELLING`, `DEV__REPORTING`, etc.) and never matched, so they were always treated as orphans and dropped after 21 days
- Fix adds a `UNION ALL` that mirrors each prod model entry with a `DEV__` prefix, so DEV equivalents are also protected

## Changes

- `scripts/snowflake/cleanup_orphaned_dbt_objects.sql` — updated `current_dbt_models` CTE
- `scripts/snowflake/preview_orphaned_dbt_objects.sql` — same change to keep preview in sync

## Test plan

- [x] Run `preview_orphaned_dbt_objects.sql` and verify DEV models that exist in prod no longer appear as orphans
- [x] Confirm legitimate orphans (renamed/deleted models) still show up for cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended orphaned object detection and cleanup utilities to include development namespace models, ensuring comprehensive coverage across both standard and development database environments for improved maintenance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->