### PR TITLE
fix: Use COALESCE for defensive delete_ind NULL handling in LPF stagi…

### DIFF
--- a/models/staging/pid_env/stg_lpf_allergies.sql
+++ b/models/staging/pid_env/stg_lpf_allergies.sql
@@ -56,7 +56,7 @@ cleaned as (
         criticality_display,
         asserted_date
     from raw_allergies
-    where delete_ind != 'Y'
+    where coalesce(delete_ind, 'N') != 'Y'
         and allergy_id is not null
 ),
 

--- a/models/staging/pid_env/stg_lpf_appointments.sql
+++ b/models/staging/pid_env/stg_lpf_appointments.sql
@@ -21,7 +21,7 @@ with raw_data as (
 
 cleaned as (
     select * from raw_data
-    where delete_ind != 'Y'
+    where coalesce(delete_ind, 'N') != 'Y'
         and appointment_id is not null
 ),
 

--- a/models/staging/pid_env/stg_lpf_demographics.sql
+++ b/models/staging/pid_env/stg_lpf_demographics.sql
@@ -9,7 +9,7 @@ with raw_data as (
 ),
 cleaned as (
     select * from raw_data
-    where delete_ind != 'Y' and person_id is not null
+    where coalesce(delete_ind, 'N') != 'Y' and person_id is not null
 ),
 deduplicated as (
     select *,

--- a/models/staging/pid_env/stg_lpf_diagnosis.sql
+++ b/models/staging/pid_env/stg_lpf_diagnosis.sql
@@ -9,7 +9,7 @@ with raw_data as (
 ),
 cleaned as (
     select * from raw_data
-    where delete_ind != 'Y' and diagnosis_id is not null
+    where coalesce(delete_ind, 'N') != 'Y' and diagnosis_id is not null
 ),
 deduplicated as (
     select *,

--- a/models/staging/pid_env/stg_lpf_encounter.sql
+++ b/models/staging/pid_env/stg_lpf_encounter.sql
@@ -9,7 +9,7 @@ with raw_data as (
 ),
 cleaned as (
     select * from raw_data
-    where delete_ind != 'Y' and encounter_id is not null
+    where coalesce(delete_ind, 'N') != 'Y' and encounter_id is not null
 ),
 deduplicated as (
     select *,

--- a/models/staging/pid_env/stg_lpf_immunisation.sql
+++ b/models/staging/pid_env/stg_lpf_immunisation.sql
@@ -9,7 +9,7 @@ with raw_data as (
 ),
 cleaned as (
     select * from raw_data
-    where delete_ind != 'Y' and immunisation_id is not null
+    where coalesce(delete_ind, 'N') != 'Y' and immunisation_id is not null
 ),
 deduplicated as (
     select *,

--- a/models/staging/pid_env/stg_lpf_medication.sql
+++ b/models/staging/pid_env/stg_lpf_medication.sql
@@ -9,7 +9,7 @@ with raw_data as (
 ),
 cleaned as (
     select * from raw_data
-    where delete_ind != 'Y' and medication_id is not null
+    where coalesce(delete_ind, 'N') != 'Y' and medication_id is not null
 ),
 deduplicated as (
     select *,

--- a/models/staging/pid_env/stg_lpf_procedure.sql
+++ b/models/staging/pid_env/stg_lpf_procedure.sql
@@ -9,7 +9,7 @@ with raw_data as (
 ),
 cleaned as (
     select * from raw_data
-    where delete_ind != 'Y' and procedure_id is not null
+    where coalesce(delete_ind, 'N') != 'Y' and procedure_id is not null
 ),
 deduplicated as (
     select *,

--- a/models/staging/pid_env/stg_lpf_referral_request.sql
+++ b/models/staging/pid_env/stg_lpf_referral_request.sql
@@ -9,7 +9,7 @@ with raw_data as (
 ),
 cleaned as (
     select * from raw_data
-    where delete_ind != 'Y' and referral_request_id is not null
+    where coalesce(delete_ind, 'N') != 'Y' and referral_request_id is not null
 ),
 deduplicated as (
     select *,

--- a/models/staging/pid_env/stg_lpf_result.sql
+++ b/models/staging/pid_env/stg_lpf_result.sql
@@ -9,7 +9,7 @@ with raw_data as (
 ),
 cleaned as (
     select * from raw_data
-    where delete_ind != 'Y' and result_id is not null
+    where coalesce(delete_ind, 'N') != 'Y' and result_id is not null
 ),
 deduplicated as (
     select *,


### PR DESCRIPTION
…ng models

- Change: delete_ind != 'Y' → coalesce(delete_ind, 'N') != 'Y'
- Prevents unintended filtering of records with NULL delete_ind flags
- Treats NULL delete flags as 'N' (not deleted) per defensible business logic
- Improves data completeness for all 10 LPF staging models
- Addresses CodeRabbit review feedback