### PR TITLE
fix(ci): run EXECUTE DBT PROJECT on WH_WNL_ENGINEERING_M

### DIFF
--- a/.github/workflows/dbt-deploy.yml
+++ b/.github/workflows/dbt-deploy.yml
@@ -202,11 +202,17 @@ jobs:
                   print(f"Deploying {file_count} changed models + downstream: {select}")
                   args = f"build --target snowflake-prod --select {select}"
 
-              # Switch to the M warehouse for the build itself. WH_NCL_ENGINEERING_XS
-              # has statement_timeout = 3600s; EXECUTE DBT PROJECT routinely needs
-              # longer. WH_WNL_ENGINEERING_M has 7200s and is the same warehouse the
-              # scheduled tasks use. FETCH/ADD VERSION above stay on XS (cheap).
+              # Lift the 1h cap on EXECUTE DBT PROJECT. Both are required:
+              #   - ALTER SESSION overrides the account-level STATEMENT_TIMEOUT_IN_SECONDS
+              #     (currently 3600) in the session hierarchy. Without this, the
+              #     effective timeout is min(account=3600, warehouse) = 3600.
+              #   - USE WAREHOUSE switches off WH_NCL_ENGINEERING_XS (3600s cap) onto
+              #     WH_WNL_ENGINEERING_M (7200s cap). Otherwise the warehouse caps it
+              #     at 3600 regardless of the session setting.
+              # Lowest of {session-hierarchy, warehouse} wins, so we need both >= 7200.
+              # FETCH/ADD VERSION above stay on XS (cheap, short).
               print(f"Executing: dbt {args}")
+              cur.execute("ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = 7200")
               cur.execute("USE WAREHOUSE WH_WNL_ENGINEERING_M")
               cur.execute(f"EXECUTE DBT PROJECT DBT_NCL_ANALYTICS__MAIN ARGS = '{args}'")
 

--- a/.github/workflows/dbt-deploy.yml
+++ b/.github/workflows/dbt-deploy.yml
@@ -10,7 +10,8 @@
 #
 # Snowflake objects:
 #   - Role: DBT_ADMIN
-#   - Warehouse: WH_NCL_ENGINEERING_XS
+#   - Warehouse: WH_NCL_ENGINEERING_XS for FETCH + ADD VERSION,
+#                WH_WNL_ENGINEERING_M for EXECUTE DBT PROJECT (7200s timeout)
 #   - Database/Schema: ACCOUNT_ADMIN.DBT_MANAGEMENT
 #   - Git repo: REPO__GITHUB__DBT_NCL_ANALYTICS
 #   - dbt project: DBT_NCL_ANALYTICS__MAIN
@@ -201,7 +202,12 @@ jobs:
                   print(f"Deploying {file_count} changed models + downstream: {select}")
                   args = f"build --target snowflake-prod --select {select}"
 
+              # Switch to the M warehouse for the build itself. WH_NCL_ENGINEERING_XS
+              # has statement_timeout = 3600s; EXECUTE DBT PROJECT routinely needs
+              # longer. WH_WNL_ENGINEERING_M has 7200s and is the same warehouse the
+              # scheduled tasks use. FETCH/ADD VERSION above stay on XS (cheap).
               print(f"Executing: dbt {args}")
+              cur.execute("USE WAREHOUSE WH_WNL_ENGINEERING_M")
               cur.execute(f"EXECUTE DBT PROJECT DBT_NCL_ANALYTICS__MAIN ARGS = '{args}'")
 
               results = cur.fetchall()

--- a/.github/workflows/dbt-pr-validation.yml
+++ b/.github/workflows/dbt-pr-validation.yml
@@ -218,10 +218,15 @@ jobs:
                   print(f"Validating {file_count} changed models: {select}")
                   args = f"build --target snowflake-dev --select {select}"
 
-              # Switch to the M warehouse for the build itself. WH_NCL_ENGINEERING_XS
-              # has statement_timeout = 3600s; large PR validations can exceed it.
-              # WH_WNL_ENGINEERING_M has 7200s. FETCH/ADD VERSION above stay on XS.
+              # Lift the 1h cap on EXECUTE DBT PROJECT. Both are required:
+              #   - ALTER SESSION overrides the account-level STATEMENT_TIMEOUT_IN_SECONDS
+              #     (3600) in the session hierarchy.
+              #   - USE WAREHOUSE switches onto WH_WNL_ENGINEERING_M (7200s) so the
+              #     warehouse isn't the binding constraint.
+              # Lowest of {session-hierarchy, warehouse} wins, so we need both >= 7200.
+              # FETCH/ADD VERSION above stay on XS.
               print(f"Executing: dbt {args}")
+              cur.execute("ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = 7200")
               cur.execute("USE WAREHOUSE WH_WNL_ENGINEERING_M")
               cur.execute(f"EXECUTE DBT PROJECT DBT_NCL_ANALYTICS__CI ARGS = '{args}'")
 

--- a/.github/workflows/dbt-pr-validation.yml
+++ b/.github/workflows/dbt-pr-validation.yml
@@ -10,7 +10,8 @@
 #
 # Snowflake objects:
 #   - Role: DBT_ADMIN
-#   - Warehouse: WH_NCL_ENGINEERING_XS
+#   - Warehouse: WH_NCL_ENGINEERING_XS for FETCH + ADD VERSION,
+#                WH_WNL_ENGINEERING_M for EXECUTE DBT PROJECT (7200s timeout)
 #   - Database/Schema: ACCOUNT_ADMIN.DBT_MANAGEMENT
 #   - Git repo: REPO__GITHUB__DBT_NCL_ANALYTICS
 #   - dbt project: DBT_NCL_ANALYTICS__CI
@@ -217,7 +218,11 @@ jobs:
                   print(f"Validating {file_count} changed models: {select}")
                   args = f"build --target snowflake-dev --select {select}"
 
+              # Switch to the M warehouse for the build itself. WH_NCL_ENGINEERING_XS
+              # has statement_timeout = 3600s; large PR validations can exceed it.
+              # WH_WNL_ENGINEERING_M has 7200s. FETCH/ADD VERSION above stay on XS.
               print(f"Executing: dbt {args}")
+              cur.execute("USE WAREHOUSE WH_WNL_ENGINEERING_M")
               cur.execute(f"EXECUTE DBT PROJECT DBT_NCL_ANALYTICS__CI ARGS = '{args}'")
 
               results = cur.fetchall()


### PR DESCRIPTION
## Summary
- The deploy and PR-validation workflows were running \`EXECUTE DBT PROJECT\` on \`WH_NCL_ENGINEERING_XS\`, which has \`statement_timeout_in_seconds = 3600\`. Builds hitting >1h were cancelled with Snowflake error \`000630\` (most recent: 2026-05-13 18:47, query \`01c4586b-0001-70d8-0001-51c20ba0ff8a\`).
- Per Snowflake docs the effective timeout is \`min(session-hierarchy, warehouse)\`, so no session-level override can exceed the warehouse cap. The only fix is to use a warehouse with a longer timeout.
- \`WH_WNL_ENGINEERING_M\` is already configured with \`statement_timeout_in_seconds = 7200\` and is the warehouse the scheduled tasks use after [Snowflake-Deployment#13](https://github.com/wnl-icb-analytics/Snowflake-Deployment/pull/13). \`DBT_ADMIN\` has \`USAGE\` on it.
- Cheap setup statements (\`ALTER GIT REPOSITORY ... FETCH\`, \`ALTER DBT PROJECT ... ADD VERSION\`) stay on \`WH_NCL_ENGINEERING_XS\`. Only the long-running \`EXECUTE DBT PROJECT\` statement is switched to M.

## Test plan
- [ ] Re-run the deploy workflow on a known-large model set; confirm it completes past the 1h mark without \`000630\`
- [ ] Run the PR validation workflow on a PR that previously timed out; confirm no timeout
- [ ] Verify the M warehouse spins up only for the build statement (auto-suspend = 60s should bring it down quickly after)