### PR TITLE
perf: BNF chapter direct filter + dim_person_active_patients cleanup + global_data_refresh date filter

### DIFF
--- a/macros/clinical/get_medication_orders.sql
+++ b/macros/clinical/get_medication_orders.sql
@@ -1,6 +1,10 @@
 {% macro get_medication_orders(bnf_code=none, cluster_id=none, source=none, include_history=false) %}
     -- Optional source parameter to filter to specific refset (e.g., 'LTC_LCS')
     -- include_history=true expands cluster codes with retired SNOMED predecessors via SCT_History
+    --
+    -- BNF filtering uses pre-computed columns from stg_olids_medication_order
+    -- (clustered on bnf_chapter, mapped_concept_code in dbt-olids), so 2/4-char
+    -- prefixes prune to a tiny number of partitions automatically.
     {% if bnf_code is none and cluster_id is none %}
     {{ exceptions.raise_compiler_error("Must provide either bnf_code or cluster_id parameter to get_medication_orders macro") }}
 {% endif %}
@@ -24,6 +28,22 @@
         {{ exceptions.raise_compiler_error("get_medication_orders requires non-empty cluster_id values") }}
     {% endif %}
     {% set cluster_ids_str = cleaned_cluster_ids | join("','") %}
+{% endif %}
+
+{# Build the BNF prefix filter: pick the cluster-key column that matches the prefix length #}
+{% set bnf_filter = '' %}
+{% if bnf_code is not none %}
+    {% set bnf_prefix = bnf_code | string | trim %}
+    {% if bnf_prefix | length == 2 %}
+        {% set bnf_filter = "AND mo.bnf_chapter = '" ~ bnf_prefix ~ "'" %}
+    {% elif bnf_prefix | length == 4 %}
+        {% set bnf_filter = "AND mo.bnf_section = '" ~ bnf_prefix ~ "'" %}
+    {% elif bnf_prefix | length >= 15 %}
+        {% set bnf_filter = "AND mo.bnf_code = '" ~ bnf_prefix ~ "'" %}
+    {% else %}
+        {# Mid-length prefix (e.g. 6 chars for paragraph): use chapter for pruning + LIKE for precision #}
+        {% set bnf_filter = "AND mo.bnf_chapter = '" ~ bnf_prefix[:2] ~ "' AND mo.bnf_code LIKE '" ~ bnf_prefix ~ "%'" %}
+    {% endif %}
 {% endif %}
 
     {%- if cluster_id is not none -%}
@@ -76,21 +96,19 @@
         mo.mapped_concept_code,
         mo.mapped_concept_display,
         cc.cluster_id,
-        bnf.bnf_code,
-        bnf.bnf_name
+        mo.bnf_chapter,
+        mo.bnf_section,
+        mo.bnf_code,
+        mo.bnf_name
     FROM {{ ref('stg_olids_medication_order') }} mo
     JOIN {{ ref('int_patient_person_unique') }} pp
         ON mo.patient_id = pp.patient_id
     INNER JOIN {% if include_history %}expanded_codes{% else %}cluster_codes{% endif %} cc
         ON mo.mapped_concept_code = cc.mapped_concept_code
-    LEFT JOIN {{ ref('stg_reference_bnf_latest') }} bnf
-        ON mo.mapped_concept_code = bnf.snomed_code
     WHERE mo.clinical_effective_date IS NOT NULL
-    {% if bnf_code is not none %}
-        AND bnf.bnf_code LIKE '{{ bnf_code }}%'
-    {% endif %}
+    {{ bnf_filter }}
     {%- else -%}
-    -- BNF code path without cluster filtering
+    -- BNF-only path: prune via mo.bnf_chapter / bnf_section / bnf_code (clustered upstream)
     SELECT
         mo.id AS medication_order_id,
         mo.medication_statement_id,
@@ -108,16 +126,14 @@
         mo.mapped_concept_code,
         mo.mapped_concept_display,
         NULL AS cluster_id,
-        bnf.bnf_code,
-        bnf.bnf_name
+        mo.bnf_chapter,
+        mo.bnf_section,
+        mo.bnf_code,
+        mo.bnf_name
     FROM {{ ref('stg_olids_medication_order') }} mo
     JOIN {{ ref('int_patient_person_unique') }} pp
         ON mo.patient_id = pp.patient_id
-    LEFT JOIN {{ ref('stg_reference_bnf_latest') }} bnf
-        ON mo.mapped_concept_code = bnf.snomed_code
     WHERE mo.clinical_effective_date IS NOT NULL
-    {% if bnf_code is not none %}
-        AND bnf.bnf_code LIKE '{{ bnf_code }}%'
-    {% endif %}
+    {{ bnf_filter }}
     {%- endif -%}
 {% endmacro %}

--- a/macros/clinical/get_medication_statements.sql
+++ b/macros/clinical/get_medication_statements.sql
@@ -1,6 +1,10 @@
 {% macro get_medication_statements(bnf_code=none, cluster_id=none, source=none, include_history=false) %}
     -- Optional source parameter to filter to specific refset (e.g., 'LTC_LCS')
     -- include_history=true expands cluster codes with retired SNOMED predecessors via SCT_History
+    --
+    -- BNF filtering uses pre-computed columns from stg_olids_medication_statement
+    -- (clustered on bnf_chapter, mapped_concept_code in dbt-olids), so 2/4-char
+    -- prefixes prune to a tiny number of partitions automatically.
     {% if bnf_code is none and cluster_id is none %}
     {{ exceptions.raise_compiler_error("Must provide either bnf_code or cluster_id parameter to get_medication_statements macro") }}
 {% endif %}
@@ -24,6 +28,21 @@
         {{ exceptions.raise_compiler_error("get_medication_statements requires non-empty cluster_id values") }}
     {% endif %}
     {% set cluster_ids_str = cleaned_cluster_ids | join("','") %}
+{% endif %}
+
+{# Build the BNF prefix filter: pick the cluster-key column that matches the prefix length #}
+{% set bnf_filter = '' %}
+{% if bnf_code is not none %}
+    {% set bnf_prefix = bnf_code | string | trim %}
+    {% if bnf_prefix | length == 2 %}
+        {% set bnf_filter = "AND ms.bnf_chapter = '" ~ bnf_prefix ~ "'" %}
+    {% elif bnf_prefix | length == 4 %}
+        {% set bnf_filter = "AND ms.bnf_section = '" ~ bnf_prefix ~ "'" %}
+    {% elif bnf_prefix | length >= 15 %}
+        {% set bnf_filter = "AND ms.bnf_code = '" ~ bnf_prefix ~ "'" %}
+    {% else %}
+        {% set bnf_filter = "AND ms.bnf_chapter = '" ~ bnf_prefix[:2] ~ "' AND ms.bnf_code LIKE '" ~ bnf_prefix ~ "%'" %}
+    {% endif %}
 {% endif %}
 
     {%- if cluster_id is not none -%}
@@ -80,21 +99,19 @@
         ms.mapped_concept_code,
         ms.mapped_concept_display,
         cc.cluster_id,
-        bnf.bnf_code,
-        bnf.bnf_name
+        ms.bnf_chapter,
+        ms.bnf_section,
+        ms.bnf_code,
+        ms.bnf_name
     FROM {{ ref('stg_olids_medication_statement') }} ms
     JOIN {{ ref('int_patient_person_unique') }} pp
         ON ms.patient_id = pp.patient_id
     INNER JOIN {% if include_history %}expanded_codes{% else %}cluster_codes{% endif %} cc
         ON ms.mapped_concept_code = cc.mapped_concept_code
-    LEFT JOIN {{ ref('stg_reference_bnf_latest') }} bnf
-        ON ms.mapped_concept_code = bnf.snomed_code
     WHERE ms.clinical_effective_date IS NOT NULL
-    {% if bnf_code is not none %}
-        AND bnf.bnf_code LIKE '{{ bnf_code }}%'
-    {% endif %}
+    {{ bnf_filter }}
     {%- else -%}
-    -- BNF code path without cluster filtering
+    -- BNF-only path: prune via ms.bnf_chapter / bnf_section / bnf_code (clustered upstream)
     SELECT
         ms.id AS medication_statement_id,
         ms.patient_id,
@@ -116,16 +133,14 @@
         ms.mapped_concept_code,
         ms.mapped_concept_display,
         NULL AS cluster_id,
-        bnf.bnf_code,
-        bnf.bnf_name
+        ms.bnf_chapter,
+        ms.bnf_section,
+        ms.bnf_code,
+        ms.bnf_name
     FROM {{ ref('stg_olids_medication_statement') }} ms
     JOIN {{ ref('int_patient_person_unique') }} pp
         ON ms.patient_id = pp.patient_id
-    LEFT JOIN {{ ref('stg_reference_bnf_latest') }} bnf
-        ON ms.mapped_concept_code = bnf.snomed_code
     WHERE ms.clinical_effective_date IS NOT NULL
-    {% if bnf_code is not none %}
-        AND bnf.bnf_code LIKE '{{ bnf_code }}%'
-    {% endif %}
+    {{ bnf_filter }}
     {%- endif -%}
 {% endmacro %}

--- a/models/modelling/olids/medications/int_medication_order_bnf.sql
+++ b/models/modelling/olids/medications/int_medication_order_bnf.sql
@@ -5,21 +5,21 @@
 }}
 
 /*
-Medication orders enriched with BNF classification and prescription (statement) details.
-View — not materialised. Can be materialised later if performance requires it.
+Medication orders enriched with prescription (statement) details + BNF hierarchy.
+View — not materialised.
 
 Grain: one row per medication order (issue).
 
 Joins:
-- stg_reference_bnf_latest: SNOMED → BNF code mapping (96% coverage)
 - stg_olids_medication_statement: prescription details (acute/repeat, active status, expiry)
 - int_patient_person_unique: patient_id → person_id
 
-BNF hierarchy exposed as:
+BNF hierarchy comes from upstream stg_olids_medication_order (pre-joined in dbt-olids,
+clustered on bnf_chapter):
 - bnf_code: full BNF code (e.g. 0212000B0AAAAAA)
 - bnf_chapter: 2-digit chapter (e.g. 02 = Cardiovascular)
 - bnf_section: 4-digit section (e.g. 0212 = Lipid-Regulating Drugs)
-- bnf_paragraph: 6-digit paragraph (e.g. 021200 = Lipid-Regulating Drugs)
+- bnf_paragraph: 6-digit paragraph (computed inline from bnf_code)
 - bnf_name: human-readable BNF product name
 */
 
@@ -44,12 +44,12 @@ SELECT
     mo.estimated_cost,
     mo.age_at_event,
 
-    -- BNF classification (from SNOMED → BNF reference mapping)
-    bnf.bnf_code,
-    bnf.bnf_name,
-    LEFT(bnf.bnf_code, 2) AS bnf_chapter,
-    LEFT(bnf.bnf_code, 4) AS bnf_section,
-    LEFT(bnf.bnf_code, 6) AS bnf_paragraph,
+    -- BNF classification (pre-computed upstream in dbt-olids)
+    mo.bnf_code,
+    mo.bnf_name,
+    mo.bnf_chapter,
+    mo.bnf_section,
+    LEFT(mo.bnf_code, 6) AS bnf_paragraph,
 
     -- Prescription (statement) details
     -- authorisation_type_source_code is the clean classification: Acute, Repeat, Repeat Dispensing, Automatic
@@ -73,10 +73,6 @@ FROM {{ ref('stg_olids_medication_order') }} mo
 -- Person mapping
 INNER JOIN {{ ref('int_patient_person_unique') }} pp
     ON mo.patient_id = pp.patient_id
-
--- BNF classification via SNOMED code
-LEFT JOIN {{ ref('stg_reference_bnf_latest') }} bnf
-    ON mo.mapped_concept_code = bnf.snomed_code
 
 -- Prescription details (statement = the prescription, order = each issue)
 LEFT JOIN {{ ref('stg_olids_medication_statement') }} ms

--- a/models/modelling/olids/utilities/int_global_data_refresh_date.sql
+++ b/models/modelling/olids/utilities/int_global_data_refresh_date.sql
@@ -27,6 +27,10 @@ date_practice_counts AS (
     INNER JOIN practice_list p
         ON o.record_owner_organisation_code = p.practice_code
     WHERE o.clinical_effective_date < CURRENT_DATE()
+        -- Most-recent valid-data date is always within recent weeks; constrain
+        -- the scan to the last 3 months so the clinical_effective_date cluster
+        -- key prunes the OBSERVATION scan (was a near-full ~1.6B row scan).
+        AND o.clinical_effective_date >= DATEADD('month', -3, CURRENT_DATE())
     GROUP BY o.clinical_effective_date::date
 )
 

--- a/models/reporting/olids/person_status/dim_person_active_patients.sql
+++ b/models/reporting/olids/person_status/dim_person_active_patients.sql
@@ -6,17 +6,14 @@
 }}
 
 -- Person Active Patients Dimension Table
--- Now uses proper registration data from episode_of_care via int_patient_registrations
--- Filters out deceased patients and dummy patients
--- Links PATIENT_PERSON, PATIENT, PERSON, and proper registration data
+-- Uses proper registration data from episode_of_care via int_patient_registrations
+-- Filters out deceased patients and dummy patients upstream so the window function
+-- and write only process the active cohort.
 
-WITH all_persons AS (
-    SELECT person_id
-    FROM {{ ref('dim_person') }}
-),
-
-current_registrations AS (
-    -- Get current registration details per person
+WITH current_registrations AS (
+    -- One row per person with their current registration. is_current_registration
+    -- can match more than one row per person (e.g. dual-registered) - pick latest
+    -- by registration_start_date as the tie-break.
     SELECT
         ipr.person_id,
         ipr.patient_id,
@@ -27,88 +24,49 @@ current_registrations AS (
         ipr.registration_duration_days AS current_registration_duration,
         ipr.total_registrations_count,
         ipr.has_changed_practice,
-        -- Additional registration metadata
         ipr.practitioner_id
     FROM {{ ref('int_patient_registrations') }} AS ipr
     WHERE ipr.is_current_registration = TRUE
-),
-
-latest_patient_record_per_person AS (
-    -- Get the latest patient record for each person with registration details
-    SELECT
-        ap.person_id,
-        p.sk_patient_id,
-        dp.patient_ids,
-        -- Determine if patient is active based on various criteria
-        p.is_dummy_patient,
-        p.is_confidential,
-        p.is_spine_sensitive,
-        p.birth_year,
-        p.birth_month,
-        bd.death_year,
-        bd.death_month,
-        cr.current_practice_id,
-        cr.current_practice_code,
-        -- Registration details from proper episode_of_care data
-        cr.current_practice_name,
-        cr.current_registration_start,
-        cr.current_registration_duration,
-        cr.total_registrations_count,
-        cr.has_changed_practice,
-        cr.practitioner_id,
-        p.record_owner_organisation_code AS record_owner_org_code,
-        p.lds_datetime_data_acquired AS latest_record_date,
-        CASE
-            WHEN bd.is_deceased THEN FALSE -- Deceased (from all sources: OLIDS, PDS, Registries)
-            WHEN p.is_dummy_patient THEN FALSE -- Dummy patient
-            WHEN cr.person_id IS NULL THEN FALSE -- No current registration
-            ELSE TRUE
-        END AS is_active,
-        bd.is_deceased,
-        -- Rank to get the latest record
-        ROW_NUMBER() OVER (
-            PARTITION BY ap.person_id
-            ORDER BY
-                p.lds_datetime_data_acquired DESC,
-                p.id DESC
-        ) AS record_rank
-    FROM all_persons AS ap
-    LEFT JOIN {{ ref('dim_person') }} AS dp
-        ON ap.person_id = dp.person_id
-    LEFT JOIN current_registrations AS cr
-        ON ap.person_id = cr.person_id
-    LEFT JOIN {{ ref('stg_olids_patient') }} AS p
-        ON cr.patient_id = p.id
-    LEFT JOIN {{ ref('dim_person_birth_death') }} AS bd
-        ON ap.person_id = bd.person_id
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY ipr.person_id
+        ORDER BY ipr.registration_start_date DESC, ipr.patient_id DESC
+    ) = 1
 )
 
--- Select only the latest record per person and only active patients
 SELECT
-    person_id,
-    sk_patient_id,
-    patient_ids,
-    is_active,
-    is_deceased,
-    is_dummy_patient,
-    is_confidential,
-    is_spine_sensitive,
-    birth_year,
-    birth_month,
-    death_year,
-    death_month,
-    -- Registration-based practice information
-    current_practice_id,
-    current_practice_code,
-    current_practice_name,
-    current_registration_start,
-    current_registration_duration,
-    total_registrations_count,
-    has_changed_practice,
-    practitioner_id,
-    record_owner_org_code,
-    latest_record_date
-FROM latest_patient_record_per_person
+    dp.person_id,
+    p.sk_patient_id,
+    dp.patient_ids,
+    TRUE AS is_active,
+    bd.is_deceased,
+    p.is_dummy_patient,
+    p.is_confidential,
+    p.is_spine_sensitive,
+    p.birth_year,
+    p.birth_month,
+    bd.death_year,
+    bd.death_month,
+    cr.current_practice_id,
+    cr.current_practice_code,
+    cr.current_practice_name,
+    cr.current_registration_start,
+    cr.current_registration_duration,
+    cr.total_registrations_count,
+    cr.has_changed_practice,
+    cr.practitioner_id,
+    p.record_owner_organisation_code AS record_owner_org_code,
+    p.lds_datetime_data_acquired AS latest_record_date
+FROM {{ ref('dim_person') }} AS dp
+INNER JOIN current_registrations AS cr
+    ON dp.person_id = cr.person_id
+INNER JOIN {{ ref('stg_olids_patient') }} AS p
+    ON cr.patient_id = p.id
+LEFT JOIN {{ ref('dim_person_birth_death') }} AS bd
+    ON dp.person_id = bd.person_id
 WHERE
-    record_rank = 1
-    AND is_active = TRUE
+    -- Active = alive, not dummy, has a current registration. The INNER JOINs
+    -- above enforce "has current registration"; the predicates below enforce
+    -- alive + non-dummy. Filtering here means the cluster_by sort and table
+    -- write only process the active cohort (~2.2M rows, not 2.4M).
+    COALESCE(bd.is_deceased, FALSE) = FALSE
+    AND COALESCE(p.is_dummy_patient, FALSE) = FALSE


### PR DESCRIPTION
## Summary

Three independent perf improvements that landed during the same investigation. Each commit is reviewable on its own.

### 1. Medications: use upstream BNF columns directly

\`stg_olids_medication_order\` and \`stg_olids_medication_statement\` now expose stored \`bnf_chapter\`, \`bnf_section\`, \`bnf_code\`, \`bnf_name\` columns (PR [#732](https://github.com/wnl-icb-analytics/dbt-analytics/pull/732) / dbt-olids [#234](https://github.com/wnl-icb-analytics/dbt-OLIDS/pull/234)). This commit drops the redundant \`LEFT JOIN stg_reference_bnf_latest\` from:
- \`get_medication_orders\` macro
- \`get_medication_statements\` macro
- \`int_medication_order_bnf\`

BNF-prefix filtering in the macros now picks the most selective clustered column based on prefix length:
- 2 chars → \`mo.bnf_chapter = 'X'\` (leading cluster key — prunes to ~2 partitions out of 2,727)
- 4 chars → \`mo.bnf_section = 'X'\`
- 15+ chars → \`mo.bnf_code = 'X'\` (exact match)
- Other → chapter prefix + LIKE

Output gains \`bnf_chapter\` and \`bnf_section\` (additive — no breaking change for consumers using specific columns).

### 2. dim_person_active_patients cleanup

The 6.5-min model rewritten to filter the active cohort upstream rather than at the end. Changes:
- Single scan of \`dim_person\` (was two)
- INNER JOIN to \`current_registrations\` + \`stg_olids_patient\` (was LEFT JOIN with later null-check)
- Move dual-registration tiebreak inside \`current_registrations\` CTE via \`QUALIFY ROW_NUMBER\` (was an outer \`ROW_NUMBER\` over the full 2.4M post-join set)
- Drop outer \`is_active\` CASE — column is always \`TRUE\` since exclusions happen upstream
- Tiebreak order now \`registration_start_date DESC\` (was \`lds_datetime_data_acquired DESC\` — wrong for "current registration")

### 3. int_global_data_refresh_date — 3-month date filter

Added \`clinical_effective_date >= DATEADD('month', -3, CURRENT_DATE())\` so the \`clinical_effective_date\` secondary cluster key prunes the scan. The model finds the most-recent date with ≥150 practices reporting — always within recent weeks, so 3 months is generous headroom.

## Dev measurements

| Model | Before (prod XS) | After (dev M) |
|---|---|---|
| \`int_statin_medications_all\` | ~105s | **14.6s** |
| \`int_ace_inhibitor_medications_all\` | ~110s | **10.3s** |
| \`int_medication_order_bnf\` (view) | ~ | **1.7s** |
| \`dim_person_active_patients\` | ~390s | **15.5s** |
| \`int_global_data_refresh_date\` | ~45s | **3.8s** |

Dev wall-clock is faster than prod for two reasons — warehouse size (M vs XS, ~4×) and contention (prod runs 1,500 models concurrently). Real prod savings will be 2-3× per affected model, plus ongoing improvement to BNF user queries.

## Test plan
- [x] \`dbt compile\` clean (4373/4373 success)
- [x] Each model rebuilt successfully on dev with \`--full-refresh\`
- [x] Row counts preserved (medication models, dim_person_active_patients)
- [ ] Prod build auto-deploys on merge

## Follow-up branches still pending

- \`perf-pass-3\`: EMIS-local int_ tables for the 3 LTC LCS source paths + the 6 macros
- \`perf-pass-4\`: Shared int_ scans for ethnicity (3 models) and valproate (4+ models)
- \`perf-pass-5\`: Date params on clinical macros (additive) + initial sweep of "recent-only" models
- \`perf-pass-cleanup\`: Drop \`cluster_by\` from the 204 single-partition models
- \`warehouse-experiment\`: Try one prod run on \`WH_NCL_ENGINEERING_S\` to confirm the contention hypothesis from Phase 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimised medication order and statement filtering logic for improved query performance.
  * Streamlined active patient identification with refined data retrieval methods.
  * Enhanced data refresh constraints to prioritise recently uploaded practice information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wnl-icb-analytics/dbt-analytics/pull/733)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->