### PR TITLE
cancer alliance map staging

### DIFF
--- a/models/staging/shared/stg_reference_cancer_lsoa_to_cancer_alliance.sql
+++ b/models/staging/shared/stg_reference_cancer_lsoa_to_cancer_alliance.sql
@@ -1,0 +1,17 @@
+{{ config(schema='cancer__ref') }}
+
+select
+    lsoa21cd as lsoa_2021_code,
+    lsoa21nm as lsoa_2021_name,
+    sicbl25cd as ons_sub_icb_code,
+    sicbl25cdh as sub_icb_code,
+    sicbl25nm as sub_icb_name,
+    icb25cd as ons_icb_code,
+    icb25cdh as icb_code,
+    icb25nm as icb_name,
+    cal25cd as cancer_alliance_code,
+    cal25nm as cancer_alliance_name,
+    lad25cd as borough_code,
+    lad25nm as borough_name
+
+from {{ ref('lsoa_to_cancer_alliance') }}

--- a/models/staging/shared/stg_reference_cancer_lsoa_to_cancer_alliance.yml
+++ b/models/staging/shared/stg_reference_cancer_lsoa_to_cancer_alliance.yml
@@ -1,0 +1,42 @@
+version: 2
+
+models:
+  - name: stg_reference_cancer_lsoa_to_cancer_alliance
+    description: "Staging model for LSOA to Cancer Alliance mappings. Provides cleaned column names and data types for the reference lookup.\nContact: jake.kealey@nhs.net"
+    columns:
+      - name: lsoa_2021_code
+        data_type: varchar
+        description: "Official Lower Layer Super Output Area 2021 code."
+      - name: lsoa_2021_name
+        data_type: varchar
+        description: "LSOA 2021 name."
+      - name: ons_sub_icb_code
+        data_type: varchar
+        description: "ONS Sub-ICB 2025 code."
+      - name: sub_icb_code
+        data_type: varchar
+        description: "Short/historical Sub-ICB code used in source data."
+      - name: sub_icb_name
+        data_type: varchar
+        description: "Sub-ICB 2025 name."
+      - name: ons_icb_code
+        data_type: varchar
+        description: "ONS ICB 2025 code."
+      - name: icb_code
+        data_type: varchar
+        description: "Short/historical ICB code used in source data."
+      - name: icb_name
+        data_type: varchar
+        description: "ICB 2025 name."
+      - name: cancer_alliance_code
+        data_type: varchar
+        description: "Cancer Alliance 2025 code."
+      - name: cancer_alliance_name
+        data_type: varchar
+        description: "Cancer Alliance 2025 name."
+      - name: borough_code
+        data_type: varchar
+        description: "Local Authority District (borough) 2025 code."
+      - name: borough_name
+        data_type: varchar
+        description: "Local Authority District (borough) 2025 name."

--- a/models/staging/shared/stg_reference_cancer_lsoa_to_cancer_alliance.yml
+++ b/models/staging/shared/stg_reference_cancer_lsoa_to_cancer_alliance.yml
@@ -7,36 +7,39 @@ models:
       - name: lsoa_2021_code
         data_type: varchar
         description: "Official Lower Layer Super Output Area 2021 code."
+        tests:
+          - unique
+          - not_null
       - name: lsoa_2021_name
         data_type: varchar
-        description: "LSOA 2021 name."
+        description: "LSOA 2021 name"
       - name: ons_sub_icb_code
         data_type: varchar
-        description: "ONS Sub-ICB 2025 code."
+        description: "ONS Sub-ICB code"
       - name: sub_icb_code
         data_type: varchar
-        description: "Short/historical Sub-ICB code used in source data."
+        description: "Sub-ICB code"
       - name: sub_icb_name
         data_type: varchar
-        description: "Sub-ICB 2025 name."
+        description: "Sub-ICB name"
       - name: ons_icb_code
         data_type: varchar
-        description: "ONS ICB 2025 code."
+        description: "ONS ICB code"
       - name: icb_code
         data_type: varchar
-        description: "Short/historical ICB code used in source data."
+        description: "ICB code"
       - name: icb_name
         data_type: varchar
-        description: "ICB 2025 name."
+        description: "ICB name"
       - name: cancer_alliance_code
         data_type: varchar
-        description: "Cancer Alliance 2025 code."
+        description: "Cancer Alliance code"
       - name: cancer_alliance_name
         data_type: varchar
-        description: "Cancer Alliance 2025 name."
+        description: "Cancer Alliance name"
       - name: borough_code
         data_type: varchar
-        description: "Local Authority District (borough) 2025 code."
+        description: "Local Authority (borough) code"
       - name: borough_name
         data_type: varchar
-        description: "Local Authority District (borough) 2025 name."
+        description: "Local Authority (borough) name"

--- a/models/staging/shared/stg_reference_cancer_lsoa_to_cancer_alliance.yml
+++ b/models/staging/shared/stg_reference_cancer_lsoa_to_cancer_alliance.yml
@@ -3,6 +3,10 @@ version: 2
 models:
   - name: stg_reference_cancer_lsoa_to_cancer_alliance
     description: "Staging model for LSOA to Cancer Alliance mappings. Provides cleaned column names and data types for the reference lookup.\nContact: jake.kealey@nhs.net"
+    config:
+      meta:
+        owner:
+          name: JakeKea
     columns:
       - name: lsoa_2021_code
         data_type: varchar

--- a/models/staging/shared/stg_reference_cancer_sub_icb_to_cancer_alliance.sql
+++ b/models/staging/shared/stg_reference_cancer_sub_icb_to_cancer_alliance.sql
@@ -1,0 +1,13 @@
+{{ config(schema='cancer__ref') }}
+
+select 
+    ccg21cd as ons_sub_icb_code,
+    ccg21cdh as sub_icb_code,
+    ccg21nm as sub_icb_name,
+    stp21cd as ons_icb_code,
+    stp21cdh as icb_code,
+    stp21nm as icb_name,
+    cal21cd as cancer_alliance_code,
+    cal21nm as cancer_alliance_name
+
+from {{ ref('ccg_icb_to_cancer_alliance') }}

--- a/models/staging/shared/stg_reference_cancer_sub_icb_to_cancer_alliance.yml
+++ b/models/staging/shared/stg_reference_cancer_sub_icb_to_cancer_alliance.yml
@@ -6,25 +6,32 @@ models:
     columns:
       - name: ons_sub_icb_code
         data_type: varchar
-        description: "ONS Sub-ICB (CCG) 2021 code."
+        description: "ONS Sub-ICB code."
       - name: sub_icb_code
         data_type: varchar
-        description: "Short/historical Sub-ICB code used in source data."
+        description: "Sub-ICB code"
+        tests:
+          - unique
+          - not_null
       - name: sub_icb_name
         data_type: varchar
-        description: "Sub-ICB (CCG) 2021 name."
+        description: "Sub-ICB name"
       - name: ons_icb_code
         data_type: varchar
-        description: "ONS ICB (STP) 2021 code."
+        description: "ONS ICB code"
       - name: icb_code
         data_type: varchar
-        description: "Short/historical ICB code used in source data."
+        description: "ICB code"
+        tests:
+          - not_null
       - name: icb_name
         data_type: varchar
-        description: "ICB (STP) 2021 name."
+        description: "ICB name"
       - name: cancer_alliance_code
         data_type: varchar
-        description: "Cancer Alliance 2021 code."
+        description: "Cancer Alliance code"
+        tests:
+          - not_null
       - name: cancer_alliance_name
         data_type: varchar
-        description: "Cancer Alliance 2021 name."
+        description: "Cancer Alliance name"

--- a/models/staging/shared/stg_reference_cancer_sub_icb_to_cancer_alliance.yml
+++ b/models/staging/shared/stg_reference_cancer_sub_icb_to_cancer_alliance.yml
@@ -3,6 +3,10 @@ version: 2
 models:
   - name: stg_reference_cancer_sub_icb_to_cancer_alliance
     description: "Staging model for CCG/ICB to Cancer Alliance mappings. Provides cleaned column names and data types for the reference lookup.\nContact: jake.kealey@nhs.net"
+    config:
+      meta:
+        owner:
+          name: JakeKea
     columns:
       - name: ons_sub_icb_code
         data_type: varchar

--- a/models/staging/shared/stg_reference_cancer_sub_icb_to_cancer_alliance.yml
+++ b/models/staging/shared/stg_reference_cancer_sub_icb_to_cancer_alliance.yml
@@ -1,0 +1,30 @@
+version: 2
+
+models:
+  - name: stg_reference_cancer_sub_icb_to_cancer_alliance
+    description: "Staging model for CCG/ICB to Cancer Alliance mappings. Provides cleaned column names and data types for the reference lookup.\nContact: jake.kealey@nhs.net"
+    columns:
+      - name: ons_sub_icb_code
+        data_type: varchar
+        description: "ONS Sub-ICB (CCG) 2021 code."
+      - name: sub_icb_code
+        data_type: varchar
+        description: "Short/historical Sub-ICB code used in source data."
+      - name: sub_icb_name
+        data_type: varchar
+        description: "Sub-ICB (CCG) 2021 name."
+      - name: ons_icb_code
+        data_type: varchar
+        description: "ONS ICB (STP) 2021 code."
+      - name: icb_code
+        data_type: varchar
+        description: "Short/historical ICB code used in source data."
+      - name: icb_name
+        data_type: varchar
+        description: "ICB (STP) 2021 name."
+      - name: cancer_alliance_code
+        data_type: varchar
+        description: "Cancer Alliance 2021 code."
+      - name: cancer_alliance_name
+        data_type: varchar
+        description: "Cancer Alliance 2021 name."


### PR DESCRIPTION
add: staging reference table for the cancer alliance map files. Uses cancer__ref as a custom schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardised reference datasets mapping Lower Layer Super Output Areas (LSOA) geography to Cancer Alliance regions
  * Added standardised reference datasets mapping Sub-ICB and ICB units to Cancer Alliance regions with consistent identifiers and names across Local Authority Districts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->