### PR TITLE
fix(bmi): exclude paediatric heights and weights from adult BMI

### DIFF
--- a/models/modelling/olids/observations/int_bmi_all.sql
+++ b/models/modelling/olids/observations/int_bmi_all.sql
@@ -9,7 +9,7 @@ All BMI measurements for adults aged 18+ including both recorded BMI values and 
 Includes ALL persons (active, inactive, deceased) aged 18+ with basic validation (10-150 range).
 Uses ethnicity-adjusted BMI categories per NICE NG246 for cardiometabolic risk populations.
 Avoids calculating BMI on dates where recorded BMI already exists for the same person.
-Age restriction: Adult BMI categories are only clinically appropriate for ages 18+.
+Age restriction: paediatric height and weight measurements (age_at_event < 18) are excluded at source so they never feed calculated BMI. Final join on dim_person_age further filters to currently-18+ persons as adult BMI categories are only clinically appropriate for ages 18+.
 */
 
 WITH recorded_bmi AS (
@@ -49,6 +49,8 @@ height_measurements AS (
       AND obs.result_value IS NOT NULL
       AND TRY_CAST(obs.result_value AS FLOAT) IS NOT NULL
       AND TRY_CAST(obs.result_value AS FLOAT) BETWEEN 50 AND 250
+      -- Adult heights only: paediatric measurements must not feed into adult BMI calculations
+      AND obs.age_at_event >= 18
     QUALIFY ROW_NUMBER() OVER (
         PARTITION BY obs.person_id, obs.clinical_effective_date
         ORDER BY obs.id DESC
@@ -69,6 +71,8 @@ weight_measurements AS (
       AND obs.result_value IS NOT NULL
       AND TRY_CAST(obs.result_value AS FLOAT) IS NOT NULL
       AND TRY_CAST(obs.result_value AS FLOAT) BETWEEN 10 AND 500  -- Valid weight range in kg
+      -- Adult weights only: paediatric measurements must not feed into adult BMI calculations
+      AND obs.age_at_event >= 18
 ),
 
 calculated_bmi AS (

--- a/models/modelling/olids/observations/int_bmi_all.yml
+++ b/models/modelling/olids/observations/int_bmi_all.yml
@@ -6,7 +6,7 @@ models:
 
       Key Features:
 
-      • Age restriction: Adults 18+ only (pediatric BMI requires age/gender-specific percentiles)
+      • Age restriction: Adults 18+ only (paediatric BMI requires age/gender-specific percentiles). Heights and weights recorded under age 18 are excluded at source so they never feed calculated BMI.
 
       • Ethnicity-adjusted BMI categories per NICE NG246 (lower thresholds for at-risk populations)
 

--- a/models/modelling/olids/observations/int_bmi_latest.yml
+++ b/models/modelling/olids/observations/int_bmi_latest.yml
@@ -8,6 +8,8 @@ models:
 
       • Latest valid BMI per person with ethnicity-adjusted thresholds
 
+      • Heights and weights recorded under age 18 are excluded upstream so paediatric measurements never feed calculated BMI
+
       • Includes both standard and ethnicity-adjusted categorisations
 
       • Provides ethnicity context for clinical decision-making
@@ -32,7 +34,8 @@ models:
             thresholds  (overweight ≥23, obese ≥27.5) to reflect increased risk at
             lower BMI levels.
             Age restriction: Adult BMI categories are only clinically appropriate
-            for ages 18+.
+            for ages 18+. Heights and weights with age_at_event < 18 are excluded
+            upstream so paediatric measurements never feed calculated BMI.
           is_qof: false
           source_column: "bmi_category"
           sort_order: "BRF_1_BMI_CATEGORIES"

--- a/models/reporting/olids/data_quality/dq_bmi_issues.yml
+++ b/models/reporting/olids/data_quality/dq_bmi_issues.yml
@@ -10,6 +10,8 @@ models:
 
       • Date validation: Missing or future dates
 
+      • Adult-only scope: inherits int_bmi_all filtering — heights and weights with age_at_event < 18 are excluded upstream, so paediatric measurements do not appear here
+
       Purpose: Supports BMI data validation and clinical review of extreme values.'
     config:
       meta:

--- a/models/reporting/olids/data_quality/dq_bmi_issues.yml
+++ b/models/reporting/olids/data_quality/dq_bmi_issues.yml
@@ -10,7 +10,7 @@ models:
 
       • Date validation: Missing or future dates
 
-      • Adult-only scope: inherits int_bmi_all filtering — heights and weights with age_at_event < 18 are excluded upstream, so paediatric measurements do not appear here
+      • Partial paediatric scope: inherits int_bmi_all filtering — HEIGHT and WEIGHT inputs with age_at_event < 18 are excluded from the calculated BMI path, but recorded BMI values (BMIVAL_COD) are not age-filtered at source and paediatric recorded BMI may still appear here
 
       Purpose: Supports BMI data validation and clinical review of extreme values.'
     config:

--- a/models/reporting/olids/disease_registers/fct_person_condition_episodes.yml
+++ b/models/reporting/olids/disease_registers/fct_person_condition_episodes.yml
@@ -214,6 +214,7 @@ models:
               Episode starts are triggered when BMI first enters an obesity category
               and end when a later BMI falls below the obesity threshold.
               Supports repeated on/off cycles for longitudinal weight-status analysis.
+              BMI sourced from int_bmi_all — heights and weights recorded under age 18 are excluded upstream so paediatric measurements do not feed obesity episodes.
             is_qof: false
             source_column: "current_condition_status"
             sort_order: "CONDITION_EPISODES_OB"

--- a/models/reporting/olids/disease_registers/fct_person_condition_episodes.yml
+++ b/models/reporting/olids/disease_registers/fct_person_condition_episodes.yml
@@ -214,7 +214,7 @@ models:
               Episode starts are triggered when BMI first enters an obesity category
               and end when a later BMI falls below the obesity threshold.
               Supports repeated on/off cycles for longitudinal weight-status analysis.
-              BMI sourced from int_bmi_all — heights and weights recorded under age 18 are excluded upstream so paediatric measurements do not feed obesity episodes.
+              BMI sourced from int_bmi_all — HEIGHT and WEIGHT inputs with age_at_event < 18 are excluded from the calculated BMI path so paediatric heights/weights cannot drive calculated obesity episodes. Recorded BMI values (BMIVAL_COD) are still included regardless of age, so a paediatric recorded BMI could seed an obesity episode.
             is_qof: false
             source_column: "current_condition_status"
             sort_order: "CONDITION_EPISODES_OB"

--- a/models/reporting/olids/measures/fct_person_diabetes_8_care_processes.yml
+++ b/models/reporting/olids/measures/fct_person_diabetes_8_care_processes.yml
@@ -2,7 +2,7 @@ models:
   - name: fct_person_diabetes_8_care_processes
     description: 'Diabetes 8 care processes achievement for QOF reporting.
 
-      One row per person on diabetes register with completion status for HbA1c, blood pressure, cholesterol, creatinine, ACR, foot check, BMI, and smoking status within 12 months.'
+      One row per person on diabetes register with completion status for HbA1c, blood pressure, cholesterol, creatinine, ACR, foot check, BMI, and smoking status within 12 months. BMI uses int_bmi_latest which excludes heights and weights recorded under age 18 (paediatric measurements do not feed adult BMI).'
 
     tests:
       - dbt_expectations.expect_table_row_count_to_be_between:

--- a/models/reporting/olids/measures/fct_person_diabetes_8_care_processes.yml
+++ b/models/reporting/olids/measures/fct_person_diabetes_8_care_processes.yml
@@ -2,7 +2,7 @@ models:
   - name: fct_person_diabetes_8_care_processes
     description: 'Diabetes 8 care processes achievement for QOF reporting.
 
-      One row per person on diabetes register with completion status for HbA1c, blood pressure, cholesterol, creatinine, ACR, foot check, BMI, and smoking status within 12 months. BMI uses int_bmi_latest which excludes heights and weights recorded under age 18 (paediatric measurements do not feed adult BMI).'
+      One row per person on diabetes register with completion status for HbA1c, blood pressure, cholesterol, creatinine, ACR, foot check, BMI, and smoking status within 12 months. BMI uses int_bmi_latest: HEIGHT and WEIGHT source inputs with age_at_event < 18 are excluded from the calculated BMI path, while recorded BMI values (BMIVAL_COD) remain unfiltered at source.'
 
     tests:
       - dbt_expectations.expect_table_row_count_to_be_between:

--- a/models/reporting/olids/person_status/fct_person_behavioural_risk_factors.yml
+++ b/models/reporting/olids/person_status/fct_person_behavioural_risk_factors.yml
@@ -2,7 +2,7 @@ models:
   - name: fct_person_behavioural_risk_factors
     description: 'Population view of person-level behavioural risk factors combining BMI, smoking, and alcohol status.
 
-      One row per person from dim_person_demographics (persons with recorded birth dates) with data availability flags for each risk factor.'
+      One row per person from dim_person_demographics (persons with recorded birth dates) with data availability flags for each risk factor. BMI is sourced from int_bmi_latest — heights and weights recorded under age 18 are excluded upstream, so paediatric measurements do not feed adult BMI.'
     config:
       meta:
         owner:

--- a/models/reporting/olids/person_status/fct_person_behavioural_risk_factors.yml
+++ b/models/reporting/olids/person_status/fct_person_behavioural_risk_factors.yml
@@ -2,7 +2,7 @@ models:
   - name: fct_person_behavioural_risk_factors
     description: 'Population view of person-level behavioural risk factors combining BMI, smoking, and alcohol status.
 
-      One row per person from dim_person_demographics (persons with recorded birth dates) with data availability flags for each risk factor. BMI is sourced from int_bmi_latest — heights and weights recorded under age 18 are excluded upstream, so paediatric measurements do not feed adult BMI.'
+      One row per person from dim_person_demographics (persons with recorded birth dates) with data availability flags for each risk factor. BMI is sourced from int_bmi_latest: HEIGHT and WEIGHT inputs with age_at_event < 18 are excluded from the calculated BMI path (so paediatric heights/weights cannot drive calculated BMI), while previously recorded BMI values (BMIVAL_COD) are preserved regardless of age.'
     config:
       meta:
         owner:

--- a/models/semantic/sem_olids_observations.yml
+++ b/models/semantic/sem_olids_observations.yml
@@ -26,7 +26,7 @@ models:
       - int_blood_pressure_latest / fct_person_bp_control: BP and control status
       - int_hba1c_latest: HbA1c with NICE categories
       - int_cholesterol_latest / int_cholesterol_ldl_latest: Total and LDL cholesterol
-      - int_bmi_latest: BMI with ethnicity-adjusted categories
+      - int_bmi_latest: BMI with ethnicity-adjusted categories (adults 18+ only; heights and weights under age 18 excluded upstream)
       - int_waist_circumference_latest: Waist circumference with risk categories
       - int_egfr_latest: eGFR with CKD staging
       - int_creatinine_latest: Serum creatinine


### PR DESCRIPTION
## Summary
- `int_bmi_all` filters the final output by current age (`dim_person_age.age >= 18`) but does not filter heights or weights at source. A height recorded aged 12 could be paired with a weight recorded aged 19 via the ASOF join and produce a \"calculated BMI\" for an adult based on a paediatric height.
- Fix: add `age_at_event >= 18` to the HEIGHT and WEIGHT CTEs so paediatric measurements cannot feed calculated BMI.
- Recorded BMI values (BMIVAL_COD) are unchanged — the paediatric filter only applies to the inputs used for the calculated-BMI path.

## Impact (production data)
- HEIGHT: 914,105 / 7,888,773 rows (11.6%) are `age_at_event < 18` and were previously eligible.
- WEIGHT: 1,464,757 / 12,210,798 rows (12.0%) are `age_at_event < 18` and were previously eligible.

## Changes
- `int_bmi_all.sql` — add `age_at_event >= 18` to height_measurements and weight_measurements; refresh header comment.
- `int_bmi_all.yml`, `int_bmi_latest.yml` — note the upstream paediatric exclusion.
- Downstream yml descriptions updated: `dq_bmi_issues`, `fct_person_diabetes_8_care_processes`, `fct_person_behavioural_risk_factors`, `fct_person_condition_episodes`, `sem_olids_observations`.

## Test plan
- [ ] `dbt build --select int_bmi_all+` passes.
- [ ] Spot-check: calculated BMI rows in `int_bmi_all` where the matched height was recorded at age < 18 should no longer exist.
- [ ] Downstream row counts (`int_bmi_latest`, `fct_person_obesity_register`, `fct_person_diabetes_8_care_processes`) remain close to pre-change values — paediatric cases drop out but adult coverage is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Data Quality**
  - Added explicit filtering to exclude paediatric measurements from BMI calculations at source level, ensuring only adult data contributes to BMI-based analyses

* **Documentation**
  - Updated descriptions across multiple datasets to clarify that height and weight measurements for individuals under 18 years old are excluded upstream, preventing inclusion in adult BMI calculations and related clinical measures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->