### PR TITLE
feat: add obesity condition episodes

### DIFF
--- a/models/reporting/olids/disease_registers/fct_person_condition_episodes.sql
+++ b/models/reporting/olids/disease_registers/fct_person_condition_episodes.sql
@@ -513,10 +513,67 @@ WITH all_condition_events AS (
     -- Learning Disability All Ages uses same diagnosis codes as regular LD - age filtering happens in QOF layer
 ),
 
+obesity_daily_status AS (
+    -- Collapse multiple BMI measurements on the same day to a single obesity status
+    SELECT
+        person_id,
+        clinical_effective_date AS event_date,
+        MAX(
+            CASE
+                WHEN is_valid_bmi = TRUE
+                    AND bmi_category IN ('Obese Class I', 'Obese Class II', 'Obese Class III')
+                    THEN 1
+                ELSE 0
+            END
+        ) AS is_obese
+    FROM {{ ref('int_bmi_all') }}
+    GROUP BY person_id, clinical_effective_date
+),
+
+obesity_events AS (
+    -- Derive obesity episode transitions from day-level BMI obesity status
+    SELECT
+        person_id,
+        event_date,
+        'Obesity' AS condition_name,
+        'OB' AS condition_code,
+        'Metabolic' AS clinical_domain,
+        CASE
+            WHEN is_obese = 1 AND COALESCE(prev_is_obese, 0) = 0 THEN 'onset'
+            WHEN is_obese = 1 THEN 'diagnosis'
+            WHEN is_obese = 0 AND prev_is_obese = 1 THEN 'resolved'
+        END AS event_type,
+        'BMI_OBESITY_THRESHOLD' AS concept_code,
+        'BMI-based obesity status' AS concept_display
+    FROM (
+        SELECT
+            person_id,
+            event_date,
+            is_obese,
+            LAG(is_obese) OVER (
+                PARTITION BY person_id
+                ORDER BY event_date
+            ) AS prev_is_obese
+        FROM obesity_daily_status
+    ) obesity_status_with_history
+    WHERE is_obese = 1
+        OR (is_obese = 0 AND prev_is_obese = 1)
+),
+
 -- Filter out invalid dates (NULL or future dates) for data quality
 valid_condition_events AS (
     SELECT *
     FROM all_condition_events
+
+    UNION ALL
+
+    SELECT *
+    FROM obesity_events
+),
+
+filtered_condition_events AS (
+    SELECT *
+    FROM valid_condition_events
     WHERE event_date IS NOT NULL
         AND event_date <= CURRENT_DATE
 ),
@@ -533,7 +590,7 @@ events_with_row_numbers AS (
             PARTITION BY person_id, condition_name 
             ORDER BY event_date, event_type
         ) as prev_event_type
-    FROM valid_condition_events
+    FROM filtered_condition_events
 ),
 
 episode_starts AS (

--- a/models/reporting/olids/disease_registers/fct_person_condition_episodes.yml
+++ b/models/reporting/olids/disease_registers/fct_person_condition_episodes.yml
@@ -202,6 +202,29 @@ models:
             code_clusters:
               - cluster_id: "NDH_COD"
                 category: "INCLUSION"
+          - id: "CONDITION_EPISODES_OB"
+            type: "CONDITION"
+            category: "SIMPLIFIED_CONDITION_MODEL"
+            clinical_domain: "Metabolic"
+            name_short: "Obesity Episodes"
+            description_short: "BMI-derived obesity episodes with start and resolution tracking"
+            description_long: >
+              Episode tracking for obesity using dated BMI measurements rather than
+              diagnosis register codes.
+              Episode starts are triggered when BMI first enters an obesity category
+              and end when a later BMI falls below the obesity threshold.
+              Supports repeated on/off cycles for longitudinal weight-status analysis.
+            is_qof: false
+            source_column: "current_condition_status"
+            sort_order: "CONDITION_EPISODES_OB"
+            usage_contexts:
+              - "POPULATION_HEALTH_NEEDS_DASHBOARD"
+              - "HISTORICAL_CONDITION_TRACKING"
+            code_clusters:
+              - cluster_id: "BMIVAL_COD"
+                category: "INCLUSION"
+              - cluster_id: "CALCULATED"
+                category: "INCLUSION"
 
           # Renal Conditions
           - id: "CONDITION_EPISODES_CKD"
@@ -750,6 +773,7 @@ models:
                   - 'LD'
                   - 'NAFLD'
                   - 'NDH'
+                  - 'OB'
                   - 'OST'
                   - 'PAD'
                   - 'PC'


### PR DESCRIPTION
## Summary
- add obesity to ct_person_condition_episodes
- derive obesity episode transitions from dated BMI observations rather than diagnosis register codes
- document the new OB condition episode metadata and accepted values

## Testing
- dbt build --select fct_person_condition_episodes
- all tests passed locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Obesity episodes are now tracked and reported within disease registers, capturing status transitions including onset, diagnosis, and resolution.
  * Obesity data is integrated with existing condition episodes for comprehensive patient history reporting.
  * All episode metrics (duration, status, dates) now encompass obesity-related episodes alongside other conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->