### PR TITLE
feat(dim_practice): surface ODS active status + add dim_practice_active

### DIFF
--- a/models/reporting/olids/organisation/dim_practice.sql
+++ b/models/reporting/olids/organisation/dim_practice.sql
@@ -50,6 +50,10 @@ WITH practice_org_joined AS (
     -- Enhanced practice details from Dictionary Organisation
     dict_org.start_date AS practice_start_date,
     dict_org.end_date AS practice_end_date,
+    dict_org.status AS practice_status,
+    -- Operationally active when ODS marks the practice Active and the end date has not passed
+    (COALESCE(dict_org.status, 'Unknown') = 'Active'
+        AND (dict_org.end_date IS NULL OR dict_org.end_date > CURRENT_DATE())) AS is_active_practice,
     dict_org.address_line_1 AS practice_address_line_1,
     dict_org.address_line_2 AS practice_address_line_2,
     dict_org.address_line_3 AS practice_address_line_3,
@@ -118,6 +122,7 @@ LEFT JOIN (
         organisation_name,
         start_date,
         end_date,
+        status,
         address_line_1,
         address_line_2,
         address_line_3,

--- a/models/reporting/olids/organisation/dim_practice.sql
+++ b/models/reporting/olids/organisation/dim_practice.sql
@@ -78,6 +78,8 @@ WITH practice_org_joined AS (
     dict.stp_code AS icb_code,
     dict.stp_name AS icb_name,
     dict.sk_organisation_id_stp AS sk_icb_id,
+    -- WNL = merged ICB (Z9B2Z) plus legacy NCL (QMJ) and NWL (QRV) codes still in use
+    (dict.stp_code IN ('Z9B2Z', 'QMJ', 'QRV')) AS is_wnl_practice,
     
     -- Dictionary surrogate keys
     dict.sk_organisation_id_practice AS sk_practice_id,

--- a/models/reporting/olids/organisation/dim_practice.yml
+++ b/models/reporting/olids/organisation/dim_practice.yml
@@ -168,6 +168,11 @@ models:
       - name: sk_icb_id
         description: 'Surrogate key for ICB organisation'
 
+      - name: is_wnl_practice
+        description: 'TRUE when practice belongs to West and North London ICB (merged Z9B2Z, or legacy NCL/QMJ and NWL/QRV codes).'
+        tests:
+          - not_null
+
       - name: sk_practice_id
         description: 'Dictionary surrogate key for practice'
 

--- a/models/reporting/olids/organisation/dim_practice.yml
+++ b/models/reporting/olids/organisation/dim_practice.yml
@@ -86,6 +86,14 @@ models:
       - name: practice_end_date
         description: 'Practice end date from Dictionary (NULL if still active)'
 
+      - name: practice_status
+        description: 'ODS practice status from Dictionary (Active, Inactive, or NULL/Unknown)'
+
+      - name: is_active_practice
+        description: 'TRUE when ODS status is Active and end date is NULL or in the future. Use this for filtering to operationally live practices.'
+        tests:
+          - not_null
+
       - name: practice_address_line_1
         description: 'Practice address line 1 from Dictionary'
 

--- a/models/reporting/olids/organisation/dim_practice_active.sql
+++ b/models/reporting/olids/organisation/dim_practice_active.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        materialized='table',
+        tags=['dimension', 'practice', 'organisation'],
+        cluster_by=['practice_code'])
+}}
+
+/*
+Active Practice Dimension
+Filtered variant of dim_practice restricted to operationally active practices
+(ODS status = Active and end date NULL or in the future).
+*/
+
+SELECT *
+FROM {{ ref('dim_practice') }}
+WHERE is_active_practice = TRUE

--- a/models/reporting/olids/organisation/dim_practice_active.yml
+++ b/models/reporting/olids/organisation/dim_practice_active.yml
@@ -1,0 +1,34 @@
+models:
+  - name: dim_practice_active
+    description: 'Active practices only — filtered view of dim_practice where is_active_practice = TRUE
+      (ODS status Active and end date NULL or future). Use when reports should exclude closed,
+      retired, or dormant practices. Column set matches dim_practice.'
+
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: organisation_id
+        description: 'OLIDS internal organisation ID for practice'
+        tests:
+          - not_null
+          - unique
+
+      - name: practice_code
+        description: 'Practice ODS code'
+        tests:
+          - not_null
+
+      - name: practice_name
+        description: 'Cleaned practice name'
+        tests:
+          - not_null
+
+      - name: is_active_practice
+        description: 'Always TRUE in this model'
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true]


### PR DESCRIPTION
## Summary
- Adds `practice_status` and `is_active_practice` columns to [dim_practice](models/reporting/olids/organisation/dim_practice.sql), sourced from `Dictionary.dbo.Organisation` via the existing `dict_org` join.
- `is_active_practice = Status='Active' AND (EndDate IS NULL OR EndDate > CURRENT_DATE())` — combining both checks correctly excludes 8 London practices flagged Active in ODS but with a past EndDate (e.g. Boundary Court Surgery, Clover Health Centre).
- Adds new [dim_practice_active](models/reporting/olids/organisation/dim_practice_active.sql) — a thin filtered variant for consumers that want only operationally live practices.

## Numbers (dev)
Validated against `DEV__REPORTING.OLIDS_ORGANISATION`:
- `dim_practice`: 1,241 total → 1,134 active / 107 inactive
- `dim_practice_active`: 1,134

## Test plan
- [x] `dbt run -s dim_practice dim_practice_active` on dev — both models built successfully
- [x] `dbt test -s dim_practice dim_practice_active` — 18/18 tests pass (incl. new `not_null` on `is_active_practice` and `accepted_values [true]` on the active variant)
- [ ] Reviewer to confirm the Status + EndDate combination is the right authoritative active flag (vs OLIDS `practice_is_obsolete` / `practice_close_date`, which are kept on the base table unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Practice status information is now available in reporting datasets, showing whether a practice is Active, Inactive, or Unknown.
  * New active practice indicator helps identify operationally live practices based on status and end dates.
  * New active practices dataset provides a filtered view containing only currently operational practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wnl-icb-analytics/dbt-analytics/pull/741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->