### PR TITLE
fix(dim-person-homeless): include HOMELESS_COD when picking latest residential code

### DIFF
--- a/models/reporting/olids/person_status/dim_person_homeless.sql
+++ b/models/reporting/olids/person_status/dim_person_homeless.sql
@@ -30,7 +30,7 @@ WHERE cluster_id in ('RESIDE_COD', 'HOMELESS_COD')
        INNER JOIN homeless_codes cc ON obs.mapped_concept_code = cc.code
        WHERE obs.clinical_effective_date IS NOT NULL
         AND obs.clinical_effective_date <= CURRENT_DATE
-        AND cc.cluster_id = 'RESIDE_COD' 
+        AND cc.cluster_id IN ('RESIDE_COD', 'HOMELESS_COD')
        QUALIFY ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY clinical_effective_date DESC ) = 1
 )
 -- Identify people currently homeless by checking if the latest code is in HOMELESS_COD cluster


### PR DESCRIPTION
## Summary
- `dim_person_homeless` picked each patient's most recent housing code from observations filtered to `cluster_id = 'RESIDE_COD'` only, then checked downstream whether that code was in `HOMELESS_COD`. This implicitly assumed `HOMELESS_COD ⊂ RESIDE_COD`.
- 9 codes in `HOMELESS_COD` are not in `RESIDE_COD` (e.g. `1095491000000105`, `1303097003`, `702526004`, `390818002`, `1077211000000104`, `1091381000000101`, `160703004`, `1091461000000102`, `1104581000000103`), so patients whose latest housing-related code was one of these were silently excluded from the clinical-signal flag.
- Widen the latest-code CTE to consider both clusters (`IN ('RESIDE_COD', 'HOMELESS_COD')`) so the most recent code per person is picked from the union; the existing `HOMELESS_COD` check then correctly flags anyone whose latest housing code is homeless.

## Test plan
- [ ] `dbt build --select dim_person_homeless` succeeds.
- [ ] Row count for `dim_person_homeless` should be ≥ previous run; verify any newly-included patients have a `concept_code` in the 9 HOMELESS_COD-only codes listed above.
- [ ] Spot-check a handful of newly-flagged patients to confirm their latest residential observation is genuinely a homelessness code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of homelessness status determination in reporting by expanding the criteria to include additional relevant observations that were previously excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->