### PR TITLE
fix: surface new BNF columns from dbt-olids on MEDICATION_ORDER + MEDICATION_STATEMENT

### DIFF
--- a/models/raw/olids/raw_olids_medication_order.sql
+++ b/models/raw/olids/raw_olids_medication_order.sql
@@ -57,5 +57,9 @@ select
     "SOURCE_CODE" as source_code,
     "SOURCE_DISPLAY" as source_display,
     "SOURCE_SYSTEM" as source_system,
-    "TARGET_SYSTEM" as target_system
+    "TARGET_SYSTEM" as target_system,
+    "BNF_CHAPTER" as bnf_chapter,
+    "BNF_SECTION" as bnf_section,
+    "BNF_CODE" as bnf_code,
+    "BNF_NAME" as bnf_name
 from {{ source('olids', 'MEDICATION_ORDER') }}

--- a/models/raw/olids/raw_olids_medication_statement.sql
+++ b/models/raw/olids/raw_olids_medication_statement.sql
@@ -60,5 +60,9 @@ select
     "SOURCE_SYSTEM" as source_system,
     "TARGET_SYSTEM" as target_system,
     "AUTHORISATION_TYPE_CODE" as authorisation_type_code,
-    "AUTHORISATION_TYPE_DISPLAY" as authorisation_type_display
+    "AUTHORISATION_TYPE_DISPLAY" as authorisation_type_display,
+    "BNF_CHAPTER" as bnf_chapter,
+    "BNF_SECTION" as bnf_section,
+    "BNF_CODE" as bnf_code,
+    "BNF_NAME" as bnf_name
 from {{ source('olids', 'MEDICATION_STATEMENT') }}

--- a/models/sources/auto_data_lake_olids.yml
+++ b/models/sources/auto_data_lake_olids.yml
@@ -816,6 +816,14 @@ sources:
       data_type: TEXT
     - name: TARGET_SYSTEM
       data_type: TEXT
+    - name: BNF_CHAPTER
+      data_type: TEXT
+    - name: BNF_SECTION
+      data_type: TEXT
+    - name: BNF_CODE
+      data_type: TEXT
+    - name: BNF_NAME
+      data_type: TEXT
   - name: MEDICATION_STATEMENT
     identifier: '"MEDICATION_STATEMENT"'
     columns:
@@ -932,6 +940,14 @@ sources:
     - name: AUTHORISATION_TYPE_CODE
       data_type: TEXT
     - name: AUTHORISATION_TYPE_DISPLAY
+      data_type: TEXT
+    - name: BNF_CHAPTER
+      data_type: TEXT
+    - name: BNF_SECTION
+      data_type: TEXT
+    - name: BNF_CODE
+      data_type: TEXT
+    - name: BNF_NAME
       data_type: TEXT
   - name: NDOO_HASHED
     identifier: '"NDOO_HASHED"'

--- a/models/staging/olids/stg_olids_medication_order.sql
+++ b/models/staging/olids/stg_olids_medication_order.sql
@@ -48,6 +48,12 @@ select
     mapped_concept_code,
     mapped_concept_display,
 
+    -- BNF classification (pre-computed upstream in dbt-olids)
+    bnf_chapter,
+    bnf_section,
+    bnf_code,
+    bnf_name,
+
     -- Metadata
     lds_start_date_time,
     lds_is_deleted,

--- a/models/staging/olids/stg_olids_medication_statement.sql
+++ b/models/staging/olids/stg_olids_medication_statement.sql
@@ -51,6 +51,12 @@ select
     lds_datetime_data_acquired,
     lds_initial_data_received_date,
 
+    -- BNF classification (pre-computed upstream in dbt-olids)
+    bnf_chapter,
+    bnf_section,
+    bnf_code,
+    bnf_name,
+
     -- Metadata
     lds_start_date_time,
     lds_is_deleted,


### PR DESCRIPTION
## Summary

dbt-olids [#234](https://github.com/wnl-icb-analytics/dbt-OLIDS/pull/234) added \`bnf_chapter\`, \`bnf_section\`, \`bnf_code\`, \`bnf_name\` as stored columns on \`MEDICATION_ORDER\` and \`MEDICATION_STATEMENT\`. Until the dbt-analytics raw layer surfaces them, any medication model fails to compile:

\`\`\`
View definition for 'DATA_LAKE.OLIDS.MEDICATION_ORDER' declared 54 column(s),
but view query produces 58 column(s).
\`\`\`

This PR is the dbt-analytics half of that landing.

## Changes
- \`raw_olids_medication_order\` / \`raw_olids_medication_statement\` — surface the 4 new BNF columns
- \`stg_olids_medication_order\` / \`stg_olids_medication_statement\` — pass them through
- \`auto_data_lake_olids.yml\` — declare on both source tables

## Test plan
- [x] Dev: \`dbt run -s raw_olids_medication_order raw_olids_medication_statement stg_olids_medication_order stg_olids_medication_statement int_statin_medications_all int_polypharmacy_history --full-refresh\` — 11/11 success (2m 16s)
- [x] Validated medication models that were failing now compile and build cleanly
- [ ] Prod build picks up via auto-deploy on merge

## Note on perf wins still to come
This is a small surgical fix; the broader perf work (BNF chapter direct filtering in macros, EMIS-local int_ tables, \`dim_person_active_patients\` cleanup, etc.) will follow in subsequent PRs. Splitting them keeps each diff reviewable in isolation and lets us measure the impact of each in turn.