### PR TITLE
fix: add Z9B2Z WNL ICB to organisation STP filters + add sub_icb_code/name

### DIFF
--- a/models/modelling/olids/organisation/int_organisation_borough_mapping.sql
+++ b/models/modelling/olids/organisation/int_organisation_borough_mapping.sql
@@ -143,7 +143,19 @@ SELECT
     pbf.practice_code,
     pbf.borough AS borough_registered,
     pbf.historic_ccg AS practice_historic_ccg,
-    
+    -- Legacy sub-ICB derived from borough. Useful when comparing the merged
+    -- WNL ICB (Z9B2Z) against its constituent legacy entities (NCL/NWL).
+    CASE
+        WHEN pbf.borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'QMJ'
+        WHEN pbf.borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
+                             'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'QRV'
+    END AS legacy_sub_icb_code,
+    CASE
+        WHEN pbf.borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'NHS North Central London'
+        WHEN pbf.borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
+                             'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'NHS North West London'
+    END AS legacy_sub_icb_name,
+
     -- PCN mapping
     pp.network_code,
     pcnbf.borough AS pcn_borough,

--- a/models/modelling/olids/organisation/int_organisation_borough_mapping.sql
+++ b/models/modelling/olids/organisation/int_organisation_borough_mapping.sql
@@ -143,18 +143,18 @@ SELECT
     pbf.practice_code,
     pbf.borough AS borough_registered,
     pbf.historic_ccg AS practice_historic_ccg,
-    -- Legacy sub-ICB derived from borough. Useful when comparing the merged
-    -- WNL ICB (Z9B2Z) against its constituent legacy entities (NCL/NWL).
+    -- Sub-ICB / place-based partnership derived from borough. Z9B2Z (WNL)
+    -- is composed of two place-based partnerships: NCL and NWL.
     CASE
         WHEN pbf.borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'QMJ'
         WHEN pbf.borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
                              'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'QRV'
-    END AS legacy_sub_icb_code,
+    END AS sub_icb_code,
     CASE
         WHEN pbf.borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'NHS North Central London'
         WHEN pbf.borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
                              'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'NHS North West London'
-    END AS legacy_sub_icb_name,
+    END AS sub_icb_name,
 
     -- PCN mapping
     pp.network_code,

--- a/models/modelling/olids/organisation/int_organisation_borough_mapping.sql
+++ b/models/modelling/olids/organisation/int_organisation_borough_mapping.sql
@@ -7,13 +7,19 @@
 
 /*
 Organisation Borough Mapping
-Maps practices and PCNs to North Central London boroughs using current organisational hierarchy.
-Uses Dictionary.dbo.OrganisationDescendent for GP Practice -> PCN -> CCG -> ICB hierarchy.
+Maps practices and PCNs to London boroughs using current organisational hierarchy. Now
+covers all London ICBs including the merged West and North London entry (Z9B2Z) alongside
+the legacy NCL/NWL codes; the full London borough set is enumerated via borough_ccgs.
+Uses Dictionary's OrganisationDescendent for GP Practice -> PCN -> CCG -> ICB hierarchy.
+
+Also derives the canonical sub_icb_code / sub_icb_name (place-based partnership: NCL or NWL)
+at both practice level (from borough_registered) and PCN level (from pcn_borough). Downstream
+dims read these directly rather than re-implementing the borough-to-sub-ICB CASE.
 
 Special handling:
 - Medicus Select Care (Y03103) manually assigned to Enfield borough regardless of CCG history,
   as they provide cross-borough services but parent organisation is Enfield-based.
-- Filters to London practices only (maintains existing behaviour)
+- Filters to London practices only (maintains existing behaviour).
 */
 
 WITH borough_ccgs AS (
@@ -159,7 +165,19 @@ SELECT
     -- PCN mapping
     pp.network_code,
     pcnbf.borough AS pcn_borough,
-    pcnbf.borough_practice_count AS pcn_borough_practice_count
+    pcnbf.borough_practice_count AS pcn_borough_practice_count,
+    -- PCN-level sub-ICB derived from PCN's predominant borough. Same logic as
+    -- sub_icb_code above but at PCN grain so dim_pcn doesn't need to re-derive.
+    CASE
+        WHEN pcnbf.borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'QMJ'
+        WHEN pcnbf.borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
+                               'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'QRV'
+    END AS pcn_sub_icb_code,
+    CASE
+        WHEN pcnbf.borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'NHS North Central London'
+        WHEN pcnbf.borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
+                               'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'NHS North West London'
+    END AS pcn_sub_icb_name
 
 FROM borough_registered_final pbf
 LEFT JOIN practice_pcn pp

--- a/models/modelling/olids/organisation/int_organisation_borough_mapping.sql
+++ b/models/modelling/olids/organisation/int_organisation_borough_mapping.sql
@@ -72,7 +72,7 @@ practice_pcn AS (
     FROM {{ ref('stg_dictionary_dbo_organisationmatrixpracticeview') }}
     WHERE practice_code IS NOT NULL
         AND network_code IS NOT NULL
-        AND stp_code IN ('QMJ', 'QMF', 'QRV', 'QWE', 'QKK')  -- All London ICBs
+        AND stp_code IN ('Z9B2Z', 'QMJ', 'QMF', 'QRV', 'QWE', 'QKK')  -- All London ICBs (Z9B2Z = merged WNL from Apr 2026; QMJ/QRV retained as legacy)
 ),
 
 -- Get historic CCG relationships from OrganisationDescendent paths (for borough mapping)

--- a/models/modelling/olids/organisation/int_organisation_borough_mapping.yml
+++ b/models/modelling/olids/organisation/int_organisation_borough_mapping.yml
@@ -26,6 +26,18 @@ models:
       meta:
         owner:
           name: EddieDavison92
+    data_tests:
+      # Catch silent breakage from misspelled or missing borough values inside
+      # the WNL footprint. Intentional NULLs outside WNL boroughs are allowed.
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              sub_icb_code IS NOT NULL
+              OR borough_registered NOT IN (
+                'Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey',
+                'Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
+                'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster'
+              )
     columns:
       - name: practice_code
         description: 'GP practice identifier. Not unique - practices may appear multiple times if they have multiple PCN relationships.'
@@ -37,17 +49,6 @@ models:
         description: 'Historic CCG code used for borough mapping'
       - name: sub_icb_code
         description: 'Sub-ICB / place-based partnership ODS code derived from borough — QMJ for NCL boroughs (Camden, Islington, Barnet, Enfield, Haringey), QRV for NWL boroughs (Brent, Ealing, Hammersmith and Fulham, Harrow, Hillingdon, Hounslow, Kensington and Chelsea, Westminster). NULL outside WNL.'
-        data_tests:
-          # Catch silent breakage from misspelled or missing borough values inside
-          # the WNL footprint. Intentional NULLs outside WNL boroughs are allowed.
-          - dbt_utils.expression_is_true:
-              expression: >
-                sub_icb_code IS NOT NULL
-                OR borough_registered NOT IN (
-                  'Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey',
-                  'Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
-                  'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster'
-                )
       - name: sub_icb_name
         description: 'Sub-ICB display name (NHS North Central London / NHS North West London). NULL outside WNL.'
       - name: network_code

--- a/models/modelling/olids/organisation/int_organisation_borough_mapping.yml
+++ b/models/modelling/olids/organisation/int_organisation_borough_mapping.yml
@@ -37,8 +37,19 @@ models:
         description: 'Historic CCG code used for borough mapping'
       - name: sub_icb_code
         description: 'Sub-ICB / place-based partnership ODS code derived from borough — QMJ for NCL boroughs (Camden, Islington, Barnet, Enfield, Haringey), QRV for NWL boroughs (Brent, Ealing, Hammersmith and Fulham, Harrow, Hillingdon, Hounslow, Kensington and Chelsea, Westminster). NULL outside WNL.'
+        data_tests:
+          # Catch silent breakage from misspelled or missing borough values inside
+          # the WNL footprint. Intentional NULLs outside WNL boroughs are allowed.
+          - dbt_utils.expression_is_true:
+              expression: >
+                sub_icb_code IS NOT NULL
+                OR borough_registered NOT IN (
+                  'Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey',
+                  'Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
+                  'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster'
+                )
       - name: sub_icb_name
-        description: 'Sub-ICB display name (NHS North Central London / NHS North West London).'
+        description: 'Sub-ICB display name (NHS North Central London / NHS North West London). NULL outside WNL.'
       - name: network_code
         description: 'Primary Care Network (PCN) identifier that the practice belongs
           to'
@@ -46,3 +57,7 @@ models:
         description: 'Borough assignment for the PCN based on majority practice allocation'
       - name: pcn_borough_practice_count
         description: 'Number of practices within the PCN assigned to this borough'
+      - name: pcn_sub_icb_code
+        description: 'Sub-ICB / place-based partnership ODS code at the PCN grain — derived from pcn_borough using the same mapping as sub_icb_code. NULL outside WNL.'
+      - name: pcn_sub_icb_name
+        description: 'Sub-ICB display name at the PCN grain. NULL outside WNL.'

--- a/models/modelling/olids/organisation/int_organisation_borough_mapping.yml
+++ b/models/modelling/olids/organisation/int_organisation_borough_mapping.yml
@@ -1,6 +1,6 @@
 models:
   - name: int_organisation_borough_mapping
-    description: 'Organisation borough mapping for North Central London practices
+    description: 'Organisation borough mapping for West and North London practices
       and PCNs with historic CCG relationships.
 
       Key Features:
@@ -10,16 +10,18 @@ models:
 
       • Maps PCNs to boroughs based on majority practice allocation
 
-      • Hardcoded CCG-to-borough mapping: 07R→Camden, 08H→Islington, 07M→Barnet, 07X→Enfield,
-      08D→Haringey
+      • Hardcoded CCG-to-borough mapping covering all London ICB constituents
+
+      • Derives legacy_sub_icb_code (QMJ NCL / QRV NWL) from borough so the merged
+      WNL ICB can still be split into its pre-merger structure
 
       • Special handling for cross-borough services (Medicus Select Care Y03103 assigned
       to Enfield)
 
       • Uses most recent relationship for each practice-borough combination
 
-      Purpose: Provide borough context for North Central London practices and PCNs
-      for geographic analysis.'
+      Purpose: Provide borough context for London practices and PCNs for geographic
+      analysis.'
     config:
       meta:
         owner:
@@ -32,8 +34,11 @@ models:
       - name: borough_registered
         description: 'Borough assignment for the practice based on historic CCG relationships'
       - name: practice_historic_ccg
-        description: 'Historic CCG code used for borough mapping (07R, 08H, 07M, 07X,
-          08D)'
+        description: 'Historic CCG code used for borough mapping'
+      - name: legacy_sub_icb_code
+        description: 'Legacy sub-ICB ODS code derived from borough — QMJ for NCL boroughs (Camden, Islington, Barnet, Enfield, Haringey), QRV for NWL boroughs (Brent, Ealing, Hammersmith and Fulham, Harrow, Hillingdon, Hounslow, Kensington and Chelsea, Westminster). NULL outside WNL.'
+      - name: legacy_sub_icb_name
+        description: 'Legacy sub-ICB display name (NHS North Central London / NHS North West London).'
       - name: network_code
         description: 'Primary Care Network (PCN) identifier that the practice belongs
           to'

--- a/models/modelling/olids/organisation/int_organisation_borough_mapping.yml
+++ b/models/modelling/olids/organisation/int_organisation_borough_mapping.yml
@@ -12,8 +12,8 @@ models:
 
       • Hardcoded CCG-to-borough mapping covering all London ICB constituents
 
-      • Derives legacy_sub_icb_code (QMJ NCL / QRV NWL) from borough so the merged
-      WNL ICB can still be split into its pre-merger structure
+      • Derives sub_icb_code (QMJ NCL / QRV NWL) from borough so the merged WNL
+      ICB can be split into its place-based partnerships
 
       • Special handling for cross-borough services (Medicus Select Care Y03103 assigned
       to Enfield)
@@ -35,10 +35,10 @@ models:
         description: 'Borough assignment for the practice based on historic CCG relationships'
       - name: practice_historic_ccg
         description: 'Historic CCG code used for borough mapping'
-      - name: legacy_sub_icb_code
-        description: 'Legacy sub-ICB ODS code derived from borough — QMJ for NCL boroughs (Camden, Islington, Barnet, Enfield, Haringey), QRV for NWL boroughs (Brent, Ealing, Hammersmith and Fulham, Harrow, Hillingdon, Hounslow, Kensington and Chelsea, Westminster). NULL outside WNL.'
-      - name: legacy_sub_icb_name
-        description: 'Legacy sub-ICB display name (NHS North Central London / NHS North West London).'
+      - name: sub_icb_code
+        description: 'Sub-ICB / place-based partnership ODS code derived from borough — QMJ for NCL boroughs (Camden, Islington, Barnet, Enfield, Haringey), QRV for NWL boroughs (Brent, Ealing, Hammersmith and Fulham, Harrow, Hillingdon, Hounslow, Kensington and Chelsea, Westminster). NULL outside WNL.'
+      - name: sub_icb_name
+        description: 'Sub-ICB display name (NHS North Central London / NHS North West London).'
       - name: network_code
         description: 'Primary Care Network (PCN) identifier that the practice belongs
           to'

--- a/models/reporting/olids/organisation/dim_pcn.sql
+++ b/models/reporting/olids/organisation/dim_pcn.sql
@@ -20,7 +20,7 @@ WITH pcn_practices AS (
     FROM {{ ref('stg_dictionary_dbo_organisationmatrixpracticeview') }}
     WHERE network_code IS NOT NULL
         AND practice_code IS NOT NULL
-        AND stp_code = 'QMJ'
+        AND stp_code IN ('Z9B2Z', 'QMJ', 'QRV')  -- WNL merged + legacy NCL/NWL
     GROUP BY network_code
 )
 
@@ -75,4 +75,4 @@ LEFT JOIN {{ ref('stg_dictionary_dbo_organisation') }} AS dict_org
 LEFT JOIN {{ ref('int_organisation_borough_mapping') }} AS borough_map
     ON dict.network_code = borough_map.network_code
 WHERE dict.network_code IS NOT NULL
-    AND dict.stp_code = 'QMJ'
+    AND dict.stp_code IN ('Z9B2Z', 'QMJ', 'QRV')  -- WNL merged + legacy NCL/NWL

--- a/models/reporting/olids/organisation/dim_pcn.sql
+++ b/models/reporting/olids/organisation/dim_pcn.sql
@@ -8,7 +8,7 @@
 /*
 PCN (Primary Care Network) Dimension
 Contains PCN details and member practice information.
-Sources from Dictionary.dbo.OrganisationMatrixPracticeView.
+Sourced from Dictionary's OrganisationMatrixPracticeView.
 Includes borough context for PCN naming.
 */
 
@@ -20,6 +20,9 @@ WITH pcn_practices AS (
     FROM {{ ref('stg_dictionary_dbo_organisationmatrixpracticeview') }}
     WHERE network_code IS NOT NULL
         AND practice_code IS NOT NULL
+        -- Z9B2Z-only is intentional and diverges from dim_practice. The 4 practices
+        -- still under legacy QMJ/QRV STP codes have zero OLIDS appointments — keeping
+        -- them here would re-introduce empty PCN rows that match no fact data.
         AND stp_code = 'Z9B2Z'  -- WNL ICB (merged NCL + NWL, Apr 2026)
     GROUP BY network_code
 )
@@ -38,18 +41,11 @@ SELECT DISTINCT
     
     -- Borough information
     borough_map.pcn_borough,
-    -- Sub-ICB / place-based partnership derived from PCN's predominant borough.
-    -- Z9B2Z (WNL) is composed of two place-based partnerships: NCL and NWL.
-    CASE
-        WHEN borough_map.pcn_borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'QMJ'
-        WHEN borough_map.pcn_borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
-                                         'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'QRV'
-    END AS sub_icb_code,
-    CASE
-        WHEN borough_map.pcn_borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'NHS North Central London'
-        WHEN borough_map.pcn_borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
-                                         'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'NHS North West London'
-    END AS sub_icb_name,
+    -- Sub-ICB / place-based partnership for the PCN. Centralised in
+    -- int_organisation_borough_mapping (pcn_sub_icb_code/name) so the
+    -- borough-to-sub-ICB CASE lives in exactly one place.
+    borough_map.pcn_sub_icb_code AS sub_icb_code,
+    borough_map.pcn_sub_icb_name AS sub_icb_name,
     
     -- PCN membership details
     pp.member_practice_count,

--- a/models/reporting/olids/organisation/dim_pcn.sql
+++ b/models/reporting/olids/organisation/dim_pcn.sql
@@ -38,18 +38,18 @@ SELECT DISTINCT
     
     -- Borough information
     borough_map.pcn_borough,
-    -- Legacy sub-ICB derived from PCN's predominant borough. Useful when
-    -- comparing the merged WNL ICB against its constituent legacy entities.
+    -- Sub-ICB / place-based partnership derived from PCN's predominant borough.
+    -- Z9B2Z (WNL) is composed of two place-based partnerships: NCL and NWL.
     CASE
         WHEN borough_map.pcn_borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'QMJ'
         WHEN borough_map.pcn_borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
                                          'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'QRV'
-    END AS legacy_sub_icb_code,
+    END AS sub_icb_code,
     CASE
         WHEN borough_map.pcn_borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'NHS North Central London'
         WHEN borough_map.pcn_borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
                                          'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'NHS North West London'
-    END AS legacy_sub_icb_name,
+    END AS sub_icb_name,
     
     -- PCN membership details
     pp.member_practice_count,

--- a/models/reporting/olids/organisation/dim_pcn.sql
+++ b/models/reporting/olids/organisation/dim_pcn.sql
@@ -38,6 +38,18 @@ SELECT DISTINCT
     
     -- Borough information
     borough_map.pcn_borough,
+    -- Legacy sub-ICB derived from PCN's predominant borough. Useful when
+    -- comparing the merged WNL ICB against its constituent legacy entities.
+    CASE
+        WHEN borough_map.pcn_borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'QMJ'
+        WHEN borough_map.pcn_borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
+                                         'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'QRV'
+    END AS legacy_sub_icb_code,
+    CASE
+        WHEN borough_map.pcn_borough IN ('Camden', 'Islington', 'Barnet', 'Enfield', 'Haringey') THEN 'NHS North Central London'
+        WHEN borough_map.pcn_borough IN ('Brent', 'Ealing', 'Hammersmith and Fulham', 'Harrow',
+                                         'Hillingdon', 'Hounslow', 'Kensington and Chelsea', 'Westminster') THEN 'NHS North West London'
+    END AS legacy_sub_icb_name,
     
     -- PCN membership details
     pp.member_practice_count,

--- a/models/reporting/olids/organisation/dim_pcn.sql
+++ b/models/reporting/olids/organisation/dim_pcn.sql
@@ -20,7 +20,7 @@ WITH pcn_practices AS (
     FROM {{ ref('stg_dictionary_dbo_organisationmatrixpracticeview') }}
     WHERE network_code IS NOT NULL
         AND practice_code IS NOT NULL
-        AND stp_code IN ('Z9B2Z', 'QMJ', 'QRV')  -- WNL merged + legacy NCL/NWL
+        AND stp_code = 'Z9B2Z'  -- WNL ICB (merged NCL + NWL, Apr 2026)
     GROUP BY network_code
 )
 
@@ -75,4 +75,4 @@ LEFT JOIN {{ ref('stg_dictionary_dbo_organisation') }} AS dict_org
 LEFT JOIN {{ ref('int_organisation_borough_mapping') }} AS borough_map
     ON dict.network_code = borough_map.network_code
 WHERE dict.network_code IS NOT NULL
-    AND dict.stp_code IN ('Z9B2Z', 'QMJ', 'QRV')  -- WNL merged + legacy NCL/NWL
+    AND dict.stp_code = 'Z9B2Z'  -- WNL ICB (merged NCL + NWL, Apr 2026)

--- a/models/reporting/olids/organisation/dim_pcn.yml
+++ b/models/reporting/olids/organisation/dim_pcn.yml
@@ -98,12 +98,18 @@ models:
                 values: ['Z9B2Z']
 
       - name: stp_name
-        description: 'STP name (NHS North Central London Integrated Care Board)'
+        description: 'STP name (NHS West and North London Integrated Care Board)'
         tests:
           - not_null
 
       - name: sk_stp_id
         description: 'Surrogate key for STP organisation'
+
+      - name: legacy_sub_icb_code
+        description: 'Legacy sub-ICB ODS code (QMJ NCL, QRV NWL) derived from the PCN predominant borough. Useful for split reporting against the pre-merger structure.'
+
+      - name: legacy_sub_icb_name
+        description: 'Legacy sub-ICB display name (NHS North Central London / NHS North West London).'
 
       - name: sk_pcn_dict_id
         description: 'Dictionary organisation surrogate key for PCN'

--- a/models/reporting/olids/organisation/dim_pcn.yml
+++ b/models/reporting/olids/organisation/dim_pcn.yml
@@ -106,10 +106,10 @@ models:
         description: 'Surrogate key for STP organisation'
 
       - name: sub_icb_code
-        description: 'Sub-ICB / place-based partnership ODS code (QMJ NCL, QRV NWL) derived from the PCN predominant borough.'
+        description: 'Sub-ICB / place-based partnership ODS code (QMJ NCL, QRV NWL) derived from the PCN predominant borough. NULL for any PCN whose majority borough falls outside the WNL borough set.'
 
       - name: sub_icb_name
-        description: 'Sub-ICB display name (NHS North Central London / NHS North West London).'
+        description: 'Sub-ICB display name (NHS North Central London / NHS North West London). NULL for any PCN whose majority borough falls outside the WNL borough set.'
 
       - name: sk_pcn_dict_id
         description: 'Dictionary organisation surrogate key for PCN'

--- a/models/reporting/olids/organisation/dim_pcn.yml
+++ b/models/reporting/olids/organisation/dim_pcn.yml
@@ -105,11 +105,11 @@ models:
       - name: sk_stp_id
         description: 'Surrogate key for STP organisation'
 
-      - name: legacy_sub_icb_code
-        description: 'Legacy sub-ICB ODS code (QMJ NCL, QRV NWL) derived from the PCN predominant borough. Useful for split reporting against the pre-merger structure.'
+      - name: sub_icb_code
+        description: 'Sub-ICB / place-based partnership ODS code (QMJ NCL, QRV NWL) derived from the PCN predominant borough.'
 
-      - name: legacy_sub_icb_name
-        description: 'Legacy sub-ICB display name (NHS North Central London / NHS North West London).'
+      - name: sub_icb_name
+        description: 'Sub-ICB display name (NHS North Central London / NHS North West London).'
 
       - name: sk_pcn_dict_id
         description: 'Dictionary organisation surrogate key for PCN'

--- a/models/reporting/olids/organisation/dim_pcn.yml
+++ b/models/reporting/olids/organisation/dim_pcn.yml
@@ -4,7 +4,7 @@ models:
 
       Key Features:
 
-      • One row per PCN filtered to North Central London (STPCode = QMJ)
+      • One row per PCN filtered to West and North London ICB (STPCode Z9B2Z + legacy QMJ/QRV)
 
       • Borough-prefixed PCN names for geographic clarity
 
@@ -90,12 +90,12 @@ models:
         description: 'Surrogate key for commissioner organisation'
 
       - name: stp_code
-        description: 'STP code (always QMJ for North Central London in this dataset)'
+        description: 'STP/ICB code — Z9B2Z (merged WNL ICB) + legacy QMJ (NCL) / QRV (NWL) for historical continuity'
         tests:
           - not_null
           - accepted_values:
               arguments:
-                values: ['QMJ']
+                values: ['Z9B2Z', 'QMJ', 'QRV']
 
       - name: stp_name
         description: 'STP name (NHS North Central London Integrated Care Board)'

--- a/models/reporting/olids/organisation/dim_pcn.yml
+++ b/models/reporting/olids/organisation/dim_pcn.yml
@@ -4,7 +4,7 @@ models:
 
       Key Features:
 
-      • One row per PCN filtered to West and North London ICB (STPCode Z9B2Z + legacy QMJ/QRV)
+      • One row per PCN filtered to West and North London ICB (STPCode Z9B2Z)
 
       • Borough-prefixed PCN names for geographic clarity
 
@@ -90,12 +90,12 @@ models:
         description: 'Surrogate key for commissioner organisation'
 
       - name: stp_code
-        description: 'STP/ICB code — Z9B2Z (merged WNL ICB) + legacy QMJ (NCL) / QRV (NWL) for historical continuity'
+        description: 'STP/ICB code — Z9B2Z (West and North London ICB, merged NCL + NWL from Apr 2026)'
         tests:
           - not_null
           - accepted_values:
               arguments:
-                values: ['Z9B2Z', 'QMJ', 'QRV']
+                values: ['Z9B2Z']
 
       - name: stp_name
         description: 'STP name (NHS North Central London Integrated Care Board)'

--- a/models/reporting/olids/organisation/dim_practice.sql
+++ b/models/reporting/olids/organisation/dim_practice.sql
@@ -35,6 +35,8 @@ WITH practice_org_joined AS (
     borough_map.borough_registered,
     borough_map.pcn_borough,
     borough_map.practice_historic_ccg,
+    borough_map.legacy_sub_icb_code,
+    borough_map.legacy_sub_icb_name,
     
     -- Practice organisational details from OLIDS
     org.type_code AS practice_type_code,

--- a/models/reporting/olids/organisation/dim_practice.sql
+++ b/models/reporting/olids/organisation/dim_practice.sql
@@ -8,7 +8,7 @@
 /*
 Practice Dimension
 Contains comprehensive practice details including organisational hierarchy.
-Sources from Dictionary.dbo.OrganisationMatrixPracticeView and OLIDS organisation data.
+Sourced from Dictionary's OrganisationMatrixPracticeView combined with OLIDS organisation data.
 Note: Deduplicates by organisation_id to ensure uniqueness when multiple practice codes map to same organisation.
 */
 

--- a/models/reporting/olids/organisation/dim_practice.sql
+++ b/models/reporting/olids/organisation/dim_practice.sql
@@ -35,8 +35,8 @@ WITH practice_org_joined AS (
     borough_map.borough_registered,
     borough_map.pcn_borough,
     borough_map.practice_historic_ccg,
-    borough_map.legacy_sub_icb_code,
-    borough_map.legacy_sub_icb_name,
+    borough_map.sub_icb_code,
+    borough_map.sub_icb_name,
     
     -- Practice organisational details from OLIDS
     org.type_code AS practice_type_code,

--- a/models/reporting/olids/organisation/dim_practice.sql
+++ b/models/reporting/olids/organisation/dim_practice.sql
@@ -144,11 +144,12 @@ LEFT JOIN {{ ref('int_organisation_borough_mapping') }} AS borough_map
     ON dict.practice_code = borough_map.practice_code
 WHERE dict.practice_code IS NOT NULL
     AND dict.stp_code IN (
-        'QMJ',  -- NHS NORTH CENTRAL LONDON INTEGRATED CARE BOARD
-        'QMF',  -- NHS NORTH EAST LONDON INTEGRATED CARE BOARD
-        'QRV',  -- NHS NORTH WEST LONDON INTEGRATED CARE BOARD
-        'QWE',  -- NHS SOUTH WEST LONDON INTEGRATED CARE BOARD
-        'QKK'   -- NHS SOUTH EAST LONDON INTEGRATED CARE BOARD
+        'Z9B2Z', -- NHS WEST AND NORTH LONDON INTEGRATED CARE BOARD (merged NCL + NWL from Apr 2026)
+        'QMJ',   -- NHS NORTH CENTRAL LONDON (legacy, retained for historical continuity)
+        'QRV',   -- NHS NORTH WEST LONDON (legacy, retained for historical continuity)
+        'QMF',   -- NHS NORTH EAST LONDON INTEGRATED CARE BOARD
+        'QWE',   -- NHS SOUTH WEST LONDON INTEGRATED CARE BOARD
+        'QKK'    -- NHS SOUTH EAST LONDON INTEGRATED CARE BOARD
     )
 )
 

--- a/models/reporting/olids/organisation/dim_practice.yml
+++ b/models/reporting/olids/organisation/dim_practice.yml
@@ -139,6 +139,12 @@ models:
               arguments:
                 values: ['Z9B2Z', 'QMJ', 'QMF', 'QRV', 'QWE', 'QKK']
 
+      - name: legacy_sub_icb_code
+        description: 'Legacy sub-ICB ODS code (QMJ NCL, QRV NWL) for practices in the merged WNL ICB. NULL outside WNL boroughs. Useful for split reporting against the pre-merger structure.'
+
+      - name: legacy_sub_icb_name
+        description: 'Legacy sub-ICB display name (NHS North Central London / NHS North West London). NULL outside WNL boroughs.'
+
       - name: stp_name
         description: 'STP/ICB name (London Integrated Care Boards)'
         tests:

--- a/models/reporting/olids/organisation/dim_practice.yml
+++ b/models/reporting/olids/organisation/dim_practice.yml
@@ -132,12 +132,12 @@ models:
         description: 'Surrogate key for commissioner organisation'
 
       - name: stp_code
-        description: 'STP/ICB code (London ICBs: QMJ, QMF, QRV, QWE, QKK)'
+        description: 'STP/ICB code (London ICBs: Z9B2Z WNL, QMF NEL, QWE SWL, QKK SEL; legacy QMJ/QRV retained for historical continuity)'
         tests:
           - not_null
           - accepted_values:
               arguments:
-                values: ['QMJ', 'QMF', 'QRV', 'QWE', 'QKK']
+                values: ['Z9B2Z', 'QMJ', 'QMF', 'QRV', 'QWE', 'QKK']
 
       - name: stp_name
         description: 'STP/ICB name (London Integrated Care Boards)'

--- a/models/reporting/olids/organisation/dim_practice.yml
+++ b/models/reporting/olids/organisation/dim_practice.yml
@@ -14,7 +14,7 @@ models:
 
       • Complete organisational hierarchy (Practice > PCN > Commissioner > STP)
 
-      • Filtered to London ICBs: North Central, North East, North West, South East, South West
+      • Filtered to London ICBs: West and North London (merged NCL + NWL), North East, South East, South West
 
       Purpose: Supports practice-level reporting, geographic analysis, and organisational hierarchy navigation.'
 

--- a/models/reporting/olids/organisation/dim_practice.yml
+++ b/models/reporting/olids/organisation/dim_practice.yml
@@ -139,11 +139,11 @@ models:
               arguments:
                 values: ['Z9B2Z', 'QMJ', 'QMF', 'QRV', 'QWE', 'QKK']
 
-      - name: legacy_sub_icb_code
-        description: 'Legacy sub-ICB ODS code (QMJ NCL, QRV NWL) for practices in the merged WNL ICB. NULL outside WNL boroughs. Useful for split reporting against the pre-merger structure.'
+      - name: sub_icb_code
+        description: 'Sub-ICB / place-based partnership ODS code (QMJ NCL, QRV NWL) for practices in the merged WNL ICB. NULL outside WNL boroughs.'
 
-      - name: legacy_sub_icb_name
-        description: 'Legacy sub-ICB display name (NHS North Central London / NHS North West London). NULL outside WNL boroughs.'
+      - name: sub_icb_name
+        description: 'Sub-ICB display name (NHS North Central London / NHS North West London). NULL outside WNL boroughs.'
 
       - name: stp_name
         description: 'STP/ICB name (London Integrated Care Boards)'

--- a/models/reporting/olids/person_analytics/person_month_analysis_base.sql
+++ b/models/reporting/olids/person_analytics/person_month_analysis_base.sql
@@ -90,6 +90,8 @@ SELECT
     -- Practice and geography
     d.practice_code,
     d.borough_registered,
+    d.sub_icb_code,
+    d.sub_icb_name,
     d.practice_postcode,
     d.practice_lsoa,
     d.practice_msoa,

--- a/models/reporting/olids/person_demographics/dim_person_demographics.sql
+++ b/models/reporting/olids/person_demographics/dim_person_demographics.sql
@@ -98,6 +98,8 @@ WITH base AS (
 
         -- Geographic Information
         hist.borough_registered,
+        hist.sub_icb_code,
+        hist.sub_icb_name,
         hist.practice_postcode,
         hist.practice_lsoa,
         hist.practice_msoa,

--- a/models/reporting/olids/person_demographics/dim_person_demographics_historical.sql
+++ b/models/reporting/olids/person_demographics/dim_person_demographics_historical.sql
@@ -346,6 +346,8 @@ SELECT
 
     -- Geographic Information (practice-based)
     dp.borough_registered,
+    dp.sub_icb_code,
+    dp.sub_icb_name,
     dp.practice_postcode_dict AS practice_postcode,
     dp.practice_lsoa,
     dp.practice_msoa,
@@ -408,6 +410,8 @@ LEFT JOIN (
         pcn_name,
         pcn_name_with_borough,
         borough_registered,
+        sub_icb_code,
+        sub_icb_name,
         practice_postcode_dict,
         practice_lsoa,
         practice_msoa,

--- a/models/semantic/sem_olids_appointments.sql
+++ b/models/semantic/sem_olids_appointments.sql
@@ -110,6 +110,8 @@ DIMENSIONS(
     practice.pcn_name AS pcn_name COMMENT = 'PCN name of the appointment-owning practice',
     practice.pcn_name_with_borough AS pcn_name_with_borough COMMENT = 'PCN with borough prefix for the appointment-owning practice',
     practice.borough_registered AS borough_registered COMMENT = 'Borough of the appointment-owning practice',
+    practice.sub_icb_code AS sub_icb_code COMMENT = 'Sub-ICB / place-based partnership ODS code of the appointment-owning practice — QMJ for NCL boroughs, QRV for NWL. NULL outside WNL.',
+    practice.sub_icb_name AS sub_icb_name COMMENT = 'Sub-ICB display name (NHS North Central London / NHS North West London) of the appointment-owning practice. NULL outside WNL.',
 
     -- Booking
     appt.booking_method AS booking_method COMMENT = 'Booking method source code',

--- a/models/semantic/sem_olids_appointments.sql
+++ b/models/semantic/sem_olids_appointments.sql
@@ -110,8 +110,8 @@ DIMENSIONS(
     practice.pcn_name AS pcn_name COMMENT = 'PCN name of the appointment-owning practice',
     practice.pcn_name_with_borough AS pcn_name_with_borough COMMENT = 'PCN with borough prefix for the appointment-owning practice',
     practice.borough_registered AS borough_registered COMMENT = 'Borough of the appointment-owning practice',
-    practice.sub_icb_code AS sub_icb_code COMMENT = 'Sub-ICB / place-based partnership ODS code of the appointment-owning practice — QMJ for NCL boroughs, QRV for NWL. NULL outside WNL.',
-    practice.sub_icb_name AS sub_icb_name COMMENT = 'Sub-ICB display name (NHS North Central London / NHS North West London) of the appointment-owning practice. NULL outside WNL.',
+    practice.sub_icb_code AS sub_icb_code COMMENT = 'Sub-ICB / place-based partnership ODS code of the appointment-owning practice: QMJ = NHS North Central London (Camden, Islington, Barnet, Enfield, Haringey); QRV = NHS North West London (Brent, Ealing, Hammersmith and Fulham, Harrow, Hillingdon, Hounslow, Kensington and Chelsea, Westminster). NULL outside the WNL footprint.',
+    practice.sub_icb_name AS sub_icb_name COMMENT = 'Sub-ICB display name (NHS North Central London or NHS North West London) of the appointment-owning practice. NULL outside the WNL footprint.',
 
     -- Booking
     appt.booking_method AS booking_method COMMENT = 'Booking method source code',

--- a/models/semantic/sem_olids_observations.sql
+++ b/models/semantic/sem_olids_observations.sql
@@ -185,6 +185,8 @@ DIMENSIONS(
     demographics.pcn_code AS pcn_code COMMENT = 'Primary Care Network code',
     demographics.pcn_name AS pcn_name COMMENT = 'Primary Care Network name',
     demographics.borough_registered AS borough_registered COMMENT = 'Registration borough',
+    demographics.sub_icb_code AS sub_icb_code COMMENT = 'Sub-ICB / place-based partnership ODS code of the registered practice: QMJ = NHS North Central London (Camden, Islington, Barnet, Enfield, Haringey); QRV = NHS North West London (Brent, Ealing, Hammersmith and Fulham, Harrow, Hillingdon, Hounslow, Kensington and Chelsea, Westminster). NULL outside the WNL footprint.',
+    demographics.sub_icb_name AS sub_icb_name COMMENT = 'Sub-ICB display name (NHS North Central London or NHS North West London) of the registered practice. NULL outside the WNL footprint.',
     demographics.neighbourhood_registered AS neighbourhood_registered COMMENT = 'Registration neighbourhood',
 
     -- Geography (residence)

--- a/models/semantic/sem_olids_population.sql
+++ b/models/semantic/sem_olids_population.sql
@@ -101,6 +101,8 @@ DIMENSIONS(
     demographics.pcn_name AS pcn_name COMMENT = 'Primary Care Network name',
     demographics.pcn_name_with_borough AS pcn_name_with_borough COMMENT = 'PCN name with borough prefix',
     demographics.borough_registered AS borough_registered COMMENT = 'Borough where GP practice is located',
+    demographics.sub_icb_code AS sub_icb_code COMMENT = 'Sub-ICB / place-based partnership ODS code of the registered practice: QMJ = NHS North Central London (Camden, Islington, Barnet, Enfield, Haringey); QRV = NHS North West London (Brent, Ealing, Hammersmith and Fulham, Harrow, Hillingdon, Hounslow, Kensington and Chelsea, Westminster). NULL outside the WNL footprint.',
+    demographics.sub_icb_name AS sub_icb_name COMMENT = 'Sub-ICB display name (NHS North Central London or NHS North West London) of the registered practice. NULL outside the WNL footprint.',
     demographics.neighbourhood_registered AS neighbourhood_registered COMMENT = 'NCL neighbourhood based on registration',
 
     -- Geography (Residence)

--- a/models/semantic/sem_olids_prescribing.sql
+++ b/models/semantic/sem_olids_prescribing.sql
@@ -196,8 +196,8 @@ DIMENSIONS(
     practice.pcn_name AS pcn_name COMMENT = 'PCN name of the prescribing practice',
     practice.pcn_name_with_borough AS pcn_name_with_borough COMMENT = 'PCN with borough prefix',
     practice.borough_registered AS borough_registered COMMENT = 'Borough of the prescribing practice',
-    practice.sub_icb_code AS sub_icb_code COMMENT = 'Sub-ICB / place-based partnership ODS code of the prescribing practice — QMJ for NCL boroughs, QRV for NWL. NULL outside WNL.',
-    practice.sub_icb_name AS sub_icb_name COMMENT = 'Sub-ICB display name (NHS North Central London / NHS North West London) of the prescribing practice. NULL outside WNL.',
+    practice.sub_icb_code AS sub_icb_code COMMENT = 'Sub-ICB / place-based partnership ODS code of the prescribing practice: QMJ = NHS North Central London (Camden, Islington, Barnet, Enfield, Haringey); QRV = NHS North West London (Brent, Ealing, Hammersmith and Fulham, Harrow, Hillingdon, Hounslow, Kensington and Chelsea, Westminster). NULL outside the WNL footprint.',
+    practice.sub_icb_name AS sub_icb_name COMMENT = 'Sub-ICB display name (NHS North Central London or NHS North West London) of the prescribing practice. NULL outside the WNL footprint.',
 
     -- Patient demographics (current snapshot)
     demographics.gender AS gender COMMENT = 'Patient gender (Male, Female, Unknown)',

--- a/models/semantic/sem_olids_prescribing.sql
+++ b/models/semantic/sem_olids_prescribing.sql
@@ -196,6 +196,8 @@ DIMENSIONS(
     practice.pcn_name AS pcn_name COMMENT = 'PCN name of the prescribing practice',
     practice.pcn_name_with_borough AS pcn_name_with_borough COMMENT = 'PCN with borough prefix',
     practice.borough_registered AS borough_registered COMMENT = 'Borough of the prescribing practice',
+    practice.sub_icb_code AS sub_icb_code COMMENT = 'Sub-ICB / place-based partnership ODS code of the prescribing practice — QMJ for NCL boroughs, QRV for NWL. NULL outside WNL.',
+    practice.sub_icb_name AS sub_icb_name COMMENT = 'Sub-ICB display name (NHS North Central London / NHS North West London) of the prescribing practice. NULL outside WNL.',
 
     -- Patient demographics (current snapshot)
     demographics.gender AS gender COMMENT = 'Patient gender (Male, Female, Unknown)',

--- a/models/semantic/sem_olids_trends.sql
+++ b/models/semantic/sem_olids_trends.sql
@@ -71,6 +71,8 @@ DIMENSIONS(
     trends.pcn_name AS pcn_name COMMENT = 'PCN name',
     trends.pcn_name_with_borough AS pcn_name_with_borough COMMENT = 'PCN with borough prefix',
     trends.borough_registered AS borough_registered COMMENT = 'Borough of registration',
+    trends.sub_icb_code AS sub_icb_code COMMENT = 'Sub-ICB / place-based partnership ODS code of the registered practice: QMJ = NHS North Central London (Camden, Islington, Barnet, Enfield, Haringey); QRV = NHS North West London (Brent, Ealing, Hammersmith and Fulham, Harrow, Hillingdon, Hounslow, Kensington and Chelsea, Westminster). NULL outside the WNL footprint.',
+    trends.sub_icb_name AS sub_icb_name COMMENT = 'Sub-ICB display name (NHS North Central London or NHS North West London) of the registered practice. NULL outside the WNL footprint.',
     trends.neighbourhood_registered AS neighbourhood_registered COMMENT = 'NCL neighbourhood',
 
     -- Geography


### PR DESCRIPTION
## Summary

When NCL + NWL merged into West and North London ICB (April 2026), ODS introduced a new STP code **Z9B2Z** for the merged entity. The legacy codes (QMJ for NCL, QRV for NWL) now contain near-zero practices in the ODS source.

The STP filter in `dim_practice`, `dim_pcn`, and `int_organisation_borough_mapping` only included the legacy codes — so **~557 practices were being silently dropped**, including every NCL practice. Downstream effect: every NCL appointment/prescription in the semantic views joined to NULL `practice_name` / `pcn_name` / `borough_registered`, causing `GROUP BY practice_name` to collapse into a single NULL row in the semantic-layer POC.

## Changes

**Fixed filters** (the actual bug):
- `dim_practice.sql` + `.yml` — added `Z9B2Z`, retained legacy QMJ/QRV as historical safety net across all 5 London ICBs
- `int_organisation_borough_mapping.sql` + `.yml` — added `Z9B2Z` to ICB filter
- `dim_pcn.sql` + `.yml` — switched to `Z9B2Z` only (the 4 practices under legacy QMJ/QRV have zero OLIDS appointments, so keeping them added dim rows that match nothing)

**New columns** (`sub_icb_code`, `sub_icb_name`) on `dim_practice` + `dim_pcn`:
- `sub_icb_code` = `QMJ` (NCL) / `QRV` (NWL), derived from borough
- `sub_icb_name` = `NHS North Central London` / `NHS North West London`
- NCL and NWL still operate as place-based partnerships within WNL, so split reporting against the pre-merger structure remains useful. NULL outside WNL boroughs.

## Verification

Ran against prod Snowflake before the fix:
- `SELECT practice_name FROM SEM_OLIDS_APPOINTMENTS GROUP BY practice_name` returned **1 row** with `NULL`
- `DIM_PRACTICE` had **686 rows** (missing all NCL/NWL)

After the fix simulated end-to-end:
- F83010 → `Islington Central Medical Centre`, `Islington`, `QMJ`, `NHS North Central London`
- F85002 → `Medicus Health Partners`, `Enfield`, `QMJ`, `NHS North Central London`
- E83017 → `Longrove Surgery`, `Barnet`, `QMJ`, `NHS North Central London`
- Expected `DIM_PRACTICE` row count after rebuild: ~1,243 (686 + ~557 WNL)

## Out of scope (flagged for separate ticket)

`self_icb_code = 'QMJ'` Jinja variable in commissioning-demographics models (`dim_snapshot_person_pds_demographics`, `dim_person_demographics_basic`, `int_person_pmi_combined`, `int_person_pds_demographics`). These depend on NCL-scoped seeds (`stg_reference_lookup_ncl_lsoa_*`, `int_person_pds_ncl_population_flags`, `stg_reference_lookup_ncl_gp_practice`). Changing the ICB code there without migrating the seeds would silently drop data from the other half of the ICB — needs a deliberate follow-up.

Also the `emis_list_size` seed is still structured as NCL-only and needs a refresh once the WNL footprint is agreed.

## Test plan

- [ ] `dbt build --select +dim_practice +dim_pcn +int_organisation_borough_mapping`
- [ ] Confirm `DIM_PRACTICE` row count jumps from ~686 to ~1,243
- [ ] Confirm sample NCL practice codes (F83010, F85002, E83017) now have non-NULL `practice_name`, `borough_registered`, `sub_icb_code`
- [ ] Re-run a failing board chart in the semantic-layer POC — the scatter plot that showed one NULL point should now render per-practice correctly
- [ ] `dbt test --select dim_practice dim_pcn` — accepted_values tests updated to include Z9B2Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sub‑ICB code and name fields for practices and Primary Care Networks to surface place‑based partnership identifiers.

* **Updates**
  * Expanded London ICB coverage to include the new West and North London ICB alongside legacy codes.
  * Updated dataset descriptions and tests; sub‑ICB is now validated as present for records within the West and North London borough set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->