### PR TITLE
refactor: apply deduplication macro to eosinophil int tables

### DIFF
--- a/macros/transformations/deduplicate_table.sql
+++ b/macros/transformations/deduplicate_table.sql
@@ -3,23 +3,30 @@
 {% macro deduplicate_table(
         table,
         partition_cols,
-        order_col
+        order_cols
     ) %}
 
-    {# 
-        This macro deduplicates a table by 
+    {#
+        This macro deduplicates a table by
 
         dedup_table (dbt table ref):
             a ref to the raw csds table to be deduplicated
-         
+
         partition_cols (list[str]):
             a list of column(s) present in the dedup_table which the deduplication occurs over
+
+        order_cols (list[str]):
+            a list of column(s) to order by when picking the row to keep (DESC)
 
         Example usage:
     #}
 
     {% if partition_cols | length == 0 %}
         {{ exceptions.raise_compiler_error("You must provide at least one partition column to deduplicate_table.") }}
+    {% endif %}
+
+    {% if order_cols is not iterable or order_cols is string or order_cols | length == 0 %}
+        {{ exceptions.raise_compiler_error("You must provide order_cols as a non-empty list to deduplicate_table.") }}
     {% endif %}
 
     SELECT
@@ -31,7 +38,7 @@
             {{ "tbl." ~ col }}{% if not loop.last %}, {% endif %}
         {%- endfor %}
         ORDER BY
-        {%- for col in order_col %}
+        {%- for col in order_cols %}
             tbl.{{ col }} DESC{% if not loop.last %},{% endif %}
         {%- endfor %}
     ) = 1

--- a/models/modelling/olids/observations/int_eosinophil_count.sql
+++ b/models/modelling/olids/observations/int_eosinophil_count.sql
@@ -20,7 +20,7 @@ deduplicated AS (
     {{ deduplicate_table(
         table='raw_observations',
         partition_cols=['person_id', 'clinical_effective_date', 'result_value', 'result_unit_code', 'mapped_concept_code'],
-        order_col=['date_recorded', 'id']
+        order_cols=['date_recorded', 'id']
     ) }}
 ),
 

--- a/models/modelling/olids/observations/int_eosinophil_percentage.sql
+++ b/models/modelling/olids/observations/int_eosinophil_percentage.sql
@@ -20,7 +20,7 @@ deduplicated AS (
     {{ deduplicate_table(
         table='raw_observations',
         partition_cols=['person_id', 'clinical_effective_date', 'result_value', 'result_unit_code', 'mapped_concept_code'],
-        order_col=['date_recorded', 'id']
+        order_cols=['date_recorded', 'id']
     ) }}
 ),
 

--- a/models/modelling/olids/observations/int_feno_all.sql
+++ b/models/modelling/olids/observations/int_feno_all.sql
@@ -20,7 +20,7 @@ deduplicated AS (
     {{ deduplicate_table(
         table='raw_observations',
         partition_cols=['person_id', 'clinical_effective_date', 'result_value', 'result_unit_code', 'mapped_concept_code'],
-        order_col=['date_recorded', 'id']
+        order_cols=['date_recorded', 'id']
     ) }}
 ),
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked eosinophil observation pipelines to a three‑stage flow (raw → deduplicated → base), improving deduplication clarity and downstream consistency.
  * Introduced a reusable deduplication utility that supports multi‑column ordering (with tie‑breaking) and input validation to stabilise record selection when timestamps match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->