### PR TITLE
fix(meta): skip inherited column indicators to prevent duplicate rows

### DIFF
--- a/macros/governance/extract_indicator_metadata.sql
+++ b/macros/governance/extract_indicator_metadata.sql
@@ -154,10 +154,24 @@
           
         {% endfor %}
         
+        {# Collect model-level indicator ids so inherited column meta can be skipped.
+           dbt-fusion propagates model config.meta to every column, so without this
+           each column re-emits the model indicator N times (Snowflake MERGE in
+           archive_definitions then fails with a duplicate-row error). #}
+        {% set model_indicator_ids = [] %}
+        {% if model_meta and model_meta.get('id') %}
+          {% do model_indicator_ids.append(model_meta.id) %}
+        {% endif %}
+        {% for ind_meta in model_indicators %}
+          {% if ind_meta.get('id') %}
+            {% do model_indicator_ids.append(ind_meta.id) %}
+          {% endif %}
+        {% endfor %}
+
         {# Process column-level indicators (for future BRFs) #}
         {% for column in node.columns.values() %}
           {% set col_meta = column.get('meta', {}).get('indicator', {}) %}
-          {% if col_meta %}
+          {% if col_meta and col_meta.get('id') not in model_indicator_ids %}
             
             {# Generate sort order #}
             {% set sort_order = '' %}


### PR DESCRIPTION
## Summary
- `extract_indicator_metadata` was emitting each model-level indicator once per column because dbt-fusion propagates `config.meta` to every column's `meta`.
- The `archive_definitions` Snowflake MERGE then failed with a duplicate-row error.
- Fix: collect model-level indicator ids up front, and skip any column-level indicator whose id matches. Genuine column-level indicators (different id) still emit.

## Test plan
- [x] Ran `extract_indicator_metadata` locally against affected models — single row per model indicator, no duplicates.
- [x] `archive_definitions` MERGE succeeds end-to-end.
- [ ] CI green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed duplicate indicator metadata appearing across columns when indicators are defined at the model level. Column-level metadata that duplicates model-level indicator definitions is now correctly excluded, eliminating redundant entries. This improvement delivers cleaner output structures and enhanced efficiency across the indicator metadata system and related processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->