### PR TITLE
fix: deterministic dedup in fct_flu_status to handle partial rebuilds

### DIFF
--- a/models/reporting/olids/programme/flu/fct_flu_status.sql
+++ b/models/reporting/olids/programme/flu/fct_flu_status.sql
@@ -22,9 +22,14 @@ This gives a complete picture of vaccination patterns across the population.
 ) }}
 
 WITH
--- All eligible people (from eligibility table)
+-- All eligible people (from eligibility table). One row per (campaign_id, person_id).
+-- fct_flu_eligibility carries one row per (person, eligibility rule) and stamps
+-- created_at = CURRENT_DATE at build time. A SELECT DISTINCT here would preserve
+-- duplicates whenever rule firings have different created_at (e.g. a partial
+-- rebuild leaves some int_flu_* rows from a previous build day). Dedup
+-- deterministically by keeping the most recent rule firing per person.
 all_eligible_people AS (
-    SELECT DISTINCT
+    SELECT
         campaign_id,
         person_id,
         birth_date_approx,
@@ -33,6 +38,10 @@ all_eligible_people AS (
         reference_date,
         created_at
     FROM {{ ref('fct_flu_eligibility') }}
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY campaign_id, person_id
+        ORDER BY created_at DESC, reference_date DESC
+    ) = 1
 ),
 
 -- All vaccination administration records (both campaigns automatically included from intermediate models)


### PR DESCRIPTION
## Hotfix

PR [#733](https://github.com/wnl-icb-analytics/dbt-analytics/pull/733) deploy failed on the \`dbt_utils.unique_combination_of_columns\` test for \`fct_flu_status\` on \`(campaign_id, person_id, status_type)\` — 215,256 duplicate combinations.

## Root cause (latent design fragility)

\`fct_flu_eligibility\` stamps \`created_at = CURRENT_DATE\` at build time (via \`audit_end_date\` in \`flu_campaign_config.sql\`). \`fct_flu_status\` then does:

\`\`\`sql
all_eligible_people AS (
    SELECT DISTINCT
        campaign_id, person_id, ..., created_at
    FROM fct_flu_eligibility
)
\`\`\`

DISTINCT collapses cleanly only when all rule firings for a person share the same \`created_at\`. That holds on a full build (everything built today). It **breaks on partial rebuilds**: PR #733 changed \`get_medication_orders\` / \`get_medication_statements\` macros, triggering rebuild of ~7 \`int_flu_*\` models but not the other ~13. The unchanged ones still carry \`created_at = 2026-05-13\`; the rebuilt ones now have \`created_at = 2026-05-14\`. A person eligible via both old-build and new-build rules gets two distinct rows after DISTINCT, then the LEFT JOIN at line 137 (matched on campaign_id + person_id, not created_at) inflates 2× for that person.

Result: \`fct_flu_status\` jumped from 1,849,340 rows (yesterday) to 2,236,266 rows (today). Difference of 386,926 matches the duplicate count.

## Fix

Replace the SELECT DISTINCT with QUALIFY ROW_NUMBER OVER (PARTITION BY campaign_id, person_id ORDER BY created_at DESC, reference_date DESC) = 1. Picks the most recent rule firing deterministically. Same data shape, no more dupes on partial rebuilds.

## Dev validation

- \`DEV__REPORTING.OLIDS_PROGRAMME.FCT_FLU_STATUS\` after fix:
  - row count: **1,849,322**
  - distinct \`(campaign_id, person_id, status_type)\`: **1,849,322**
  - dupes: **0**

## Follow-up (separate work)

The underlying \`audit_end_date = CURRENT_DATE\` pattern in \`flu_campaign_config.sql\` is build-day-dependent data masquerading as a stable value. It will keep producing similar latent issues anywhere downstream models do DISTINCT including \`created_at\`. A separate PR should make it a \`var()\` so it is stable across partial rebuilds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flu eligibility reporting consistency by using the most recent eligibility record when multiple entries exist for the same person and campaign. This ensures more accurate and deterministic results in eligibility status queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wnl-icb-analytics/dbt-analytics/pull/735)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->