### PR TITLE
Fix: centralising Hx Flake logic generation for wider use. Fixes #699

### DIFF
--- a/macros/transformations/HxFlake_pseudo_generation.sql
+++ b/macros/transformations/HxFlake_pseudo_generation.sql
@@ -1,0 +1,55 @@
+{% macro hxflake_pseudo_generation(sk_patient_id) %}
+LEFT(
+    SUBSTR(
+        TRIM(
+            REVERSE(
+                RIGHT(
+                    LPAD(
+                        TO_CHAR({{ sk_patient_id }}, 'XXXXXXXXX'),
+                        9,
+                        0
+                    ),
+                    10
+                )
+            )
+        ) || '0000000000',
+        1,
+        2
+    ) || '-' || RPAD(
+        SUBSTR(
+            TRIM(
+                REVERSE(
+                    RIGHT(
+                        LPAD(
+                            TO_CHAR({{ sk_patient_id }}, 'XXXXXXXXX'),
+                            9,
+                            0
+                        ),
+                        10
+                    )
+                )
+            ) || '0000000000',
+            3,
+            4
+        ),
+        3,
+        '0'
+    ) || '-' || SUBSTR(
+        TRIM(
+            REVERSE(
+                RIGHT(
+                    LPAD(
+                        TO_CHAR({{ sk_patient_id }}, 'XXXXXXXXX'),
+                        9,
+                        0
+                    ),
+                    10
+                )
+            )
+        ) || '0000000000',
+        6,
+        3
+    ) || '0000000000',
+    10
+)
+{% endmacro %}

--- a/macros/transformations/HxFlake_pseudo_generation.yml
+++ b/macros/transformations/HxFlake_pseudo_generation.yml
@@ -1,0 +1,11 @@
+
+macros:
+  - name: hxflake_pseudo_generation
+    description: >
+      Generates an HxFlake pseudonym in XX-XXX-XXX format from a patient surrogate key for re-id API use
+
+
+    arguments:
+      - name: sk_patient_id
+        type: string
+        description: Universal commissioning data patient ID

--- a/models/reporting/olids/person_demographics/dim_person_pseudo.sql
+++ b/models/reporting/olids/person_demographics/dim_person_pseudo.sql
@@ -32,59 +32,7 @@ SELECT
     bd.sk_patient_id,
 
     -- HxFlake Pseudonym Generation (exact formula match)
-    LEFT(
-         SUBSTR(
-             TRIM(
-                 REVERSE(
-                     RIGHT(
-                         LPAD(
-                             TO_CHAR(bd.sk_patient_id, 'XXXXXXXXX'),
-                             9,
-                             0
-                         ),
-                         10
-                     )
-                 )
-             ) || '0000000000',
-             1,
-             2
-         ) || '-' || RPAD(
-             SUBSTR(
-                 TRIM(
-                     REVERSE(
-                         RIGHT(
-                             LPAD(
-                                 TO_CHAR(bd.sk_patient_id, 'XXXXXXXXX'),
-                                 9,
-                                 0
-                             ),
-                             10
-                         )
-                     )
-                 ) || '0000000000',
-                 3,
-                 4
-             ),
-             3,
-             '0'
-         ) || '-' || SUBSTR(
-             TRIM(
-                 REVERSE(
-                     RIGHT(
-                         LPAD(
-                             TO_CHAR(bd.sk_patient_id, 'XXXXXXXXX'),
-                             9,
-                             0
-                         ),
-                         10
-                     )
-                 )
-             ) || '0000000000',
-             6,
-             3
-         ) || '0000000000',
-         10
-     ) AS hx_flake
+    {{ hxflake_pseudo_generation('bd.sk_patient_id') }} AS hx_flake
 
 FROM {{ ref('dim_person_birth_death') }} bd
 WHERE bd.sk_patient_id IS NOT NULL


### PR DESCRIPTION
Centralising HxFlake logic so it can be applied to CDS data without logic duplication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted patient pseudo identifier generation logic into a reusable macro component for improved code maintainability.
  * Updated the person demographics reporting model to utilise the new pseudo identifier generation macro.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->