### PR TITLE
feat: update vacc1 script at 1 year

### DIFF
--- a/models/modelling/olids/programme/childhood_imms/int_childhood_imms_vaccs_current_age_1.sql
+++ b/models/modelling/olids/programme/childhood_imms/int_childhood_imms_vaccs_current_age_1.sql
@@ -95,7 +95,7 @@ WHERE AGE = 1
     LEFT JOIN VACC1YRBASE v2 
     ON v1.PERSON_ID = v2.PERSON_ID AND v2.VACCINE_ID = 'MENB_2B' AND v2.VACCINATION_STATUS in ('Completed', 'OutofSchedule')
     WHERE v1.VACCINE_ID = 'MENB_1' AND v1.VACCINATION_STATUS in ('Completed', 'OutofSchedule')
-    AND v1.BORN_JUL_2024_FLAG = 'Yes'
+    AND (v1.BORN_JUL_2024_FLAG = 'Yes' OR v1.BORN_JAN_2025_FLAG = 'Yes')
 )
 -- Creating CTE for PCV (dose 1) Children born before 1st July 2024 receive their vaccination at 12 weeks
 ,PCV1 AS (
@@ -122,7 +122,7 @@ WHERE AGE = 1
         ROUND(MONTHS_BETWEEN(v1.VACCINATION_DATE, v1.BIRTH_DATE_APPROX)) AS pcv_first_event_age_mths
          FROM VACC1YRBASE v1
         WHERE v1.VACCINE_ID = 'PCV_1B' AND v1.VACCINATION_STATUS in ('Completed', 'OutofSchedule') 
-       AND BORN_JUL_2024_FLAG = 'Yes'
+       AND (v1.BORN_JUL_2024_FLAG = 'Yes' OR v1.BORN_JAN_2025_FLAG = 'Yes')
 )  
 ,COMBINED AS (
 SELECT distinct


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded eligibility criteria for childhood immunisation programmes to include an additional birth cohort for meningococcal B (dose 2) and pneumococcal conjugate vaccine (dose 1) vaccinations. This change ensures more patients receive appropriate vaccination schedules and improves consistency across all eligible birth cohorts in the immunisation programme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->