### PR TITLE
fix(covid): deduplicate fct_covid_status rows

### DIFF
--- a/models/reporting/olids/programme/covid/fct_covid_status.sql
+++ b/models/reporting/olids/programme/covid/fct_covid_status.sql
@@ -28,7 +28,8 @@ This gives a complete picture of vaccination patterns across the population.
 ) }}
 
 WITH
--- All eligible people (from eligibility table)
+-- One row per person per campaign (created_at excluded to prevent fan-out
+-- from intermediate models materializing at different times)
 all_eligible_people AS (
     SELECT DISTINCT
         campaign_id,
@@ -36,8 +37,7 @@ all_eligible_people AS (
         birth_date_approx,
         age_months,
         age_years,
-        reference_date,
-        created_at
+        reference_date
     FROM {{ ref('fct_covid_eligibility') }}
 ),
 
@@ -82,7 +82,7 @@ eligible_no_vaccination AS (
         ep.age_years AS age_years_at_ref_date,
         'NO_VACCINATION_RECORD' AS status_type,
         3 AS status_priority,
-        ep.created_at
+        CURRENT_TIMESTAMP() AS created_at
     FROM all_eligible_people ep
     WHERE NOT EXISTS (
         SELECT 1 


### PR DESCRIPTION
## Summary
- Removed `created_at` from the `all_eligible_people` DISTINCT in `fct_covid_status`
- Each intermediate model materializes at a different time, giving each eligibility reason a different `created_at` — this broke DISTINCT deduplication
- The duplicated `all_eligible_people` caused fan-out in both the `eligible_no_vaccination` CTE and the `final_status` LEFT JOIN
- Row count reduced from ~2.8M to ~1.07M (correct)

## Root cause
```sql
-- BEFORE: created_at differs per intermediate model, so DISTINCT doesn't collapse
SELECT DISTINCT campaign_id, person_id, ..., created_at
FROM fct_covid_eligibility

-- AFTER: one row per person per campaign
SELECT DISTINCT campaign_id, person_id, ..., reference_date
FROM fct_covid_eligibility
```

## Test plan
- [x] `dbt build -s fct_covid_status+` passes (2 models, 4 tests)
- [x] Zero duplicate rows per (person_id, campaign_id, status_type)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated timestamp generation for vaccination status records in COVID reporting to reflect the report execution time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->