### PR TITLE
refactor(dims): standardise stp_* to icb_* naming in dim_practice/dim_pcn

### DIFF
--- a/models/reporting/olids/organisation/dim_pcn.sql
+++ b/models/reporting/olids/organisation/dim_pcn.sql
@@ -67,10 +67,10 @@ SELECT DISTINCT
     dict.commissioner_name,
     dict.sk_organisation_id_commissioner AS sk_commissioner_id,
     
-    -- STP relationship
-    dict.stp_code,
-    dict.stp_name,
-    dict.sk_organisation_id_stp AS sk_stp_id,
+    -- ICB relationship (top-level; Dictionary still labels the column "STP" upstream)
+    dict.stp_code AS icb_code,
+    dict.stp_name AS icb_name,
+    dict.sk_organisation_id_stp AS sk_icb_id,
     
     -- Dictionary surrogate keys
     dict.sk_organisation_id_network AS sk_pcn_dict_id

--- a/models/reporting/olids/organisation/dim_pcn.yml
+++ b/models/reporting/olids/organisation/dim_pcn.yml
@@ -4,13 +4,13 @@ models:
 
       Key Features:
 
-      • One row per PCN filtered to West and North London ICB (STPCode Z9B2Z)
+      • One row per PCN filtered to West and North London ICB (Z9B2Z)
 
       • Borough-prefixed PCN names for geographic clarity
 
       • Member practice arrays with counts for network analysis
 
-      • Complete organisational hierarchy linking to commissioners and STP
+      • Complete organisational hierarchy linking to commissioners and ICB
 
       • Address and operational details from Dictionary sources
 
@@ -89,21 +89,21 @@ models:
       - name: sk_commissioner_id
         description: 'Surrogate key for commissioner organisation'
 
-      - name: stp_code
-        description: 'STP/ICB code — Z9B2Z (West and North London ICB, merged NCL + NWL from Apr 2026)'
+      - name: icb_code
+        description: 'ICB code — Z9B2Z (West and North London ICB, merged NCL + NWL from Apr 2026). Sourced from Dictionary STPCode.'
         tests:
           - not_null
           - accepted_values:
               arguments:
                 values: ['Z9B2Z']
 
-      - name: stp_name
-        description: 'STP name (NHS West and North London Integrated Care Board)'
+      - name: icb_name
+        description: 'ICB display name (NHS West and North London Integrated Care Board)'
         tests:
           - not_null
 
-      - name: sk_stp_id
-        description: 'Surrogate key for STP organisation'
+      - name: sk_icb_id
+        description: 'Surrogate key for ICB organisation'
 
       - name: sub_icb_code
         description: 'Legacy ICB ODS code (QMJ NCL, QRV NWL) derived from the PCN''s commissioner via ODS hierarchy. All PCNs in dim_pcn are Z9B2Z so this always resolves to QMJ or QRV.'

--- a/models/reporting/olids/organisation/dim_practice.sql
+++ b/models/reporting/olids/organisation/dim_practice.sql
@@ -70,10 +70,10 @@ WITH practice_org_joined AS (
     dict.commissioner_name AS commissioner_name,
     dict.sk_organisation_id_commissioner AS sk_commissioner_id,
     
-    -- STP relationship
-    dict.stp_code AS stp_code,
-    dict.stp_name AS stp_name,
-    dict.sk_organisation_id_stp AS sk_stp_id,
+    -- ICB relationship (top-level; Dictionary still labels the column "STP" upstream)
+    dict.stp_code AS icb_code,
+    dict.stp_name AS icb_name,
+    dict.sk_organisation_id_stp AS sk_icb_id,
     
     -- Dictionary surrogate keys
     dict.sk_organisation_id_practice AS sk_practice_id,

--- a/models/reporting/olids/organisation/dim_practice.yml
+++ b/models/reporting/olids/organisation/dim_practice.yml
@@ -12,7 +12,7 @@ models:
 
       • Geographic coordinates and LSOA/MSOA mapping for spatial analysis
 
-      • Complete organisational hierarchy (Practice > PCN > Commissioner > STP)
+      • Complete organisational hierarchy (Practice > PCN > Commissioner > ICB)
 
       • Filtered to London ICBs: West and North London (merged NCL + NWL), North East, South East, South West
 
@@ -131,8 +131,8 @@ models:
       - name: sk_commissioner_id
         description: 'Surrogate key for commissioner organisation'
 
-      - name: stp_code
-        description: 'STP/ICB code (London ICBs: Z9B2Z WNL, QMF NEL, QWE SWL, QKK SEL; legacy QMJ/QRV retained for historical continuity)'
+      - name: icb_code
+        description: 'ICB code (London ICBs: Z9B2Z WNL, QMF NEL, QWE SWL, QKK SEL; legacy QMJ/QRV retained for historical continuity). Sourced from Dictionary STPCode.'
         tests:
           - not_null
           - accepted_values:
@@ -152,13 +152,13 @@ models:
         tests:
           - not_null
 
-      - name: stp_name
-        description: 'STP/ICB name (London Integrated Care Boards)'
+      - name: icb_name
+        description: 'ICB display name (London Integrated Care Boards)'
         tests:
           - not_null
 
-      - name: sk_stp_id
-        description: 'Surrogate key for STP organisation'
+      - name: sk_icb_id
+        description: 'Surrogate key for ICB organisation'
 
       - name: sk_practice_id
         description: 'Dictionary surrogate key for practice'

--- a/models/reporting/olids/person_demographics/dim_person_demographics_historical.sql
+++ b/models/reporting/olids/person_demographics/dim_person_demographics_historical.sql
@@ -341,8 +341,8 @@ SELECT
     dp.pcn_name_with_borough,
 
     -- ICB Information
-    dp.stp_code AS icb_code,
-    dp.stp_name AS icb_name,
+    dp.icb_code,
+    dp.icb_name,
 
     -- Geographic Information (practice-based)
     dp.borough_registered,
@@ -417,8 +417,8 @@ LEFT JOIN (
         practice_msoa,
         practice_latitude,
         practice_longitude,
-        stp_code,
-        stp_name
+        icb_code,
+        icb_name
     FROM {{ ref('dim_practice') }}
     QUALIFY ROW_NUMBER() OVER (PARTITION BY practice_code ORDER BY practice_type_desc NULLS LAST) = 1
 ) dp ON pwa.practice_code = dp.practice_code


### PR DESCRIPTION
## Summary
- Renames `stp_code` / `stp_name` / `sk_stp_id` → `icb_code` / `icb_name` / `sk_icb_id` in `dim_practice` and `dim_pcn`, so all reporting dims use a single `icb_*` convention
- Simplifies `dim_person_demographics_historical` to reference `dp.icb_code` / `dp.icb_name` directly instead of aliasing `dp.stp_code AS icb_code` on the way through
- Keeps staging/raw column names (`stp_code`, `stp_name`) unchanged — they reflect the Dictionary source column `STPCode` and shouldn't be renamed away from source

## Scope
- `dim_practice.sql` + `.yml`
- `dim_pcn.sql` + `.yml`
- `dim_person_demographics_historical.sql`

No changes to: intermediate models, staging, commissioning dims (they join Dictionary directly, not `dim_practice`/`dim_pcn`), or semantic models (those only read `sub_icb_code`/`sub_icb_name`, which are unchanged).

## Breaking change
Any downstream consumer reading `stp_code` / `stp_name` / `sk_stp_id` from `dim_practice` or `dim_pcn` must switch to `icb_code` / `icb_name` / `sk_icb_id`. Worth checking any external BI dashboards or notebooks before merging.

## Test plan
- [ ] `dbt compile` clean on the affected models and everything downstream
- [ ] `dbt build --select dim_practice dim_pcn dim_person_demographics_historical dim_person_demographics+` passes
- [ ] Spot-check row counts and ICB code distribution vs. main
- [ ] Confirm no external dashboard/notebook references `stp_code`/`stp_name` against these dims

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Organisational hierarchy reporting now uses ICB terminology instead of STP, with updated column labels for codes, names, and organisation identifiers across reporting data models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->