### PR TITLE
feat(ltc-lcs): add ward columns to case finding dashboard base

### DIFF
--- a/models/published/direct_care/olids/ltc_lcs/ltc_lcs_cf_dashboard_base.sql
+++ b/models/published/direct_care/olids/ltc_lcs/ltc_lcs_cf_dashboard_base.sql
@@ -80,6 +80,8 @@ base_data AS (
         d.imd_decile_19,
         d.lsoa_code_21,
         d.lsoa_name_21,
+        d.ward_code,
+        d.ward_name,
         d.borough_resident,
         d.neighbourhood_resident,
         d.icb_code_resident,
@@ -140,6 +142,8 @@ final_dashboard AS (
         imd_quintile_19 as imd_quintile_label,
         imd_decile_19,
         lsoa_code_21 as lsoa_code,
+        ward_code,
+        ward_name,
         
         -- Practice information
         practice_code,

--- a/models/published/direct_care/olids/ltc_lcs/ltc_lcs_cf_dashboard_base.yml
+++ b/models/published/direct_care/olids/ltc_lcs/ltc_lcs_cf_dashboard_base.yml
@@ -103,6 +103,12 @@ models:
       - name: lsoa_code
         description: Lower Super Output Area code
 
+      - name: ward_code
+        description: Electoral ward code (residence-based)
+
+      - name: ward_name
+        description: Electoral ward name (residence-based)
+
       - name: practice_code
         description: GP practice code
 


### PR DESCRIPTION
## Summary
- Adds `ward_code` and `ward_name` from `dim_person_demographics` to `ltc_lcs_cf_dashboard_base`
- Enables ward-level geographic breakdowns in the case finding dashboard
- Secondary use model inherits columns automatically via `SELECT base.*`

## Test plan
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Electoral ward code and Electoral ward name (residence-based) fields to the long-term care dashboard, enabling enhanced geographical analysis, improved segmentation, and more detailed reporting capabilities organised by electoral ward boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->