### PR TITLE
fix(diabetes): use PCD FOOTEXAM_COD for foot check completion

### DIFF
--- a/models/modelling/olids/observations/int_foot_examination_all.sql
+++ b/models/modelling/olids/observations/int_foot_examination_all.sql
@@ -79,7 +79,7 @@ foot_status AS (
 ),
 
 -- Then get the check details for each date
-check_details AS (
+check_details_raw AS (
     SELECT
         person_id,
         clinical_effective_date,
@@ -100,11 +100,12 @@ check_details AS (
             ELSE FALSE
         END) AS right_foot_checked,
 
-        -- Both feet checked: Townson scale or generic bilateral exam code
+        -- Bilateral signal at the row level (Townson or generic bilateral exam code).
+        -- Paired left+right rows on the same date are folded in by check_details below.
         MAX(CASE
             WHEN source_cluster_id = 'FOOTEXAM_COD' AND (is_townson OR is_bilateral_generic) THEN TRUE
             ELSE FALSE
-        END) AS both_feet_checked,
+        END) AS both_feet_checked_row_level,
 
         -- Risk level by foot (only populated where the code carries an explicit risk descriptor)
         MAX(CASE
@@ -130,6 +131,25 @@ check_details AS (
 
     FROM foot_observations_tagged
     GROUP BY person_id, clinical_effective_date
+),
+
+-- Canonical both_feet_checked: bilateral row OR paired left+right on same date
+check_details AS (
+    SELECT
+        person_id,
+        clinical_effective_date,
+        is_unsuitable,
+        is_declined,
+        left_foot_checked,
+        right_foot_checked,
+        (both_feet_checked_row_level OR (left_foot_checked AND right_foot_checked)) AS both_feet_checked,
+        left_foot_risk_level,
+        right_foot_risk_level,
+        townson_scale_level,
+        all_concept_codes,
+        all_concept_displays,
+        all_source_cluster_ids
+    FROM check_details_raw
 )
 
 -- Final selection combining check details with foot status
@@ -158,7 +178,6 @@ SELECT
         WHEN cd.is_unsuitable THEN 'Unsuitable'
         WHEN cd.is_declined THEN 'Declined'
         WHEN cd.both_feet_checked THEN 'Complete - Both Feet'
-        WHEN cd.left_foot_checked AND cd.right_foot_checked THEN 'Complete - Both Feet'
         WHEN cd.left_foot_checked AND (fs.right_foot_absent OR fs.right_foot_amputated) THEN 'Complete - Left Only (Right Missing)'
         WHEN cd.right_foot_checked AND (fs.left_foot_absent OR fs.left_foot_amputated) THEN 'Complete - Right Only (Left Missing)'
         WHEN cd.left_foot_checked THEN 'Partial - Left Only'

--- a/models/modelling/olids/observations/int_foot_examination_all.sql
+++ b/models/modelling/olids/observations/int_foot_examination_all.sql
@@ -51,8 +51,19 @@ WITH foot_observations AS (
             ELSE NULL
         END AS risk_level
 
-    FROM ({{ get_observations("'FEPU_COD', 'FEDEC_COD', 'FRC_COD', 'CONABL_COD', 'CONABR_COD', 'AMPL_COD', 'AMPR_COD'") }}) obs
+    FROM ({{ get_observations("'FEPU_COD', 'FEDEC_COD', 'FOOTEXAM_COD', 'CONABL_COD', 'CONABR_COD', 'AMPL_COD', 'AMPR_COD'") }}) obs
     WHERE obs.clinical_effective_date IS NOT NULL
+),
+
+-- Tag foot exam rows with no laterality keyword and no Townson as generic bilateral checks
+foot_observations_tagged AS (
+    SELECT
+        *,
+        (source_cluster_id = 'FOOTEXAM_COD'
+         AND NOT has_left
+         AND NOT has_right
+         AND NOT is_townson) AS is_bilateral_generic
+    FROM foot_observations
 ),
 
 -- First aggregate foot status (amputations/absences) across all time
@@ -63,7 +74,7 @@ foot_status AS (
         MAX(CASE WHEN source_cluster_id = 'CONABR_COD' THEN TRUE ELSE FALSE END) AS right_foot_absent,
         MAX(CASE WHEN source_cluster_id = 'AMPL_COD' THEN TRUE ELSE FALSE END) AS left_foot_amputated,
         MAX(CASE WHEN source_cluster_id = 'AMPR_COD' THEN TRUE ELSE FALSE END) AS right_foot_amputated
-    FROM foot_observations
+    FROM foot_observations_tagged
     GROUP BY person_id
 ),
 
@@ -77,32 +88,32 @@ check_details AS (
         MAX(CASE WHEN source_cluster_id = 'FEPU_COD' THEN TRUE ELSE FALSE END) AS is_unsuitable,
         MAX(CASE WHEN source_cluster_id = 'FEDEC_COD' THEN TRUE ELSE FALSE END) AS is_declined,
 
-        -- Foot checks - left foot is checked if either explicit left foot check OR Townson scale
+        -- Left foot checked: explicit left code, Townson, or generic bilateral exam code
         MAX(CASE
-            WHEN source_cluster_id = 'FRC_COD' AND (has_left OR is_townson) THEN TRUE
+            WHEN source_cluster_id = 'FOOTEXAM_COD' AND (has_left OR is_townson OR is_bilateral_generic) THEN TRUE
             ELSE FALSE
         END) AS left_foot_checked,
 
-        -- Right foot is checked if either explicit right foot check OR Townson scale
+        -- Right foot checked: explicit right code, Townson, or generic bilateral exam code
         MAX(CASE
-            WHEN source_cluster_id = 'FRC_COD' AND (has_right OR is_townson) THEN TRUE
+            WHEN source_cluster_id = 'FOOTEXAM_COD' AND (has_right OR is_townson OR is_bilateral_generic) THEN TRUE
             ELSE FALSE
         END) AS right_foot_checked,
 
-        -- Both feet checked if Townson scale used
+        -- Both feet checked: Townson scale or generic bilateral exam code
         MAX(CASE
-            WHEN source_cluster_id = 'FRC_COD' AND is_townson THEN TRUE
+            WHEN source_cluster_id = 'FOOTEXAM_COD' AND (is_townson OR is_bilateral_generic) THEN TRUE
             ELSE FALSE
         END) AS both_feet_checked,
 
-        -- Get risk levels for each foot
+        -- Risk level by foot (only populated where the code carries an explicit risk descriptor)
         MAX(CASE
-            WHEN source_cluster_id = 'FRC_COD' AND (has_left OR is_townson) THEN risk_level
+            WHEN source_cluster_id = 'FOOTEXAM_COD' AND (has_left OR is_townson) THEN risk_level
             ELSE NULL
         END) AS left_foot_risk_level,
 
         MAX(CASE
-            WHEN source_cluster_id = 'FRC_COD' AND (has_right OR is_townson) THEN risk_level
+            WHEN source_cluster_id = 'FOOTEXAM_COD' AND (has_right OR is_townson) THEN risk_level
             ELSE NULL
         END) AS right_foot_risk_level,
 
@@ -117,7 +128,7 @@ check_details AS (
         ARRAY_AGG(DISTINCT concept_display) WITHIN GROUP (ORDER BY concept_display) AS all_concept_displays,
         ARRAY_AGG(DISTINCT source_cluster_id) WITHIN GROUP (ORDER BY source_cluster_id) AS all_source_cluster_ids
 
-    FROM foot_observations
+    FROM foot_observations_tagged
     GROUP BY person_id, clinical_effective_date
 )
 

--- a/models/modelling/olids/observations/int_foot_examination_all.yml
+++ b/models/modelling/olids/observations/int_foot_examination_all.yml
@@ -1,8 +1,6 @@
 models:
   - name: int_foot_examination_all
-    description: 'Diabetic foot examination procedures with risk assessment for diabetes care monitoring and QOF reporting.
-
-      One row per foot examination event using multiple foot-related clusters with bilateral foot assessment and Townson scale integration.'
+    description: 'Diabetic foot examination events for QOF DM019 reporting. Uses PCD cluster FOOTEXAM_COD (153 codes: neuropathy, monofilament, pedal pulses, ABPI, diabetic foot screen, Townson scale, laterality-specific risk findings) plus FEPU_COD / FEDEC_COD for unsuitable/declined and AMPL_COD / AMPR_COD / CONABL_COD / CONABR_COD for permanent exemption. One row per person per examination date. Codes with no left/right keyword and not Townson are treated as bilateral (both feet checked).'
     config:
       meta:
         owner:
@@ -10,4 +8,4 @@ models:
     tests:
       - cluster_ids_exist:
           arguments:
-            cluster_ids: AMPL_COD, AMPR_COD, CONABL_COD, CONABR_COD, FEDEC_COD, FEPU_COD, FRC_COD
+            cluster_ids: AMPL_COD, AMPR_COD, CONABL_COD, CONABR_COD, FEDEC_COD, FEPU_COD, FOOTEXAM_COD

--- a/models/reporting/olids/measures/fct_person_diabetes_8_care_processes.sql
+++ b/models/reporting/olids/measures/fct_person_diabetes_8_care_processes.sql
@@ -67,7 +67,6 @@ care_process_data AS (
             AND fc.clinical_effective_date >= t.twelve_months_ago
             AND (
                 fc.both_feet_checked
-                OR (fc.left_foot_checked AND fc.right_foot_checked)
                 OR (
                     fc.left_foot_checked
                     AND (fc.right_foot_absent OR fc.right_foot_amputated)

--- a/models/reporting/olids/measures/fct_person_diabetes_8_care_processes.sql
+++ b/models/reporting/olids/measures/fct_person_diabetes_8_care_processes.sql
@@ -67,6 +67,7 @@ care_process_data AS (
             AND fc.clinical_effective_date >= t.twelve_months_ago
             AND (
                 fc.both_feet_checked
+                OR (fc.left_foot_checked AND fc.right_foot_checked)
                 OR (
                     fc.left_foot_checked
                     AND (fc.right_foot_absent OR fc.right_foot_amputated)

--- a/models/reporting/olids/measures/fct_person_diabetes_foot_check.sql
+++ b/models/reporting/olids/measures/fct_person_diabetes_foot_check.sql
@@ -30,7 +30,6 @@ SELECT
         <= 12
         AND (
             fc.both_feet_checked
-            OR (fc.left_foot_checked AND fc.right_foot_checked)
             OR (
                 fc.left_foot_checked
                 AND (fc.right_foot_absent OR fc.right_foot_amputated)
@@ -55,10 +54,7 @@ SELECT
         WHEN fc.clinical_effective_date IS NULL THEN 'Not Done'
         WHEN fc.is_declined THEN 'Declined'
         WHEN fc.is_unsuitable THEN 'Unsuitable'
-        WHEN
-            fc.both_feet_checked
-            OR (fc.left_foot_checked AND fc.right_foot_checked)
-            THEN 'Complete - Both Feet'
+        WHEN fc.both_feet_checked THEN 'Complete - Both Feet'
         WHEN
             fc.left_foot_checked
             AND (fc.right_foot_absent OR fc.right_foot_amputated)
@@ -81,9 +77,6 @@ SELECT
         WHEN fc.is_unsuitable THEN 'Not Appropriate - Unsuitable'
         WHEN fc.is_declined THEN 'Not Appropriate - Declined'
         WHEN fc.both_feet_checked THEN 'Complete - Both Feet'
-        WHEN
-            fc.left_foot_checked AND fc.right_foot_checked
-            THEN 'Complete - Both Feet'
         WHEN
             fc.left_foot_checked
             AND (fc.right_foot_absent OR fc.right_foot_amputated)

--- a/models/reporting/olids/measures/fct_person_diabetes_foot_check.sql
+++ b/models/reporting/olids/measures/fct_person_diabetes_foot_check.sql
@@ -30,6 +30,7 @@ SELECT
         <= 12
         AND (
             fc.both_feet_checked
+            OR (fc.left_foot_checked AND fc.right_foot_checked)
             OR (
                 fc.left_foot_checked
                 AND (fc.right_foot_absent OR fc.right_foot_amputated)


### PR DESCRIPTION
## Summary
- `fct_person_diabetes_8_care_processes` reports only 322 / 121,355 (0.3%) diabetes register patients as having a completed foot check in the last 12 months — far below the other seven processes (55–70%).
- Root cause: `int_foot_examination_all` uses PCD cluster `FRC_COD` (14 risk-classification codes only). Patients recorded with monofilament, pedal pulses, ABPI, "Diabetic foot examination", etc. are invisible. Additionally, the per-row logic requires "left"/"right" keywords or Townson — generic bilateral codes set none of the foot flags.
- Fix: swap to PCD `FOOTEXAM_COD` (153 QOF DM019 codes — superset of `FRC_COD`), tag FOOTEXAM_COD rows without left/right/Townson as generic bilateral (`both_feet_checked`), and count paired left+right codes on the same date as complete in the fct models.
- Impact (validated against `MODELLING.OLIDS_OBSERVATIONS` + `REPORTING.OLIDS_DISEASE_REGISTERS`): 68,427 / 121,355 (56.4%) diabetes patients have a FOOTEXAM_COD code in last 12 months.

## Changes
- `int_foot_examination_all.sql` — cluster swap, new `is_bilateral_generic` tag, updated left/right/both flag logic. Risk-level extraction unchanged (still keyed to explicit left/right/Townson).
- `int_foot_examination_all.yml` — updated `cluster_ids_exist` test and description.
- `fct_person_diabetes_8_care_processes.sql`, `fct_person_diabetes_foot_check.sql` — added `OR (left_foot_checked AND right_foot_checked)` branch.

## Test plan
- [x] `dbt build --select int_foot_examination_all+` succeeds (incl. `cluster_ids_exist`).
- [x] Re-run the completion query from the screenshot; confirm foot check % moves from 0.3% to ~55–60%.
- [x] Spot-check patients flagged only by generic codes (e.g. 401191002 "Diabetic foot examination") now appear as complete.
- [x] Permanent exemption logic (both feet absent/amputated) still resolves correctly.
- [x] `fct_person_diabetes_foot_check` risk-level breakdowns unchanged for patients with explicit left/right codes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined bilateral foot examination detection to accurately identify instances where both left and right feet have been assessed separately.
  * Enhanced foot examination data processing to improve support for QOF DM019 diabetes care outcome reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->