### PR TITLE
fix: add post-hook descriptions for seeds and snapshots

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -146,6 +146,7 @@ seeds:
     +database: "DATA_LAKE__NCL"
     +schema: "DBT_SEEDS"
     +quote_columns: false
+    +post-hook: ["{{ add_model_comment() }}"]
 
     bnf_polypharmacy_exclusions:
       +column_types:
@@ -223,3 +224,4 @@ snapshots:
   wnl_analytics:
     +database: "MODELLING"
     +target_schema: "DBT_SNAPSHOTS"
+    +post-hook: ["{{ add_model_comment() }}"]


### PR DESCRIPTION
## Summary
- Seeds and snapshots were missing the `add_model_comment()` post-hook that models have, so their yml descriptions weren't being persisted to Snowflake
- Adds `+post-hook: ["{{ add_model_comment() }}"]` to both the `seeds` and `snapshots` sections in `dbt_project.yml`
- The macro's default branch already handles non-standard materializations (`seed`, `snapshot`) correctly via `COMMENT ON TABLE`

## Test plan
- [ ] Run `dbt seed` for a seed with a description and verify the comment appears in Snowflake
- [ ] Run `dbt snapshot` and verify the comment appears in Snowflake

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Seeds and snapshots in analytics configurations now automatically include generated comments for improved metadata and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->