### PR TITLE
fix: handle null code descriptions in def_indicator_codes

### DIFF
--- a/models/reporting/olids/definitions/def_indicator_codes.sql
+++ b/models/reporting/olids/definitions/def_indicator_codes.sql
@@ -37,7 +37,7 @@ expanded_codes AS (
         cd.indicator_id,
         'SNOMED' AS code_system,
         cs.code,
-        cs.code_description,
+        COALESCE(NULLIF(TRIM(cs.code_description), ''), CONCAT('No description available for code ', cs.code)) AS code_description,
         cd.code_category,
         cd.cluster_id
     FROM cluster_definitions cd


### PR DESCRIPTION
## Summary
- fix def_indicator_codes so code_description is always populated
- apply fallback when upstream stg_reference_combined_codesets.code_description is null/blank
- resolves failing test 
ot_null_def_indicator_codes_code_description (44 rows)

## Context
A failure surfaced after recent metadata updates (related to #437 context), but this specific error path is caused by null/blank descriptions in joined terminology rows rather than missing cluster joins.

## Change
In models/reporting/olids/definitions/def_indicator_codes.sql:
- replaced direct select of cs.code_description with:
  - COALESCE(NULLIF(TRIM(cs.code_description), ''), CONCAT('No description available for code ', cs.code))

## Test plan
- [x] dbt test -s def_indicator_codes
- [x] confirm 	est_audit.not_null_def_indicator_codes_code_description passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced code description handling to display a default message when original descriptions are missing, empty, or contain only whitespace, ensuring consistent information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->