### PR TITLE
feat: NDOO_HASHED source and native OLIDS PERSON migration [skip deploy]

### DIFF
--- a/.github/workflows/dbt-deploy.yml
+++ b/.github/workflows/dbt-deploy.yml
@@ -29,6 +29,13 @@ jobs:
   deploy-models:
     name: Deploy Changed Models + Downstream
     runs-on: ubuntu-latest
+    # Skip if the merge commit message contains [skip deploy] or [skip-deploy].
+    # Manual workflow_dispatch always runs.
+    if: |
+      github.event_name == 'workflow_dispatch' || (
+        !contains(github.event.head_commit.message, '[skip deploy]') &&
+        !contains(github.event.head_commit.message, '[skip-deploy]')
+      )
     # Queue deploys sequentially - don't cancel, wait for previous to finish
     concurrency:
       group: dbt-deploy-prod

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -61,7 +61,7 @@ models:
       +post-hook: ["{{ add_model_comment() }}"]
       olids:
         +meta:
-          custom_message: "Includes OLIDS data - don't publish/share outputs without DAC approval"
+          custom_message: "Includes OLIDS data - for secondary use, INNER JOIN to REPORTING.OLIDS_PERSON_STATUS.DIM_PERSON_SECONDARY_USE_ALLOWED ON person_id to apply National Data Opt-Out and Type 1 opt-out filtering."
 
     # Modelling layer - business logic and transformations
     modelling:
@@ -76,7 +76,7 @@ models:
         +schema: "COMMISSIONING_MODELLING"
       olids:
         +meta:
-          custom_message: "Includes OLIDS data - don't publish/share outputs without DAC approval"
+          custom_message: "Includes OLIDS data - for secondary use, INNER JOIN to REPORTING.OLIDS_PERSON_STATUS.DIM_PERSON_SECONDARY_USE_ALLOWED ON person_id to apply National Data Opt-Out and Type 1 opt-out filtering."
 
     # Reporting layer - aggregated and analytical models
     reporting:
@@ -91,7 +91,7 @@ models:
         +schema: "COMMISSIONING_REPORTING"
       olids:
         +meta:
-          custom_message: "Includes OLIDS data - don't publish/share outputs without DAC approval"
+          custom_message: "Includes OLIDS data - for secondary use, INNER JOIN to REPORTING.OLIDS_PERSON_STATUS.DIM_PERSON_SECONDARY_USE_ALLOWED ON person_id to apply National Data Opt-Out and Type 1 opt-out filtering."
         # Schema names automatically derived from subdomain folder names via generate_schema_name macro
         definitions:
           +database: "{{ target.database.replace('MODELLING', 'REPORTING') }}"
@@ -104,7 +104,7 @@ models:
       +schema: "SEMANTIC"
       +tags: ["semantic"]
       +meta:
-        custom_message: "Snowflake Semantic View - Includes OLIDS data - don't publish/share outputs without DAC approval. Query via SEMANTIC_VIEW() function."
+        custom_message: "Snowflake Semantic View - Includes OLIDS data - for secondary use, INNER JOIN to REPORTING.OLIDS_PERSON_STATUS.DIM_PERSON_SECONDARY_USE_ALLOWED ON person_id to apply National Data Opt-Out and Type 1 opt-out filtering. Query via SEMANTIC_VIEW() function."
 
     # Published layer - production-ready datasets for end users
     published:
@@ -118,7 +118,7 @@ models:
         +database: "PUBLISHED_REPORTING__DIRECT_CARE"
         olids:
           +meta:
-            custom_message: "Includes OLIDS data - don't publish/share outputs without DAC approval"
+            custom_message: "Includes OLIDS data - direct care use; opt-out filtering NOT applied. For secondary use, INNER JOIN to REPORTING.OLIDS_PERSON_STATUS.DIM_PERSON_SECONDARY_USE_ALLOWED ON person_id."
           # Schema names automatically derived from subdomain folder names via generate_schema_name macro
         C_LTCS:
           +meta:
@@ -128,7 +128,7 @@ models:
         +database: "PUBLISHED_REPORTING__SECONDARY_USE"
         olids:
           +meta:
-            custom_message: "Includes OLIDS data - don't publish/share outputs without DAC approval"
+            custom_message: "Includes OLIDS data already filtered via REPORTING.OLIDS_PERSON_STATUS.DIM_PERSON_SECONDARY_USE_ALLOWED (National Data Opt-Out and Type 1 opt-outs excluded). Safe to use for secondary purposes."
           # Schema names automatically derived from subdomain folder names via generate_schema_name macro
           +post-hook:
             - "{{ add_model_comment() }}"

--- a/models/modelling/olids/person_attributes/int_person_ndoo_status.sql
+++ b/models/modelling/olids/person_attributes/int_person_ndoo_status.sql
@@ -1,0 +1,39 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'])
+}}
+
+/*
+Latest National Data Opt-Out preference per person.
+Joins NDOO_HASHED -> int_patient_person_unique on sk_patient_id to resolve person_id.
+One row per (person_id, preference_type) with is_opted_in derived from the latest record.
+*/
+
+WITH ndoo_resolved AS (
+    SELECT
+        pp.person_id,
+        n.preference_type,
+        n.preference_status,
+        n.effective_from,
+        n.effective_to,
+        n.lds_start_date_time
+    FROM {{ ref('stg_olids_ndoo_hashed') }} n
+    INNER JOIN {{ ref('int_patient_person_unique') }} pp
+        ON TRY_TO_NUMBER(n.sk_patient_id) = pp.sk_patient_id
+    WHERE n.lds_is_deleted = FALSE
+        AND n.is_latest = 1
+)
+
+SELECT
+    person_id,
+    preference_type,
+    preference_status,
+    preference_status = 'OPT_IN' AS is_opted_in,
+    effective_from,
+    effective_to
+FROM ndoo_resolved
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY person_id, preference_type
+    ORDER BY COALESCE(effective_from, lds_start_date_time) DESC, lds_start_date_time DESC
+) = 1

--- a/models/modelling/olids/person_attributes/int_person_ndoo_status.yml
+++ b/models/modelling/olids/person_attributes/int_person_ndoo_status.yml
@@ -1,0 +1,37 @@
+models:
+  - name: int_person_ndoo_status
+    description: Latest National Data Opt-Out preference per person. One row per (person_id, preference_type). Resolved from NDOO_HASHED via nhs_number_hash join to PERSON.matched_nhs_no_hash.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 1
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - person_id
+              - preference_type
+    columns:
+      - name: person_id
+        description: Resolved person_id from PERSON.id
+        tests:
+          - not_null
+      - name: preference_type
+        description: Normalised preference type (e.g. NATIONAL_DATA_OPT_OUT)
+        tests:
+          - not_null
+      - name: preference_status
+        description: Normalised preference status (e.g. OPT_IN, OPT_OUT)
+        tests:
+          - not_null
+      - name: is_opted_in
+        description: TRUE when preference_status = 'OPT_IN'
+        tests:
+          - not_null
+      - name: effective_from
+        description: Validity start of the latest preference record
+      - name: effective_to
+        description: Validity end of the latest preference record

--- a/models/published/secondary_use/olids/childhood_imms/childhood_imms_person_level_adolescent_dm_secondary_use.yml
+++ b/models/published/secondary_use/olids/childhood_imms/childhood_imms_person_level_adolescent_dm_secondary_use.yml
@@ -2,7 +2,7 @@ models:
   - name: childhood_imms_person_level_adolescent_dm_secondary_use
     description: |
       Childhood immunisations person-level data for adolescents, for secondary use.
-      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      Filtered to patients allowed for secondary use via dim_person_secondary_use_allowed (National Data Opt-Out OPT_IN and no active Type 1 opt-out).
       See childhood_imms_person_level_adolescent_dm in published_reporting_direct_care for full details.
 
     config:

--- a/models/published/secondary_use/olids/childhood_imms/childhood_imms_person_level_child_dm_secondary_use.yml
+++ b/models/published/secondary_use/olids/childhood_imms/childhood_imms_person_level_child_dm_secondary_use.yml
@@ -2,7 +2,7 @@ models:
   - name: childhood_imms_person_level_child_dm_secondary_use
     description: |
       Childhood immunisations person-level data for children, for secondary use.
-      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      Filtered to patients allowed for secondary use via dim_person_secondary_use_allowed (National Data Opt-Out OPT_IN and no active Type 1 opt-out).
       See childhood_imms_person_level_child_dm in published_reporting_direct_care for full details.
 
     config:

--- a/models/published/secondary_use/olids/covid_flu/covid_flu_dashboard_base_secondary_use.yml
+++ b/models/published/secondary_use/olids/covid_flu/covid_flu_dashboard_base_secondary_use.yml
@@ -2,7 +2,7 @@ models:
   - name: covid_flu_dashboard_base_secondary_use
     description: |
       COVID and Flu Dashboard base table for secondary use.
-      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      Filtered to patients allowed for secondary use via dim_person_secondary_use_allowed (National Data Opt-Out OPT_IN and no active Type 1 opt-out).
       See covid_flu_dashboard_base in published_reporting_direct_care for full details.
 
     config:

--- a/models/published/secondary_use/olids/ltc_lcs/ltc_lcs_cf_dashboard_base_secondary_use.yml
+++ b/models/published/secondary_use/olids/ltc_lcs/ltc_lcs_cf_dashboard_base_secondary_use.yml
@@ -2,7 +2,7 @@ models:
   - name: ltc_lcs_cf_dashboard_base_secondary_use
     description: |
       LTC/LCS Case Finding Dashboard base table for secondary use.
-      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      Filtered to patients allowed for secondary use via dim_person_secondary_use_allowed (National Data Opt-Out OPT_IN and no active Type 1 opt-out).
       See ltc_lcs_cf_dashboard_base in published_reporting_direct_care for full details.
 
     config:

--- a/models/published/secondary_use/olids/ltc_lcs/ltc_lcs_risk_stratification_base_secondary_use.yml
+++ b/models/published/secondary_use/olids/ltc_lcs/ltc_lcs_risk_stratification_base_secondary_use.yml
@@ -5,7 +5,7 @@ models:
       One row per person on any LTC LCS disease register (AF, CKD, CHD, Diabetes, Hypertension,
       NAFLD, Asthma Adult, Asthma CYP, COPD, Heart Failure, PAD, Stroke/TIA).
 
-      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      Filtered to patients allowed for secondary use via dim_person_secondary_use_allowed (National Data Opt-Out OPT_IN and no active Type 1 opt-out).
       See ltc_lcs_risk_stratification_base in published_reporting_direct_care for full details.
     config:
       meta:

--- a/models/published/secondary_use/olids/pop_health_needs/population_health_needs_base_readable_secondary_use.yml
+++ b/models/published/secondary_use/olids/pop_health_needs/population_health_needs_base_readable_secondary_use.yml
@@ -2,7 +2,7 @@ models:
   - name: population_health_needs_base_readable_secondary_use
     description: |
       Population health needs base readable table for secondary use.
-      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      Filtered to patients allowed for secondary use via dim_person_secondary_use_allowed (National Data Opt-Out OPT_IN and no active Type 1 opt-out).
       See population_health_needs_base_readable in published_reporting_direct_care for full details.
 
     config:

--- a/models/published/secondary_use/olids/pop_health_needs/population_health_needs_base_secondary_use.yml
+++ b/models/published/secondary_use/olids/pop_health_needs/population_health_needs_base_secondary_use.yml
@@ -2,7 +2,7 @@ models:
   - name: population_health_needs_base_secondary_use
     description: |
       Population health needs base table for secondary use.
-      Filtered to exclude patients with Type 1 opt-outs via dim_person_secondary_use_allowed.
+      Filtered to patients allowed for secondary use via dim_person_secondary_use_allowed (National Data Opt-Out OPT_IN and no active Type 1 opt-out).
       See population_health_needs_base in published_reporting_direct_care for full details.
 
     config:

--- a/models/raw/olids/raw_olids_ndoo_hashed.sql
+++ b/models/raw/olids/raw_olids_ndoo_hashed.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        description="Raw layer (OLIDS stable layer - National Data Opt-Out preferences keyed by hashed NHS number). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE.OLIDS.NDOO_HASHED \ndbt: source(''olids'', ''NDOO_HASHED'') \nColumns:\n  ID -> id\n  LDS_RECORD_ID -> lds_record_id\n  SK_PATIENT_ID -> sk_patient_id\n  NHS_NUMBER_HASH -> nhs_number_hash\n  PREFERENCE_TYPE -> preference_type\n  PREFERENCE_STATUS -> preference_status\n  LDS_IS_DELETED -> lds_is_deleted\n  LDS_DATETIME_DATA_ACQUIRED -> lds_datetime_data_acquired\n  LDS_START_DATE_TIME -> lds_start_date_time\n  LDS_BATCH_ID -> lds_batch_id\n  LDS_FILE_ID -> lds_file_id\n  LDS_DATASET_ID -> lds_dataset_id\n  EFFECTIVE_FROM -> effective_from\n  EFFECTIVE_TO -> effective_to\n  IS_LATEST -> is_latest\n  LAKEHOUSE_DATE_PROCESSED -> lakehouse_date_processed\n  HIGH_WATERMARK_DATE_TIME -> high_watermark_date_time"
+    )
+}}
+select
+    "ID" as id,
+    "LDS_RECORD_ID" as lds_record_id,
+    "SK_PATIENT_ID" as sk_patient_id,
+    "NHS_NUMBER_HASH" as nhs_number_hash,
+    "PREFERENCE_TYPE" as preference_type,
+    "PREFERENCE_STATUS" as preference_status,
+    "LDS_IS_DELETED" as lds_is_deleted,
+    "LDS_DATETIME_DATA_ACQUIRED" as lds_datetime_data_acquired,
+    "LDS_START_DATE_TIME" as lds_start_date_time,
+    "LDS_BATCH_ID" as lds_batch_id,
+    "LDS_FILE_ID" as lds_file_id,
+    "LDS_DATASET_ID" as lds_dataset_id,
+    "EFFECTIVE_FROM" as effective_from,
+    "EFFECTIVE_TO" as effective_to,
+    "IS_LATEST" as is_latest,
+    "LAKEHOUSE_DATE_PROCESSED" as lakehouse_date_processed,
+    "HIGH_WATERMARK_DATE_TIME" as high_watermark_date_time
+from {{ source('olids', 'NDOO_HASHED') }}

--- a/models/raw/olids/raw_olids_person.sql
+++ b/models/raw/olids/raw_olids_person.sql
@@ -1,16 +1,38 @@
 {{
     config(
-        description="Raw layer (OLIDS stable layer - cleaned and filtered patient records). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE.OLIDS.PERSON \ndbt: source(''olids'', ''PERSON'') \nColumns:\n  ID -> id\n  PERSON_UUID -> person_uuid\n  NHS_NUMBER_HASH -> nhs_number_hash\n  TITLE -> title\n  GENDER_CONCEPT_ID -> gender_concept_id\n  BIRTH_YEAR -> birth_year\n  BIRTH_MONTH -> birth_month\n  DEATH_YEAR -> death_year\n  DEATH_MONTH -> death_month"
+        description="Raw layer (OLIDS stable layer - cleaned and filtered patient records). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE.OLIDS.PERSON \ndbt: source(''olids'', ''PERSON'') \nColumns:\n  ID -> id\n  PERSON_UUID -> person_uuid\n  MATCHED_NHS_NO_HASH -> matched_nhs_no_hash\n  GENDER -> gender\n  BIRTH_YEAR -> birth_year\n  BIRTH_MONTH -> birth_month\n  DEATH_YEAR -> death_year\n  DEATH_MONTH -> death_month\n  COMPOSITE_ID -> composite_id\n  DEATH_NOTIFICATION_STATUS -> death_notification_status\n  POSTCODE_HASH -> postcode_hash\n  PREFERRED_CONTACT_METHOD -> preferred_contact_method\n  NOMINATED_PHARMACY -> nominated_pharmacy\n  DISPENSING_DOCTOR -> dispensing_doctor\n  MEDICAL_APPLIANCE_SUPPLIER -> medical_appliance_supplier\n  GP_PRACTICE_CODE -> gp_practice_code\n  GP_REGISTRATION_DATE -> gp_registration_date\n  AS_AT_DATE -> as_at_date\n  SENSITIVITY_FLAG -> sensitivity_flag\n  ERROR_SUCCESS_CODE -> error_success_code\n  LDS_RECORD_ID -> lds_record_id\n  LDS_ID -> lds_id\n  LDS_BUSINESS_KEY -> lds_business_key\n  LDS_DATASET_ID -> lds_dataset_id\n  LDS_CDM_EVENT_ID -> lds_cdm_event_id\n  LDS_DATETIME_DATA_ACQUIRED -> lds_datetime_data_acquired\n  LDS_INITIAL_DATA_RECEIVED_DATE -> lds_initial_data_received_date\n  LDS_IS_DELETED -> lds_is_deleted\n  LDS_START_DATE_TIME -> lds_start_date_time\n  LDS_LAKEHOUSE_DATE_PROCESSED -> lds_lakehouse_date_processed\n  LDS_LAKEHOUSE_DATETIME_UPDATED -> lds_lakehouse_datetime_updated"
     )
 }}
 select
     "ID" as id,
     "PERSON_UUID" as person_uuid,
-    "NHS_NUMBER_HASH" as nhs_number_hash,
-    "TITLE" as title,
-    "GENDER_CONCEPT_ID" as gender_concept_id,
+    "MATCHED_NHS_NO_HASH" as matched_nhs_no_hash,
+    "GENDER" as gender,
     "BIRTH_YEAR" as birth_year,
     "BIRTH_MONTH" as birth_month,
     "DEATH_YEAR" as death_year,
-    "DEATH_MONTH" as death_month
+    "DEATH_MONTH" as death_month,
+    "COMPOSITE_ID" as composite_id,
+    "DEATH_NOTIFICATION_STATUS" as death_notification_status,
+    "POSTCODE_HASH" as postcode_hash,
+    "PREFERRED_CONTACT_METHOD" as preferred_contact_method,
+    "NOMINATED_PHARMACY" as nominated_pharmacy,
+    "DISPENSING_DOCTOR" as dispensing_doctor,
+    "MEDICAL_APPLIANCE_SUPPLIER" as medical_appliance_supplier,
+    "GP_PRACTICE_CODE" as gp_practice_code,
+    "GP_REGISTRATION_DATE" as gp_registration_date,
+    "AS_AT_DATE" as as_at_date,
+    "SENSITIVITY_FLAG" as sensitivity_flag,
+    "ERROR_SUCCESS_CODE" as error_success_code,
+    "LDS_RECORD_ID" as lds_record_id,
+    "LDS_ID" as lds_id,
+    "LDS_BUSINESS_KEY" as lds_business_key,
+    "LDS_DATASET_ID" as lds_dataset_id,
+    "LDS_CDM_EVENT_ID" as lds_cdm_event_id,
+    "LDS_DATETIME_DATA_ACQUIRED" as lds_datetime_data_acquired,
+    "LDS_INITIAL_DATA_RECEIVED_DATE" as lds_initial_data_received_date,
+    "LDS_IS_DELETED" as lds_is_deleted,
+    "LDS_START_DATE_TIME" as lds_start_date_time,
+    "LDS_LAKEHOUSE_DATE_PROCESSED" as lds_lakehouse_date_processed,
+    "LDS_LAKEHOUSE_DATETIME_UPDATED" as lds_lakehouse_datetime_updated
 from {{ source('olids', 'PERSON') }}

--- a/models/reporting/olids/person_status/dim_patient_secondary_use_allowed.sql
+++ b/models/reporting/olids/person_status/dim_patient_secondary_use_allowed.sql
@@ -1,0 +1,23 @@
+{{
+    config(
+        materialized='table',
+        tags=['dimension', 'patient', 'opt_out'],
+        cluster_by=['sk_patient_id'],
+        meta={
+            'custom_message': 'Opt-out filter dim at sk_patient_id grain. INNER JOIN to this from OLIDS models keyed by sk_patient_id to apply National Data Opt-Out and Type 1 opt-out filtering. Fan-out of dim_person_secondary_use_allowed via int_patient_person_unique.'
+        })
+}}
+
+/*
+Patient-grain fan-out of dim_person_secondary_use_allowed.
+One row per sk_patient_id for persons allowed for secondary use.
+Use when the downstream model is keyed by sk_patient_id rather than person_id.
+*/
+
+SELECT DISTINCT
+    pp.sk_patient_id,
+    pp.person_id,
+    TRUE AS is_allowed_secondary_use
+FROM {{ ref('int_patient_person_unique') }} pp
+INNER JOIN {{ ref('dim_person_secondary_use_allowed') }} d
+    ON pp.person_id = d.person_id

--- a/models/reporting/olids/person_status/dim_patient_secondary_use_allowed.yml
+++ b/models/reporting/olids/person_status/dim_patient_secondary_use_allowed.yml
@@ -1,0 +1,26 @@
+
+models:
+  - name: dim_patient_secondary_use_allowed
+    description: Patient-grain (sk_patient_id) fan-out of dim_person_secondary_use_allowed. One row per sk_patient_id for persons allowed for secondary use. Use when the downstream model is keyed by sk_patient_id rather than person_id.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: sk_patient_id
+        description: 'Surrogate patient key - primary key (unique per patient record)'
+        tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: Person identifier this patient record maps to (allowed for secondary use)
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_person_secondary_use_allowed')
+                field: person_id
+      - name: is_allowed_secondary_use
+        description: Always TRUE for rows in this dim (presence implies allowed)
+        tests:
+          - not_null

--- a/models/reporting/olids/person_status/dim_person_opt_out_type_1_status.sql
+++ b/models/reporting/olids/person_status/dim_person_opt_out_type_1_status.sql
@@ -7,8 +7,9 @@
 
 /*
 Type 1 opt-out status dimension.
-Holds latest Type 1 opt-out status (dissent from secondary use of primary care data).
+Holds latest Type 1 opt-out status (dissent from secondary use of primary care data) from clinical observations.
 Only includes persons with Type 1 opt-out records.
+Feeds dim_person_secondary_use_allowed alongside int_person_ndoo_status.
 */
 
 WITH latest_opt_out_status AS (

--- a/models/reporting/olids/person_status/dim_person_secondary_use_allowed.sql
+++ b/models/reporting/olids/person_status/dim_person_secondary_use_allowed.sql
@@ -2,30 +2,35 @@
     config(
         materialized='table',
         tags=['dimension', 'person', 'opt_out'],
-        cluster_by=['person_id'])
+        cluster_by=['person_id'],
+        meta={
+            'custom_message': 'Opt-out filter dim at person_id grain. INNER JOIN to this from OLIDS models keyed by person_id to apply National Data Opt-Out and Type 1 opt-out filtering. Built from int_person_ndoo_status and dim_person_opt_out_type_1_status.'
+        })
 }}
 
 /*
 Persons allowed for secondary use.
-Central opt-out filter - excludes patients with active Type 1 opt-outs.
+Central opt-out filter. Included only when BOTH:
+  - National Data Opt-Out preference is OPT_IN (int_person_ndoo_status), AND
+  - No active Type 1 opt-out from clinical observations (dim_person_opt_out_type_1_status).
 All secondary use models should inner join to this to apply opt-out filtering.
-
-Future opt-outs can be added here (e.g., national data opt-out).
 */
 
-WITH opted_out_type_1 AS (
+WITH ndoo_opt_in AS (
+    SELECT person_id
+    FROM {{ ref('int_person_ndoo_status') }}
+    WHERE preference_type = 'NATIONAL_DATA_OPT_OUT'
+        AND is_opted_in = TRUE
+),
+
+opted_out_type_1 AS (
     SELECT person_id
     FROM {{ ref('dim_person_opt_out_type_1_status') }}
     WHERE is_opted_out = TRUE
-),
-
-all_persons AS (
-    SELECT DISTINCT person_id
-    FROM {{ ref('int_patient_person_unique') }}
 )
 
 SELECT
     person_id,
     TRUE AS is_allowed_secondary_use
-FROM all_persons
+FROM ndoo_opt_in
 WHERE person_id NOT IN (SELECT person_id FROM opted_out_type_1)

--- a/models/reporting/olids/person_status/dim_person_secondary_use_allowed.yml
+++ b/models/reporting/olids/person_status/dim_person_secondary_use_allowed.yml
@@ -1,8 +1,7 @@
 
 models:
   - name: dim_person_secondary_use_allowed
-    description: Persons allowed for secondary use (excludes Type 1 opt-outs). 
-      One row per person for use as opt-out filter.
+    description: Persons allowed for secondary use. Included only when National Data Opt-Out is OPT_IN AND there is no active Type 1 opt-out. One row per person; downstream consumers should INNER JOIN to filter cohorts.
     config:
       meta:
         owner:
@@ -14,6 +13,6 @@ models:
           - unique
           - not_null
       - name: is_allowed_secondary_use
-        description: Flag indicating person is allowed for secondary use
+        description: Always TRUE for rows in this dim (presence implies allowed)
         tests:
           - not_null

--- a/models/sources/auto_data_lake_olids.yml
+++ b/models/sources/auto_data_lake_olids.yml
@@ -933,6 +933,43 @@ sources:
       data_type: TEXT
     - name: AUTHORISATION_TYPE_DISPLAY
       data_type: TEXT
+  - name: NDOO_HASHED
+    identifier: '"NDOO_HASHED"'
+    columns:
+    - name: ID
+      data_type: TEXT
+    - name: LDS_RECORD_ID
+      data_type: TEXT
+    - name: SK_PATIENT_ID
+      data_type: TEXT
+    - name: NHS_NUMBER_HASH
+      data_type: TEXT
+    - name: PREFERENCE_TYPE
+      data_type: TEXT
+    - name: PREFERENCE_STATUS
+      data_type: TEXT
+    - name: LDS_IS_DELETED
+      data_type: BOOLEAN
+    - name: LDS_DATETIME_DATA_ACQUIRED
+      data_type: TIMESTAMP_NTZ
+    - name: LDS_START_DATE_TIME
+      data_type: TIMESTAMP_NTZ
+    - name: LDS_BATCH_ID
+      data_type: TEXT
+    - name: LDS_FILE_ID
+      data_type: TEXT
+    - name: LDS_DATASET_ID
+      data_type: TEXT
+    - name: EFFECTIVE_FROM
+      data_type: TIMESTAMP_NTZ
+    - name: EFFECTIVE_TO
+      data_type: TIMESTAMP_NTZ
+    - name: IS_LATEST
+      data_type: NUMBER(38,0)
+    - name: LAKEHOUSE_DATE_PROCESSED
+      data_type: DATE
+    - name: HIGH_WATERMARK_DATE_TIME
+      data_type: TIMESTAMP_NTZ
   - name: OBSERVATION
     identifier: '"OBSERVATION"'
     columns:
@@ -1364,11 +1401,9 @@ sources:
       data_type: NUMBER(38,0)
     - name: PERSON_UUID
       data_type: TEXT
-    - name: NHS_NUMBER_HASH
+    - name: MATCHED_NHS_NO_HASH
       data_type: BINARY
-    - name: TITLE
-      data_type: TEXT
-    - name: GENDER_CONCEPT_ID
+    - name: GENDER
       data_type: TEXT
     - name: BIRTH_YEAR
       data_type: NUMBER(38,0)
@@ -1378,6 +1413,52 @@ sources:
       data_type: NUMBER(38,0)
     - name: DEATH_MONTH
       data_type: NUMBER(38,0)
+    - name: COMPOSITE_ID
+      data_type: TEXT
+    - name: DEATH_NOTIFICATION_STATUS
+      data_type: TEXT
+    - name: POSTCODE_HASH
+      data_type: BINARY
+    - name: PREFERRED_CONTACT_METHOD
+      data_type: TEXT
+    - name: NOMINATED_PHARMACY
+      data_type: TEXT
+    - name: DISPENSING_DOCTOR
+      data_type: TEXT
+    - name: MEDICAL_APPLIANCE_SUPPLIER
+      data_type: TEXT
+    - name: GP_PRACTICE_CODE
+      data_type: TEXT
+    - name: GP_REGISTRATION_DATE
+      data_type: DATE
+    - name: AS_AT_DATE
+      data_type: DATE
+    - name: SENSITIVITY_FLAG
+      data_type: TEXT
+    - name: ERROR_SUCCESS_CODE
+      data_type: TEXT
+    - name: LDS_RECORD_ID
+      data_type: TEXT
+    - name: LDS_ID
+      data_type: TEXT
+    - name: LDS_BUSINESS_KEY
+      data_type: TEXT
+    - name: LDS_DATASET_ID
+      data_type: TEXT
+    - name: LDS_CDM_EVENT_ID
+      data_type: TEXT
+    - name: LDS_DATETIME_DATA_ACQUIRED
+      data_type: TIMESTAMP_NTZ
+    - name: LDS_INITIAL_DATA_RECEIVED_DATE
+      data_type: TIMESTAMP_NTZ
+    - name: LDS_IS_DELETED
+      data_type: BOOLEAN
+    - name: LDS_START_DATE_TIME
+      data_type: TIMESTAMP_NTZ
+    - name: LDS_LAKEHOUSE_DATE_PROCESSED
+      data_type: DATE
+    - name: LDS_LAKEHOUSE_DATETIME_UPDATED
+      data_type: TIMESTAMP_NTZ
   - name: POSTCODE_HASH
     identifier: '"POSTCODE_HASH"'
     columns:

--- a/models/staging/olids/stg_olids_ndoo_hashed.sql
+++ b/models/staging/olids/stg_olids_ndoo_hashed.sql
@@ -1,0 +1,29 @@
+select
+    -- Primary key
+    id,
+
+    -- Identifiers
+    sk_patient_id,
+    nhs_number_hash,
+
+    -- Preferences (normalised UPPER_SNAKE_CASE: spaces and hyphens -> underscore)
+    -- "Opt-In" -> "OPT_IN", "National Data Opt-out" -> "NATIONAL_DATA_OPT_OUT"
+    upper(replace(replace(preference_type, ' ', '_'), '-', '_')) as preference_type,
+    upper(replace(replace(preference_status, ' ', '_'), '-', '_')) as preference_status,
+
+    -- Validity
+    effective_from,
+    effective_to,
+    is_latest,
+
+    -- Metadata
+    lds_is_deleted,
+    lds_start_date_time,
+    lds_datetime_data_acquired,
+    lds_batch_id,
+    lds_file_id,
+    lds_dataset_id,
+    lds_record_id,
+    lakehouse_date_processed
+
+from {{ ref('raw_olids_ndoo_hashed') }}

--- a/models/staging/olids/stg_olids_ndoo_hashed.yml
+++ b/models/staging/olids/stg_olids_ndoo_hashed.yml
@@ -1,0 +1,40 @@
+models:
+  - name: stg_olids_ndoo_hashed
+    description: National Data Opt-Out preferences keyed by hashed NHS number. preference_type and preference_status are normalised to UPPER_SNAKE_CASE (e.g. "Opt-In" -> "OPT_IN").
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: id
+        description: Row identifier
+        tests:
+          - not_null
+      - name: sk_patient_id
+        description: Surrogate patient key
+      - name: nhs_number_hash
+        description: Hashed NHS number - join key to stg_olids_person.matched_nhs_no_hash
+        tests:
+          - not_null
+      - name: preference_type
+        description: Opt-out preference type, normalised (e.g. NATIONAL_DATA_OPT_OUT)
+        tests:
+          - not_null
+      - name: preference_status
+        description: Preference status, normalised (e.g. OPT_IN, OPT_OUT)
+        tests:
+          - not_null
+      - name: effective_from
+        description: Validity start
+      - name: effective_to
+        description: Validity end
+      - name: is_latest
+        description: 1 if this is the latest record for the (person, preference) tuple
+      - name: lds_is_deleted
+        description: Soft-delete flag
+      - name: lds_start_date_time
+        description: Incremental high-water column
+    tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 1

--- a/models/staging/olids/stg_olids_person.sql
+++ b/models/staging/olids/stg_olids_person.sql
@@ -1,16 +1,44 @@
+-- Native OLIDS PERSON can carry multiple rows per id when a person has multiple
+-- practice registrations recorded. Dedup to one row per person using the most
+-- recent gp_registration_date (with deterministic tie-breakers).
 select
     -- Primary key
     id,
-    any_value(person_uuid) as person_uuid,
+    person_uuid,
 
-    -- Business columns
-    array_agg(distinct nhs_number_hash) as nhs_number_hashes,
-    max(title) as title,
-    max(gender_concept_id) as gender_concept_id,
-    max(birth_year) as birth_year,
-    max(birth_month) as birth_month,
-    max(death_year) as death_year,
-    max(death_month) as death_month
+    -- Identifiers
+    matched_nhs_no_hash,
+    composite_id,
+
+    -- Demographics
+    birth_year,
+    birth_month,
+    death_year,
+    death_month,
+    death_notification_status,
+    postcode_hash,
+    sensitivity_flag,
+
+    -- Registration
+    gp_practice_code,
+    gp_registration_date,
+    as_at_date,
+
+    -- Contact / nominated services
+    preferred_contact_method,
+    nominated_pharmacy,
+    dispensing_doctor,
+    medical_appliance_supplier,
+
+    -- Metadata
+    lds_is_deleted,
+    lds_start_date_time,
+    lds_datetime_data_acquired
 
 from {{ ref('raw_olids_person') }}
-group by id
+qualify row_number() over (
+    partition by id
+    order by gp_registration_date desc nulls last,
+             lds_start_date_time desc nulls last,
+             gp_practice_code desc nulls last
+) = 1

--- a/models/staging/olids/stg_olids_person.yml
+++ b/models/staging/olids/stg_olids_person.yml
@@ -1,22 +1,22 @@
 models:
   - name: stg_olids_person
-    description: Person-level demographic records used for patient identity management across systems. Deduplicated by id with NHS number hashes aggregated into array.
+    description: Person-level demographic records from native OLIDS PERSON. One row per person.
     config:
       meta:
         owner:
           name: EddieDavison92
     columns:
       - name: id
-        description: Primary key - unique identifier for this person
+        description: Primary key - numeric person_id (generate_person_id hash), matches person_id on other OLIDS tables
         tests:
           - unique
           - not_null
-      - name: nhs_number_hashes
-        description: Array of distinct hashed NHS numbers associated with this person (one person may have multiple NHS number hashes)
-      - name: title
-        description: Person title (Mr, Mrs, Dr, etc.)
-      - name: gender_concept_id
-        description: Foreign key to concept.id - person gender
+      - name: person_uuid
+        description: Native person UUID
+      - name: matched_nhs_no_hash
+        description: Hashed NHS number (BINARY) - join key to NDOO_HASHED and other hash-keyed tables
+      - name: composite_id
+        description: Composite identifier from upstream
       - name: birth_year
         description: Year of birth
       - name: birth_month
@@ -25,6 +25,32 @@ models:
         description: Year of death, if deceased
       - name: death_month
         description: Month of death (1-12), if deceased
+      - name: death_notification_status
+        description: Death notification status
+      - name: postcode_hash
+        description: Hash of registered postcode
+      - name: sensitivity_flag
+        description: Record sensitivity flag
+      - name: gp_practice_code
+        description: Registered practice ODS code
+      - name: gp_registration_date
+        description: Date of registration with current GP practice
+      - name: as_at_date
+        description: Snapshot reference date for registration fields
+      - name: preferred_contact_method
+        description: Preferred contact method
+      - name: nominated_pharmacy
+        description: Nominated pharmacy
+      - name: dispensing_doctor
+        description: Dispensing doctor
+      - name: medical_appliance_supplier
+        description: Medical appliance supplier
+      - name: lds_is_deleted
+        description: Soft-delete flag
+      - name: lds_start_date_time
+        description: Incremental high-water column
+      - name: lds_datetime_data_acquired
+        description: Datetime data was acquired
     tests:
       - dbt_expectations.expect_table_row_count_to_be_between:
           arguments:


### PR DESCRIPTION
## Summary
- Adds `NDOO_HASHED` source (raw + staging) and rewires `PERSON` to native OLIDS shape.
- `dim_person_secondary_use_allowed` is now driven by **both** NDOO `OPT_IN` and absence of Type 1 opt-out (was Type 1 only).
- Adds `dim_patient_secondary_use_allowed` (sk_patient_id-grain fan-out) for direct-care/patient-grain models.
- Replaces the DAC `custom_message` text with explicit join guidance; dims themselves describe their purpose.
- Adds `[skip deploy]` / `[skip-deploy]` guard to the `dbt-deploy` workflow — used here.

## Why skip deploy
PR contains the workflow change itself and the source migration; will run prod manually via `workflow_dispatch` after pulling latest main so it picks up other concurrent changes.

## Test plan
- [x] `dbt build -s path:models/staging/olids+` on dev — 644 models succeeded
- [x] `dbt build -s stg_olids_ndoo_hashed+ --full-refresh` — 53/53 success
- [x] Cohort sanity: `dim_person_secondary_use_allowed` = 2,211,632 / direct = 2,385,476 (~7% excluded — matches expected NDOO + Type 1 overlap)
- [ ] Manual workflow_dispatch on `dbt-deploy` after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added National Data Opt-Out (NDOO) preference data integration with new data models and staging layers.

* **Updates**
  * Updated secondary-use dataset documentation across multiple datasets to clarify patient inclusion criteria: OPT_IN status for National Data Opt-Out and absence of Type 1 opt-outs.
  * Enhanced deployment workflow with conditional execution logic based on commit messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wnl-icb-analytics/dbt-analytics/pull/731)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->