### PR TITLE
Feat/qadmissions alcohol ethnicity

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -239,7 +239,7 @@ seeds:
 
     qadmissions_eth2016_to_ethrisk9:
       +column_types:
-        ethnicity: varchar(60)
+        ethnicity_subcategory: varchar(60)
         ethrisk: integer
         qadmissions_label: varchar(30)
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -237,6 +237,12 @@ seeds:
         townsend_score: float
         townsend_quintile: integer
 
+    qadmissions_eth2016_to_ethrisk9:
+      +column_types:
+        ethnicity: varchar(60)
+        ethrisk: integer
+        qadmissions_label: varchar(30)
+
 snapshots:
   wnl_analytics:
     +database: "MODELLING"

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_alcohol_category.sql
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_alcohol_category.sql
@@ -1,0 +1,75 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+Alcohol category (0..5) per person for the QAdmissions feature
+`alcohol_cat6`. The QAdmissions model expects the 6-level category from
+the ALCOHOL_MAP in the registered Python implementation:
+
+  0 = NonDrinker
+  1 = Trivial      (less than 1 unit / day)
+  2 = Light        (1-2 units / day)
+  3 = Moderate     (3-6 units / day)
+  4 = Heavy        (7-9 units / day)
+  5 = VeryHeavy    (more than 9 units / day)
+
+Source
+  int_alcohol_audit_scores filtered to audit_type = 'Full AUDIT'.
+  AUDIT-C scores are deliberately excluded - the AUDIT-C 0..12 bands do
+  not align cleanly with the QAdmissions cat6 thresholds, whereas the
+  Full AUDIT 0..40 bands map naturally to six categories.
+
+Score-to-category mapping (Full AUDIT 0..40 -> cat6):
+  0       -> 0  (NonDrinker)
+  1..3    -> 1  (Trivial)
+  4..7    -> 2  (Light)
+  8..15   -> 3  (Moderate)
+  16..19  -> 4  (Heavy)
+  20+     -> 5  (VeryHeavy)
+
+Per-person aggregation
+  Take the HIGHEST cat6 ever recorded for the person (precautionary -
+  prior heavy drinking is treated as informative even if the latest
+  AUDIT score is lower). Tie-break by latest clinical_effective_date
+  for stability when multiple observations share the same cat6.
+
+Persons with no Full AUDIT record do not appear here; the consuming
+int_qadmissions_features model passes NULL through to the registered
+QAdmissions model rather than substituting 0 (NonDrinker).
+
+Grain: one row per person who has at least one valid Full AUDIT score.
+*/
+
+WITH full_audit AS (
+    SELECT
+        person_id,
+        clinical_effective_date,
+        audit_score,
+        CASE
+            WHEN audit_score = 0                    THEN 0
+            WHEN audit_score BETWEEN  1 AND  3      THEN 1
+            WHEN audit_score BETWEEN  4 AND  7      THEN 2
+            WHEN audit_score BETWEEN  8 AND 15      THEN 3
+            WHEN audit_score BETWEEN 16 AND 19      THEN 4
+            WHEN audit_score >= 20                  THEN 5
+            ELSE NULL
+        END AS alcohol_cat6
+    FROM {{ ref('int_alcohol_audit_scores') }}
+    WHERE audit_type    = 'Full AUDIT'
+      AND is_valid_score = TRUE
+)
+
+SELECT
+    person_id,
+    alcohol_cat6,
+    audit_score,
+    clinical_effective_date
+FROM full_audit
+WHERE alcohol_cat6 IS NOT NULL
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY person_id
+    ORDER BY alcohol_cat6 DESC, clinical_effective_date DESC
+) = 1

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_alcohol_category.sql
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_alcohol_category.sql
@@ -46,6 +46,7 @@ Grain: one row per person who has at least one valid Full AUDIT score.
 WITH full_audit AS (
     SELECT
         person_id,
+        id AS observation_id,
         clinical_effective_date,
         audit_score,
         CASE
@@ -69,7 +70,14 @@ SELECT
     clinical_effective_date
 FROM full_audit
 WHERE alcohol_cat6 IS NOT NULL
+-- Tertiary keys (audit_score, observation_id) make the row pick
+-- deterministic when several Full AUDIT records share the same cat6
+-- and date.
 QUALIFY ROW_NUMBER() OVER (
     PARTITION BY person_id
-    ORDER BY alcohol_cat6 DESC, clinical_effective_date DESC
+    ORDER BY
+        alcohol_cat6 DESC,
+        clinical_effective_date DESC,
+        audit_score DESC,
+        observation_id ASC
 ) = 1

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_alcohol_category.yml
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_alcohol_category.yml
@@ -1,0 +1,48 @@
+version: 2
+
+models:
+  - name: int_qadmissions_alcohol_category
+    description: >
+      Alcohol category (0..5) per person for the QAdmissions feature
+      `alcohol_cat6`. Sourced from int_alcohol_audit_scores filtered to
+      `audit_type = 'Full AUDIT'`; the Full AUDIT 0..40 score bands map
+      naturally to the six QAdmissions cat6 levels (0 = non-drinker
+      through 5 = very-heavy >9 units / day). AUDIT-C scores are
+      excluded - their 0..12 bands do not align cleanly with cat6.
+
+      Where a person has multiple Full AUDIT scores recorded, the
+      highest derived cat6 is retained (precautionary - prior heavy
+      drinking is treated as informative even if the latest AUDIT score
+      is lower). Ties on cat6 are broken by latest
+      clinical_effective_date for stability.
+
+      Persons with no Full AUDIT record do not appear here; the
+      consuming int_qadmissions_features model passes NULL through to
+      the registered QAdmissions model.
+
+      Grain: one row per person with at least one valid Full AUDIT score.
+    config:
+      meta:
+        owner:
+          name: Thomas Shallcross
+    columns:
+      - name: person_id
+        description: 'OLIDS-native unique person identifier. Primary key of this model.'
+        data_tests:
+          - unique
+          - not_null
+      - name: alcohol_cat6
+        description: 'QAdmissions alcohol category 0..5 (0 = NonDrinker, 1 = Trivial, 2 = Light, 3 = Moderate, 4 = Heavy, 5 = VeryHeavy). Derived from the highest Full AUDIT score the person has ever recorded.'
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [0, 1, 2, 3, 4, 5]
+      - name: audit_score
+        description: 'The Full AUDIT score (0..40) that produced the retained cat6.'
+        data_tests:
+          - not_null
+      - name: clinical_effective_date
+        description: 'Clinical effective date of the retained Full AUDIT observation.'
+        data_tests:
+          - not_null

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_ethrisk.sql
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_ethrisk.sql
@@ -15,40 +15,38 @@ Ethnicity risk group (1..9) per person, for the QAdmissions feature
   5 = Other Asian
 
 Pipeline
-  dim_person_ethnicity_combi unions GP-coded ethnicity (via SNOMED) and
-  event-level ethnicity (via BK ethnicity code) and produces one row per
-  person with their latest non-blank `ethnicity` subcategory (e.g.
-  "White: British", "Asian: Indian"). The model already filters out
-  Recorded Not Known / Not Recorded / Not Stated / Refused at source.
+  dim_person_ethnicity holds one row per person with their latest
+  ethnicity_subcategory (e.g. "White: British", "Asian: Indian", or
+  "Not Recorded" for persons with no usable record - the upstream
+  COALESCEs missing records). Joining that subcategory to the
+  qadmissions_eth2016_to_ethrisk9 seed produces ethrisk for every
+  person. The seed includes explicit rows for "Not Recorded" /
+  "Not Stated" / "Refused" / "Recorded Not Known" - all mapping to 1
+  per the QAdmissions paper convention that NotRecorded shares
+  group 1 with White.
 
-  We join that subcategory text to the qadmissions_eth2016_to_ethrisk9
-  seed to derive ethrisk. Any subcategory NOT in the seed defaults to 1
-  (White / NotRecorded) - a defensive fallback; in practice every
-  subcategory in dim_person_ethnicity_combi.ethnicity should be in the
-  seed.
+  Any subcategory NOT in the seed defaults to 1 (defensive fallback;
+  the qadmissions_ethnicity_mapping_complete singular test fails when
+  this fires so data drift is surfaced rather than silently absorbed).
 
-  Persons with no ethnicity record at all do not appear in
-  dim_person_ethnicity_combi and so do not appear here; the consuming
-  int_qadmissions_features model COALESCEs to 1 for those persons.
-
-Grain: one row per person who has any usable ethnicity record.
+Grain: one row per person in dim_person_ethnicity (i.e. one per person
+in dim_person).
 */
 
 WITH ethnicity AS (
     SELECT
         person_id,
-        ethnicity,
-        code_date AS latest_ethnicity_date
-    FROM {{ ref('dim_person_ethnicity_combi') }}
-    WHERE person_id IS NOT NULL
+        ethnicity_subcategory,
+        latest_ethnicity_date
+    FROM {{ ref('dim_person_ethnicity') }}
 )
 
 SELECT
     e.person_id,
-    e.ethnicity,
+    e.ethnicity_subcategory,
     e.latest_ethnicity_date,
     COALESCE(m.ethrisk, 1) AS ethrisk,
     COALESCE(m.qadmissions_label, 'White') AS qadmissions_label
 FROM ethnicity e
 LEFT JOIN {{ ref('qadmissions_eth2016_to_ethrisk9') }} m
-    ON e.ethnicity = m.ethnicity
+    ON e.ethnicity_subcategory = m.ethnicity_subcategory

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_ethrisk.sql
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_ethrisk.sql
@@ -1,0 +1,54 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+Ethnicity risk group (1..9) per person, for the QAdmissions feature
+`ethrisk`. Numbering follows the registered QAdmissions model:
+
+  1 = White / NotRecorded (default)   6 = Black Caribbean
+  2 = Indian                          7 = Black African
+  3 = Pakistani                       8 = Chinese
+  4 = Bangladeshi                     9 = Other Ethnic Group
+  5 = Other Asian
+
+Pipeline
+  dim_person_ethnicity_combi unions GP-coded ethnicity (via SNOMED) and
+  event-level ethnicity (via BK ethnicity code) and produces one row per
+  person with their latest non-blank `ethnicity` subcategory (e.g.
+  "White: British", "Asian: Indian"). The model already filters out
+  Recorded Not Known / Not Recorded / Not Stated / Refused at source.
+
+  We join that subcategory text to the qadmissions_eth2016_to_ethrisk9
+  seed to derive ethrisk. Any subcategory NOT in the seed defaults to 1
+  (White / NotRecorded) - a defensive fallback; in practice every
+  subcategory in dim_person_ethnicity_combi.ethnicity should be in the
+  seed.
+
+  Persons with no ethnicity record at all do not appear in
+  dim_person_ethnicity_combi and so do not appear here; the consuming
+  int_qadmissions_features model COALESCEs to 1 for those persons.
+
+Grain: one row per person who has any usable ethnicity record.
+*/
+
+WITH ethnicity AS (
+    SELECT
+        person_id,
+        ethnicity,
+        code_date AS latest_ethnicity_date
+    FROM {{ ref('dim_person_ethnicity_combi') }}
+    WHERE person_id IS NOT NULL
+)
+
+SELECT
+    e.person_id,
+    e.ethnicity,
+    e.latest_ethnicity_date,
+    COALESCE(m.ethrisk, 1) AS ethrisk,
+    COALESCE(m.qadmissions_label, 'White') AS qadmissions_label
+FROM ethnicity e
+LEFT JOIN {{ ref('qadmissions_eth2016_to_ethrisk9') }} m
+    ON e.ethnicity = m.ethnicity

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_ethrisk.yml
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_ethrisk.yml
@@ -4,17 +4,15 @@ models:
   - name: int_qadmissions_ethrisk
     description: >
       Ethnicity risk group (1..9) per person for the QAdmissions feature
-      `ethrisk`. Joins dim_person_ethnicity_combi (one row per person
-      with their latest non-blank ethnicity subcategory, drawn from
-      both GP coded and event-level sources) to the
-      qadmissions_eth2016_to_ethrisk9 seed and defaults unmatched
-      subcategories to 1 (White / NotRecorded) per QResearch convention.
+      `ethrisk`. Joins dim_person_ethnicity (one row per person with
+      their latest ethnicity_subcategory, COALESCED to "Not Recorded"
+      when no record exists) to the qadmissions_eth2016_to_ethrisk9
+      seed. Defaults unmatched subcategories to 1 (White / NotRecorded)
+      per QResearch convention; the qadmissions_ethnicity_mapping_complete
+      singular test fails when an unmatched subcategory appears so data
+      drift is surfaced.
 
-      Grain: one row per person who has any usable ethnicity record.
-      Persons with no record - or those whose ethnicity is Recorded Not
-      Known / Not Recorded / Not Stated / Refused (filtered out by
-      dim_person_ethnicity_combi at source) - do not appear here; the
-      consuming int_qadmissions_features model COALESCEs to 1 for them.
+      Grain: one row per person in dim_person_ethnicity.
     config:
       meta:
         owner:
@@ -25,14 +23,12 @@ models:
         data_tests:
           - unique
           - not_null
-      - name: ethnicity
-        description: 'Subcategory text from dim_person_ethnicity_combi (e.g. "White: British", "Asian: Indian").'
+      - name: ethnicity_subcategory
+        description: 'Subcategory text from dim_person_ethnicity (e.g. "White: British", "Asian: Indian", "Not Recorded").'
         data_tests:
           - not_null
       - name: latest_ethnicity_date
-        description: 'Clinical effective date of the latest ethnicity record.'
-        data_tests:
-          - not_null
+        description: 'Clinical effective date of the latest ethnicity record. NULL for persons with no usable record.'
       - name: ethrisk
         description: 'QAdmissions ethrisk integer (1..9). Defaults to 1 for any subcategory not present in the seed.'
         data_tests:

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_ethrisk.yml
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_ethrisk.yml
@@ -31,6 +31,8 @@ models:
           - not_null
       - name: latest_ethnicity_date
         description: 'Clinical effective date of the latest ethnicity record.'
+        data_tests:
+          - not_null
       - name: ethrisk
         description: 'QAdmissions ethrisk integer (1..9). Defaults to 1 for any subcategory not present in the seed.'
         data_tests:

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_ethrisk.yml
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_ethrisk.yml
@@ -1,0 +1,44 @@
+version: 2
+
+models:
+  - name: int_qadmissions_ethrisk
+    description: >
+      Ethnicity risk group (1..9) per person for the QAdmissions feature
+      `ethrisk`. Joins dim_person_ethnicity_combi (one row per person
+      with their latest non-blank ethnicity subcategory, drawn from
+      both GP coded and event-level sources) to the
+      qadmissions_eth2016_to_ethrisk9 seed and defaults unmatched
+      subcategories to 1 (White / NotRecorded) per QResearch convention.
+
+      Grain: one row per person who has any usable ethnicity record.
+      Persons with no record - or those whose ethnicity is Recorded Not
+      Known / Not Recorded / Not Stated / Refused (filtered out by
+      dim_person_ethnicity_combi at source) - do not appear here; the
+      consuming int_qadmissions_features model COALESCEs to 1 for them.
+    config:
+      meta:
+        owner:
+          name: Thomas Shallcross
+    columns:
+      - name: person_id
+        description: 'OLIDS-native unique person identifier. Primary key of this model.'
+        data_tests:
+          - unique
+          - not_null
+      - name: ethnicity
+        description: 'Subcategory text from dim_person_ethnicity_combi (e.g. "White: British", "Asian: Indian").'
+        data_tests:
+          - not_null
+      - name: latest_ethnicity_date
+        description: 'Clinical effective date of the latest ethnicity record.'
+      - name: ethrisk
+        description: 'QAdmissions ethrisk integer (1..9). Defaults to 1 for any subcategory not present in the seed.'
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+      - name: qadmissions_label
+        description: 'Human-readable QAdmissions group label corresponding to ethrisk.'
+        data_tests:
+          - not_null

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_features.sql
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_features.sql
@@ -203,6 +203,25 @@ townsend AS (
         person_id,
         townsend_score
     FROM {{ ref('int_qadmissions_townsend') }}
+),
+
+-- Alcohol category 0..5 derived from Full AUDIT scores. NULL passes
+-- through for persons with no Full AUDIT record.
+alcohol AS (
+    SELECT
+        person_id,
+        alcohol_cat6
+    FROM {{ ref('int_qadmissions_alcohol_category') }}
+),
+
+-- Ethrisk 1..9 derived from int_ethnicity_qof joined to the
+-- qadmissions_eth2016_to_ethrisk9 seed. Persons with no ethnicity
+-- record default to 1 (NotRecorded -> 1, same group as White).
+ethrisk_lookup AS (
+    SELECT
+        person_id,
+        ethrisk
+    FROM {{ ref('int_qadmissions_ethrisk') }}
 )
 
 SELECT
@@ -273,11 +292,13 @@ SELECT
     -- model for persons with no LSOA / non-English residence).
     twn.townsend_score                                                     AS town,
 
-    -- Placeholder defaults (sourced features still to land):
-    --   alcohol_cat6 -> mapping from int_alcohol_audit_scores
-    --   ethrisk      -> mapping from int_ethnicity_qof.cluster_id
-    0                                                                      AS alcohol_cat6,
-    1                                                                      AS ethrisk
+    -- Alcohol category 0..5 from Full AUDIT (highest cat6 ever recorded
+    -- per person). NULL for persons with no Full AUDIT record.
+    alc.alcohol_cat6                                                       AS alcohol_cat6,
+
+    -- Ethnicity risk group 1..9. Persons with no ethnicity record
+    -- default to 1 (NotRecorded -> 1 per QResearch).
+    COALESCE(eth.ethrisk, 1)                                               AS ethrisk
 
 FROM base_spine                       base
 CROSS JOIN lab_thresholds             t
@@ -295,3 +316,5 @@ LEFT JOIN malabsorption_flags         mal  ON base.person_id     = mal.person_id
 LEFT JOIN vte_flags                   vte  ON base.person_id     = vte.person_id
 LEFT JOIN liver_pancreatitis_flags    lp   ON base.person_id     = lp.person_id
 LEFT JOIN townsend                    twn  ON base.person_id     = twn.person_id
+LEFT JOIN alcohol                     alc  ON base.person_id     = alc.person_id
+LEFT JOIN ethrisk_lookup              eth  ON base.person_id     = eth.person_id

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_features.yml
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_features.yml
@@ -260,11 +260,12 @@ models:
           2=Indian, 3=Pakistani, 4=Bangladeshi, 5=OtherAsian,
           6=BlackCaribbean, 7=BlackAfrican, 8=Chinese, 9=OtherEthnicGroup).
           Sourced from int_qadmissions_ethrisk, which joins
-          dim_person_ethnicity_combi to the qadmissions_eth2016_to_ethrisk9
-          seed on the `ethnicity` subcategory text and defaults unmatched
-          subcategories to 1. Persons with no usable ethnicity record
-          (absent from dim_person_ethnicity_combi at source) also default
-          to 1.
+          dim_person_ethnicity to the qadmissions_eth2016_to_ethrisk9
+          seed on `ethnicity_subcategory` text. The seed includes
+          explicit "Not Recorded" / "Not Stated" / "Refused" /
+          "Recorded Not Known" rows mapping to 1, so every person -
+          including those without a usable ethnicity record - is
+          matched.
         data_tests:
           - not_null
           - accepted_values:

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_features.yml
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_features.yml
@@ -259,10 +259,12 @@ models:
           QAdmissions ethnicity risk group (1..9: 1=White/NotRecorded,
           2=Indian, 3=Pakistani, 4=Bangladeshi, 5=OtherAsian,
           6=BlackCaribbean, 7=BlackAfrican, 8=Chinese, 9=OtherEthnicGroup).
-          Sourced from int_qadmissions_ethrisk, which joins int_ethnicity_qof
-          to the qadmissions_eth2016_to_ethrisk9 seed and defaults
-          unmatched clusters to 1. Persons with no ethnicity record
-          also default to 1.
+          Sourced from int_qadmissions_ethrisk, which joins
+          dim_person_ethnicity_combi to the qadmissions_eth2016_to_ethrisk9
+          seed on the `ethnicity` subcategory text and defaults unmatched
+          subcategories to 1. Persons with no usable ethnicity record
+          (absent from dim_person_ethnicity_combi at source) also default
+          to 1.
         data_tests:
           - not_null
           - accepted_values:

--- a/models/modelling/olids/programme/qadmissions/int_qadmissions_features.yml
+++ b/models/modelling/olids/programme/qadmissions/int_qadmissions_features.yml
@@ -12,8 +12,8 @@ models:
       input features that the registered model consumes. See the file
       header for the required ClinRisk disclaimer.
 
-      Placeholder columns still defaulted until their source intermediates
-      land: alcohol_cat6, ethrisk.
+      All feature columns are now sourced from real intermediates - no
+      placeholders remain.
     config:
       meta:
         owner:
@@ -239,8 +239,32 @@ models:
 
       - name: alcohol_cat6
         data_type: number
-        description: "TODO Step 2: alcohol category (0-5) from AUDIT scores. Currently defaulted to 0 (non-drinker) until the qadmissions_alcohol_audit_to_cat6 mapping seed lands."
+        description: >
+          QAdmissions alcohol category (0..5: NonDrinker, Trivial, Light,
+          Moderate, Heavy, VeryHeavy). Sourced from int_qadmissions_alcohol_category,
+          which derives cat6 from int_alcohol_audit_scores filtered to
+          Full AUDIT and takes the highest cat6 ever recorded per person.
+          NULL when the person has no Full AUDIT record - NULL is passed
+          through to the registered QAdmissions model.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [0, 1, 2, 3, 4, 5]
+              config:
+                where: "alcohol_cat6 IS NOT NULL"
 
       - name: ethrisk
         data_type: number
-        description: "TODO Step 2: ethnicity risk group (1-9). Currently defaulted to 1 (White / not stated) until the qadmissions_eth2016_to_ethrisk9 mapping seed lands."
+        description: >
+          QAdmissions ethnicity risk group (1..9: 1=White/NotRecorded,
+          2=Indian, 3=Pakistani, 4=Bangladeshi, 5=OtherAsian,
+          6=BlackCaribbean, 7=BlackAfrican, 8=Chinese, 9=OtherEthnicGroup).
+          Sourced from int_qadmissions_ethrisk, which joins int_ethnicity_qof
+          to the qadmissions_eth2016_to_ethrisk9 seed and defaults
+          unmatched clusters to 1. Persons with no ethnicity record
+          also default to 1.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/seeds/qadmissions_eth2016_to_ethrisk9.csv
+++ b/seeds/qadmissions_eth2016_to_ethrisk9.csv
@@ -1,0 +1,20 @@
+ethnicity,ethrisk,qadmissions_label
+White: British,1,White
+White: Irish,1,White
+White: Other White,1,White
+White: Roma,1,White
+White: Traveller,1,White
+Asian: Indian,2,Indian
+Asian: Pakistani,3,Pakistani
+Asian: Bangladeshi,4,Bangladeshi
+Asian: Other Asian,5,OtherAsian
+Mixed: White and Asian,5,OtherAsian
+Black: Caribbean,6,BlackCaribbean
+Black: Other Black,6,BlackCaribbean
+Black: African,7,BlackAfrican
+Asian: Chinese,8,Chinese
+Mixed: White and Black African,9,OtherEthnicGroup
+Mixed: White and Black Caribbean,9,OtherEthnicGroup
+Mixed: Other Mixed,9,OtherEthnicGroup
+Other: Arab,9,OtherEthnicGroup
+Other: Other,9,OtherEthnicGroup

--- a/seeds/qadmissions_eth2016_to_ethrisk9.csv
+++ b/seeds/qadmissions_eth2016_to_ethrisk9.csv
@@ -1,9 +1,14 @@
-ethnicity,ethrisk,qadmissions_label
+ethnicity_subcategory,ethrisk,qadmissions_label
 White: British,1,White
 White: Irish,1,White
 White: Other White,1,White
 White: Roma,1,White
 White: Traveller,1,White
+Not Recorded,1,White
+Not Stated,1,White
+Not stated,1,White
+Recorded Not Known,1,White
+Refused,1,White
 Asian: Indian,2,Indian
 Asian: Pakistani,3,Pakistani
 Asian: Bangladeshi,4,Bangladeshi

--- a/seeds/qadmissions_eth2016_to_ethrisk9.csv
+++ b/seeds/qadmissions_eth2016_to_ethrisk9.csv
@@ -1,14 +1,14 @@
 ethnicity_subcategory,ethrisk,qadmissions_label
-White: British,1,White
-White: Irish,1,White
-White: Other White,1,White
-White: Roma,1,White
-White: Traveller,1,White
-Not Recorded,1,White
-Not Stated,1,White
-Not stated,1,White
-Recorded Not Known,1,White
-Refused,1,White
+White: British,1,WhiteOrNone
+White: Irish,1,WhiteOrNone
+White: Other White,1,WhiteOrNone
+White: Roma,1,WhiteOrNone
+White: Traveller,1,WhiteOrNone
+Not Recorded,1,WhiteOrNone
+Not Stated,1,WhiteOrNone
+Not stated,1,WhiteOrNone
+Recorded Not Known,1,WhiteOrNone
+Refused,1,WhiteOrNone
 Asian: Indian,2,Indian
 Asian: Pakistani,3,Pakistani
 Asian: Bangladeshi,4,Bangladeshi

--- a/seeds/qadmissions_eth2016_to_ethrisk9.yml
+++ b/seeds/qadmissions_eth2016_to_ethrisk9.yml
@@ -3,9 +3,9 @@ version: 2
 seeds:
   - name: qadmissions_eth2016_to_ethrisk9
     description: >
-      Maps the `ethnicity` subcategory text exposed by
-      dim_person_ethnicity_combi to the QAdmissions ethrisk-9 group
-      expected by the registered QAdmissions model.
+      Maps the `ethnicity_subcategory` text exposed by dim_person_ethnicity
+      to the QAdmissions ethrisk-9 group expected by the registered
+      QAdmissions model.
 
       Ethrisk numbering follows the published QAdmissions C reference
       and the Python wrapper's ETHNICITY_MAP:
@@ -20,13 +20,15 @@ seeds:
         8 = Chinese
         9 = Other Ethnic Group
 
-      Persons whose ethnicity is "Recorded Not Known", "Not Recorded",
-      "Not Stated", or "Refused" never appear in dim_person_ethnicity_combi
-      (it filters them out at source); the consuming int_qadmissions_ethrisk
-      model defaults them to 1 via COALESCE.
+      All "no record" subcategories ("Not Recorded", "Not Stated",
+      "Not stated", "Recorded Not Known", "Refused") collapse to 1
+      alongside the explicit White subcategories - matching the
+      QAdmissions paper convention that NotRecorded shares group 1
+      with White. dim_person_ethnicity COALESCEs missing records to
+      "Not Recorded" so every person is matched by this seed.
     columns:
-      - name: ethnicity
-        description: 'Subcategory text from dim_person_ethnicity_combi.ethnicity (e.g. "White: British", "Asian: Indian").'
+      - name: ethnicity_subcategory
+        description: 'Subcategory text from dim_person_ethnicity.ethnicity_subcategory (e.g. "White: British", "Asian: Indian", "Not Recorded").'
         data_tests:
           - unique
           - not_null

--- a/seeds/qadmissions_eth2016_to_ethrisk9.yml
+++ b/seeds/qadmissions_eth2016_to_ethrisk9.yml
@@ -1,0 +1,43 @@
+version: 2
+
+seeds:
+  - name: qadmissions_eth2016_to_ethrisk9
+    description: >
+      Maps the `ethnicity` subcategory text exposed by
+      dim_person_ethnicity_combi to the QAdmissions ethrisk-9 group
+      expected by the registered QAdmissions model.
+
+      Ethrisk numbering follows the published QAdmissions C reference
+      and the Python wrapper's ETHNICITY_MAP:
+
+        1 = White / NotRecorded (default)
+        2 = Indian
+        3 = Pakistani
+        4 = Bangladeshi
+        5 = Other Asian
+        6 = Black Caribbean
+        7 = Black African
+        8 = Chinese
+        9 = Other Ethnic Group
+
+      Persons whose ethnicity is "Recorded Not Known", "Not Recorded",
+      "Not Stated", or "Refused" never appear in dim_person_ethnicity_combi
+      (it filters them out at source); the consuming int_qadmissions_ethrisk
+      model defaults them to 1 via COALESCE.
+    columns:
+      - name: ethnicity
+        description: 'Subcategory text from dim_person_ethnicity_combi.ethnicity (e.g. "White: British", "Asian: Indian").'
+        data_tests:
+          - unique
+          - not_null
+      - name: ethrisk
+        description: 'QAdmissions ethrisk integer (1..9).'
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+      - name: qadmissions_label
+        description: 'Human-readable QAdmissions group label corresponding to ethrisk.'
+        data_tests:
+          - not_null

--- a/tests/qadmissions_ethnicity_mapping_complete.sql
+++ b/tests/qadmissions_ethnicity_mapping_complete.sql
@@ -1,26 +1,25 @@
 -- Asserts the qadmissions_eth2016_to_ethrisk9 seed contains every
--- distinct `ethnicity` subcategory value present in
--- dim_person_ethnicity_combi. If a new ethnicity value appears in the
--- population (e.g. a future ETH2016 cluster, or an event-source
--- subcategory not previously seen) it would silently be COALESCEd to
--- ethrisk = 1 in int_qadmissions_ethrisk - hiding data drift.
+-- distinct `ethnicity_subcategory` value present in dim_person_ethnicity.
+-- If a new subcategory appears in the population (e.g. a future ETH2016
+-- cluster, or a new "no record" variant) it would silently be COALESCEd
+-- to ethrisk = 1 in int_qadmissions_ethrisk - hiding data drift.
 --
 -- The test fails when the SELECT returns rows. It returns one row per
--- ethnicity value that is in the live data but not in the mapping seed.
+-- subcategory value that is in the live data but not in the seed.
 
 with population as (
-    select distinct ethnicity
-    from {{ ref('dim_person_ethnicity_combi') }}
-    where ethnicity is not null
+    select distinct ethnicity_subcategory
+    from {{ ref('dim_person_ethnicity') }}
+    where ethnicity_subcategory is not null
 ),
 
 mapping as (
-    select distinct ethnicity
+    select distinct ethnicity_subcategory
     from {{ ref('qadmissions_eth2016_to_ethrisk9') }}
 )
 
-select p.ethnicity
+select p.ethnicity_subcategory
 from population p
 left join mapping m
-    on p.ethnicity = m.ethnicity
-where m.ethnicity is null
+    on p.ethnicity_subcategory = m.ethnicity_subcategory
+where m.ethnicity_subcategory is null

--- a/tests/qadmissions_ethnicity_mapping_complete.sql
+++ b/tests/qadmissions_ethnicity_mapping_complete.sql
@@ -1,0 +1,26 @@
+-- Asserts the qadmissions_eth2016_to_ethrisk9 seed contains every
+-- distinct `ethnicity` subcategory value present in
+-- dim_person_ethnicity_combi. If a new ethnicity value appears in the
+-- population (e.g. a future ETH2016 cluster, or an event-source
+-- subcategory not previously seen) it would silently be COALESCEd to
+-- ethrisk = 1 in int_qadmissions_ethrisk - hiding data drift.
+--
+-- The test fails when the SELECT returns rows. It returns one row per
+-- ethnicity value that is in the live data but not in the mapping seed.
+
+with population as (
+    select distinct ethnicity
+    from {{ ref('dim_person_ethnicity_combi') }}
+    where ethnicity is not null
+),
+
+mapping as (
+    select distinct ethnicity
+    from {{ ref('qadmissions_eth2016_to_ethrisk9') }}
+)
+
+select p.ethnicity
+from population p
+left join mapping m
+    on p.ethnicity = m.ethnicity
+where m.ethnicity is null


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
  Replaces the last two hard-coded placeholder columns in `int_qadmissions_features`. Every feature in the row is now sourced from a real intermediate — no placeholders remain.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Feature        | Source                               | Mapping                                                                 |
|----------------|--------------------------------------|-------------------------------------------------------------------------|
| alcohol_cat6   | int_qadmissions_alcohol_category     | Full AUDIT score → cat6 (0..5), highest ever recorded per person       |
| ethrisk        | int_qadmissions_ethrisk              | dim_person_ethnicity_combi.ethnicity → ethrisk (1..9) via the new qadmissions_eth2016_to_ethrisk9 seed |

  ## Notable decisions

  - **Ethnicity source**: switched from the originally-planned `int_ethnicity_qof` (cluster-id keyed) to `dim_person_ethnicity_combi`. The latter has wider coverage (unions GP-coded SNOMED ethnicity with event-level BK ethnicity codes) and produces one row per person with a clean `ethnicity` subcategory text (`"White: 
  British"`, `"Asian: Indian"`, etc.). It also filters out `Recorded Not Known` / `Not Recorded` / `Not Stated` / `Refused` at source — those persons fall through to `ethrisk = 1` per QResearch convention via COALESCE in the feature wiring.
  - **Ethrisk numbering** verified against `qadmission_review/python_pipeline/mapping.py:48-59` and the C reference `qadmission_review/c_pipeline/c/Q78_qadmissions_4_1.c:301`. 
  - **Alcohol source**: `int_alcohol_audit_scores` filtered to `audit_type = 'Full AUDIT'`. AUDIT-C is excluded — its 0..12 bands do not align cleanly with the QAdmissions cat6 thresholds, whereas the Full AUDIT 0..40 bands map naturally to six categories (0 / 1-3 / 4-7 / 8-15 / 16-19 / 20+ → 0..5).
  - **Per-person alcohol aggregation**: highest cat6 ever recorded (precautionary — prior heavy drinking is treated as informative even if the latest AUDIT score is lower). Ties on cat6 broken by latest `clinical_effective_date`.
  - **NULL pass-through for `alcohol_cat6`**: persons with no Full AUDIT record get `NULL`. The registered model is responsible for handling missing alcohol input.
  - **`ethrisk` defaults to 1**: persons absent from `dim_person_ethnicity_combi` (no usable ethnicity record at all, or filtered-out values) get `ethrisk = 1`. Same convention as the QAdmissions paper / Python wrapper.

  ## Files

  | Group | Files |
  |---|---|
  | New seed | `seeds/qadmissions_eth2016_to_ethrisk9.csv` (+ yml), `dbt_project.yml` column types |
  | New intermediates | `int_qadmissions_ethrisk` (sql + yml), `int_qadmissions_alcohol_category` (sql + yml) |
  | Wiring | `int_qadmissions_features.sql` + `.yml` updated for both columns |

  ## Test plan

  - [x] `dbt parse` clean (validated locally)
  - [x] `dbt build --select qadmissions_eth2016_to_ethrisk9 int_qadmissions_ethrisk int_qadmissions_alcohol_category int_qadmissions_features` builds and tests pass locally
  - [x] Spot-check `int_qadmissions_features` row count is unchanged (no fan-out from the new LEFT JOINs)
  - [ ] `ethrisk` distribution reflects the NCL population mix 
  - [ ] `alcohol_cat6` distribution: a long tail across 0..5; NULL for persons without a Full AUDIT record (the dominant case)
  - [ ] No `ethrisk` outside `[1..9]`; no `alcohol_cat6` outside `[0..5]` on non-NULL rows

  ## Coverage check (deferred)

  Worth running before merging: how many persons have a Full AUDIT score vs the QAdmissions paper-faithful alcohol-category SNOMED codelists (`ALCOHOL_NON_DRINKER_COD_Q` etc., already in `DEFINITION_STORE` from a prior PR). If SNOMED-category coverage is materially better, a follow-up PR can switch the alcohol source  
  to use those codelists directly — same shape as how `smoke_cat` is handled.

  ## Out of scope / follow-ups

  - Coverage comparison above — could motivate a switch to QAdmissions paper-faithful SNOMED clusters for `alcohol_cat6`.
  - `int_qadmissions_ethrisk` and `int_qadmissions_alcohol_category` live under `programme/qadmissions/`. If wider reuse is wanted (e.g. ethnicity grouping for non-QAdmissions analyses), they could later be promoted to `person_attributes/`. Same open question as `int_qadmissions_townsend`.
  - Re-confirm the `Mixed: Other Mixed → 9` decision with clinical input — judgement call without a clear non-white component to defer to.
  - End-to-end smoke-test of the full feature row against the registered Snowflake model now that every column is sourced.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-person alcohol category derived from Full AUDIT highest-ever scores
  * Added per-person ethnicity risk classification mapped to a 1–9 ethrisk scale
  * QAdmissions features now use these derived values instead of placeholders

* **Documentation**
  * Added ethnicity-to-ethrisk mapping reference data with descriptions and validation rules
  * Updated feature docs to describe sourcing and accepted values for alcohol_cat6 and ethrisk

* **Tests**
  * Added data integrity test ensuring complete coverage of ethnicity mappings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->