### PR TITLE
fix: filter smoking observations recorded before age 11

### DIFF
--- a/macros/clinical/get_observations.sql
+++ b/macros/clinical/get_observations.sql
@@ -37,6 +37,7 @@
         o.mapped_concept_id,
         o.mapped_concept_code,
         o.mapped_concept_display,
+        o.age_at_event,
         o.lds_start_date_time,
         cc.cluster_id,
         cc.cluster_description,

--- a/models/modelling/olids/person_attributes/int_smoking_status_all.sql
+++ b/models/modelling/olids/person_attributes/int_smoking_status_all.sql
@@ -31,6 +31,7 @@ WITH base_observations AS (
     FROM ({{ get_observations("'LSMOK_COD', 'EXSMOK_COD', 'NSMOK_COD'") }}) obs
     WHERE obs.clinical_effective_date IS NOT NULL
     AND obs.clinical_effective_date <= CURRENT_DATE() -- No future dates
+    AND obs.age_at_event >= 11 -- Filter out parent smoking codes recorded on children's records (#595)
 )
 
 SELECT


### PR DESCRIPTION
## Summary
- Adds `age_at_event` to the `get_observations` macro output
- Filters out smoking status observations where `age_at_event < 11` in `int_smoking_status_all`
- Prevents parent smoking codes incorrectly entered on children's records from appearing in `fct_person_smoking_status`

Closes #595

## Test plan
- [x] Run `int_smoking_status_all` and verify no records with `age_at_event < 11`
- [x] Check `fct_person_smoking_status` no longer shows 0-year-olds as current smokers
- [x] Verify downstream models (`int_smoking_status_latest`, `fct_person_smoking_status`) build successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added age-at-event field to clinical observations data output, enabling better temporal tracking and analysis of patient events across different life stages.

* **Bug Fixes**
  * Improved smoking status data accuracy by implementing an age-based filter to exclude parent smoking codes incorrectly recorded on children's records, ensuring data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->