### PR TITLE
Feat: HX in CLTCS pathway with fix for mismatched typing

### DIFF
--- a/macros/transformations/HxFlake_pseudo_generation.sql
+++ b/macros/transformations/HxFlake_pseudo_generation.sql
@@ -5,7 +5,7 @@ LEFT(
             REVERSE(
                 RIGHT(
                     LPAD(
-                        TO_CHAR({{ sk_patient_id }}, 'XXXXXXXXX'),
+                        TO_CHAR(TO_NUMBER({{ sk_patient_id }}), 'XXXXXXXXX'),
                         9,
                         0
                     ),
@@ -21,7 +21,7 @@ LEFT(
                 REVERSE(
                     RIGHT(
                         LPAD(
-                            TO_CHAR({{ sk_patient_id }}, 'XXXXXXXXX'),
+                            TO_CHAR(TO_NUMBER({{ sk_patient_id }}), 'XXXXXXXXX'),
                             9,
                             0
                         ),
@@ -39,7 +39,7 @@ LEFT(
             REVERSE(
                 RIGHT(
                     LPAD(
-                        TO_CHAR({{ sk_patient_id }}, 'XXXXXXXXX'),
+                        TO_CHAR(TO_NUMBER({{ sk_patient_id }}), 'XXXXXXXXX'),
                         9,
                         0
                     ),

--- a/models/published/direct_care/C_LTCS/cltcs_cohort_data.sql
+++ b/models/published/direct_care/C_LTCS/cltcs_cohort_data.sql
@@ -22,6 +22,7 @@ with inclusion_list as (
     )
 
 select il.patient_id
+      ,{{ hxflake_pseudo_generation('il.patient_id') }} AS re_id_key
  --   , il.fragmented_sk_patient_id_flag -- include as DQ check later, excluded for now
 --  , il.fragmented_person_id_flag
     , il.area_code

--- a/models/published/direct_care/C_LTCS/cltcs_live_inclusion_cohort.sql
+++ b/models/published/direct_care/C_LTCS/cltcs_live_inclusion_cohort.sql
@@ -94,8 +94,7 @@ potentially_fragmented_person_ids as (
     ORDER BY patient_count DESC
 )
 
-select rp.sk_patient_id as patient_id
-    ,pp.hx_flake as re_id_key
+select cast(rp.sk_patient_id as varchar) as patient_id
     ,pp.person_id as olids_id
     ,rp.practice_code
     ,rp.practice_name


### PR DESCRIPTION
- Added HX Flake to C-LTCS as built off PDS not OLDS
- Fixed bug in HX where can't handle varchar sk_patient_id (current default in CDS). conversion to numeric as required for the HEX derivation