### PR TITLE
Feat/emis integration into application

### DIFF
--- a/models/published/direct_care/C_LTCS/cltcs_emis_extract.sql
+++ b/models/published/direct_care/C_LTCS/cltcs_emis_extract.sql
@@ -1,0 +1,54 @@
+{{
+    config(
+        materialized='table',
+        tags=['published', 'direct_care', 'c_ltcs', 'emis_extract']
+    )
+}}
+
+with 
+emis as (
+    select * from {{ ref('stg_cltcs_emis_emis') }}
+),
+
+registered_practice as (
+    select
+        cast(sk_patient_id as varchar) as sk_patient_id,
+        practice_code
+    from {{ ref('dim_person_demographics_basic') }}
+    where practice_code is not null
+),
+
+with_pds as (
+    select
+        emis.*,
+        reg.practice_code as pds_registered_practice_code,
+        emis.practice_code is distinct from reg.practice_code
+            as pds_registered_practice_mismatch_flag
+    from emis
+    left join registered_practice reg
+        on emis.sk_patient_id = reg.sk_patient_id
+),
+
+with_olids as (
+    select
+        with_pds.*,
+        dp.current_practice_code as olids_current_practice_code,
+        with_pds.practice_code is distinct from dp.current_practice_code
+            as olids_current_practice_mismatch_flag
+    from with_pds
+    left join {{ ref('dim_person_pseudo') }} pp
+        on with_pds.sk_patient_id = pp.sk_patient_id
+    left join {{ ref('dim_person') }} dp
+        on pp.person_id = dp.person_id
+)
+
+select *
+from with_olids
+qualify
+    case
+        when count_if(not pds_registered_practice_mismatch_flag) over (partition by sk_patient_id) > 0
+            then not pds_registered_practice_mismatch_flag
+        when count_if(not olids_current_practice_mismatch_flag) over (partition by sk_patient_id) > 0
+            then not olids_current_practice_mismatch_flag
+        else true
+    end

--- a/models/published/direct_care/C_LTCS/cltcs_emis_extract.yml
+++ b/models/published/direct_care/C_LTCS/cltcs_emis_extract.yml
@@ -30,7 +30,7 @@ models:
         data_tests:
           - not_null
 
-      - name: registered_practice_code
+      - name: pds_registered_practice_code
         description: GP practice_code from dim_person_demographics_basic (PDS registration)
 
       - name: pds_registered_practice_mismatch_flag

--- a/models/published/direct_care/C_LTCS/cltcs_emis_extract.yml
+++ b/models/published/direct_care/C_LTCS/cltcs_emis_extract.yml
@@ -1,0 +1,42 @@
+version: 2
+
+
+
+models:
+
+  - name: cltcs_emis_extract
+
+    description: >
+
+      CLTCS EMIS extract for direct care, enriched with PDS registered practice from
+      dim_person_demographics_basic. One row per patient when any EMIS usual GP row matches
+      the registered practice; otherwise all usual-GP rows for that patient are retained.
+      registered_practice_mismatch_flag is true when EMIS practice_code differs from PDS
+      registered practice_code.
+
+    columns:
+
+      - name: sk_patient_id
+        data_type: varchar
+        description: Pseudonymised NHS number (surrogate key for patient)
+        data_tests:
+          - not_null
+          - unique:
+              config:
+                severity: warn
+
+      - name: practice_code
+        description: Usual GP organisation code from the EMIS extract
+        data_tests:
+          - not_null
+
+      - name: registered_practice_code
+        description: GP practice_code from dim_person_demographics_basic (PDS registration)
+
+      - name: pds_registered_practice_mismatch_flag
+        description: >
+          True when practice_code is distinct from registered_practice_code
+          (including null vs non-null)
+        data_tests:
+          - not_null
+

--- a/models/staging/pid_env/stg_cltcs_emis_emis.sql
+++ b/models/staging/pid_env/stg_cltcs_emis_emis.sql
@@ -1,108 +1,9 @@
-with emis as (
-    select
-        cast(sk_patient_id as varchar) as sk_patient_id,
-        ltc_lcs,
-        borough,
-        patient_details_usual_gp_s_organisation_code,
-        patient_details_age,
-        patient_details_date_of_birth,
-        patient_details_gender,
-        patient_details_ethnic_origin,
-        patient_details_townsend_score,
-        patient_details_lower_layer_area_2001,
-        patient_details_middle_layer_area_2001,
-        patient_details_lower_layer_area_2011,
-        patient_details_middle_layer_area_2011,
-        record_of_interpreter_information_exists,
-        homelessness_exists,
-        housebound_exists,
-        care_home_resident_exists,
-        cardiovascular_disease_exists,
-        atrial_fibrillation_exists,
-        hypertension_exists,
-        hyperlipidaemia_exists,
-        diabetes_exists,
-        chronic_kidney_disease_exists,
-        na_fatty_liver_disease_exists,
-        copd_exists,
-        asthma_exists,
-        serious_mi_exists,
-        learning_disability_exists,
-        frailty_exists,
-        smoking_status_date,
-        smoking_status_code_term,
-        smoking_status_value,
-        bmi_date,
-        bmi_code_term,
-        bmi_value,
-        o_e_bp_reading_date,
-        o_e_bp_reading_code_term,
-        o_e_bp_reading_value,
-        o_e_bp_reading_secondary_value,
-        hba1_c_date,
-        hba1_c_code_term,
-        hba1_c_value,
-        egfr_date,
-        egfr_code_term,
-        egfr_value,
-        uacr_date,
-        uacr_code_term,
-        uacr_value,
-        tc_date,
-        tc_code_term,
-        tc_value,
-        ldl_date,
-        ldl_code_term,
-        ldl_value,
-        moc_check_test_appointment_on_date,
-        moc_follow_up_appointment_on_date,
-        rpt_count_count,
-        record_source,
-        gp_practice_warning_flag,
-        metadata_file_path,
-        metadata_file_row_number,
-        metadata_record_ingestion_timestamp,
-        metadata_file_content_key,
-        metadata_file_last_modified
-    from {{ ref('raw_cltcs_emis_emis') }}
-    where sk_patient_id is not null
-    qualify row_number() over (
-        partition by
-            cast(sk_patient_id as varchar),
-            patient_details_usual_gp_s_organisation_code
-        order by
-            metadata_record_ingestion_timestamp desc nulls last,
-            metadata_file_last_modified desc nulls last,
-            metadata_file_row_number desc nulls last
-    ) = 1
-),
-
-registered_practice as (
-    select
-        cast(sk_patient_id as varchar) as sk_patient_id,
-        practice_code
-    from {{ ref('dim_person_demographics_basic') }}
-    where practice_code is not null
-),
-
-with_pds as (
-    select
-        emis.*,
-        reg.practice_code as registered_practice_code,
-        emis.patient_details_usual_gp_s_organisation_code is distinct from reg.practice_code
-            as registered_practice_mismatch_flag
-    from emis
-    left join registered_practice reg
-        on emis.sk_patient_id = reg.sk_patient_id
-)
 
 select
-    sk_patient_id,
+    cast(sk_patient_id as varchar) as sk_patient_id,
     ltc_lcs,
     borough,
     patient_details_usual_gp_s_organisation_code as practice_code,
-    registered_practice_code,
-    registered_practice_mismatch_flag,
     patient_details_age as age,
     patient_details_date_of_birth as date_of_birth,
     patient_details_gender as gender,
@@ -157,15 +58,20 @@ select
     moc_follow_up_appointment_on_date,
     rpt_count_count,
     record_source,
-    gp_practice_warning_flag,
     metadata_file_path,
     metadata_file_row_number,
     metadata_record_ingestion_timestamp,
     metadata_file_content_key,
     metadata_file_last_modified
-from with_pds
-qualify
-    count_if(not registered_practice_mismatch_flag) over (
-        partition by sk_patient_id
-    ) = 0
-    or not registered_practice_mismatch_flag
+from {{ ref('raw_cltcs_emis_emis') }}
+where sk_patient_id is not null
+qualify row_number() over (
+    partition by
+        cast(sk_patient_id as varchar),
+        patient_details_usual_gp_s_organisation_code
+    order by
+        metadata_record_ingestion_timestamp desc nulls last,
+        metadata_file_last_modified desc nulls last,
+        metadata_file_row_number desc nulls last
+) = 1
+

--- a/models/staging/pid_env/stg_cltcs_emis_emis.sql
+++ b/models/staging/pid_env/stg_cltcs_emis_emis.sql
@@ -1,0 +1,171 @@
+with emis as (
+    select
+        cast(sk_patient_id as varchar) as sk_patient_id,
+        ltc_lcs,
+        borough,
+        patient_details_usual_gp_s_organisation_code,
+        patient_details_age,
+        patient_details_date_of_birth,
+        patient_details_gender,
+        patient_details_ethnic_origin,
+        patient_details_townsend_score,
+        patient_details_lower_layer_area_2001,
+        patient_details_middle_layer_area_2001,
+        patient_details_lower_layer_area_2011,
+        patient_details_middle_layer_area_2011,
+        record_of_interpreter_information_exists,
+        homelessness_exists,
+        housebound_exists,
+        care_home_resident_exists,
+        cardiovascular_disease_exists,
+        atrial_fibrillation_exists,
+        hypertension_exists,
+        hyperlipidaemia_exists,
+        diabetes_exists,
+        chronic_kidney_disease_exists,
+        na_fatty_liver_disease_exists,
+        copd_exists,
+        asthma_exists,
+        serious_mi_exists,
+        learning_disability_exists,
+        frailty_exists,
+        smoking_status_date,
+        smoking_status_code_term,
+        smoking_status_value,
+        bmi_date,
+        bmi_code_term,
+        bmi_value,
+        o_e_bp_reading_date,
+        o_e_bp_reading_code_term,
+        o_e_bp_reading_value,
+        o_e_bp_reading_secondary_value,
+        hba1_c_date,
+        hba1_c_code_term,
+        hba1_c_value,
+        egfr_date,
+        egfr_code_term,
+        egfr_value,
+        uacr_date,
+        uacr_code_term,
+        uacr_value,
+        tc_date,
+        tc_code_term,
+        tc_value,
+        ldl_date,
+        ldl_code_term,
+        ldl_value,
+        moc_check_test_appointment_on_date,
+        moc_follow_up_appointment_on_date,
+        rpt_count_count,
+        record_source,
+        gp_practice_warning_flag,
+        metadata_file_path,
+        metadata_file_row_number,
+        metadata_record_ingestion_timestamp,
+        metadata_file_content_key,
+        metadata_file_last_modified
+    from {{ ref('raw_cltcs_emis_emis') }}
+    where sk_patient_id is not null
+    qualify row_number() over (
+        partition by
+            cast(sk_patient_id as varchar),
+            patient_details_usual_gp_s_organisation_code
+        order by
+            metadata_record_ingestion_timestamp desc nulls last,
+            metadata_file_last_modified desc nulls last,
+            metadata_file_row_number desc nulls last
+    ) = 1
+),
+
+registered_practice as (
+    select
+        cast(sk_patient_id as varchar) as sk_patient_id,
+        practice_code
+    from {{ ref('dim_person_demographics_basic') }}
+    where practice_code is not null
+),
+
+with_pds as (
+    select
+        emis.*,
+        reg.practice_code as registered_practice_code,
+        emis.patient_details_usual_gp_s_organisation_code is distinct from reg.practice_code
+            as registered_practice_mismatch_flag
+    from emis
+    left join registered_practice reg
+        on emis.sk_patient_id = reg.sk_patient_id
+)
+
+select
+    sk_patient_id,
+    ltc_lcs,
+    borough,
+    patient_details_usual_gp_s_organisation_code as practice_code,
+    registered_practice_code,
+    registered_practice_mismatch_flag,
+    patient_details_age as age,
+    patient_details_date_of_birth as date_of_birth,
+    patient_details_gender as gender,
+    patient_details_ethnic_origin as ethnic_origin,
+    patient_details_townsend_score as townsend_score,
+    patient_details_lower_layer_area_2001 as lower_layer_area_2001,
+    patient_details_middle_layer_area_2001 as middle_layer_area_2001,
+    patient_details_lower_layer_area_2011 as lower_layer_area_2011,
+    patient_details_middle_layer_area_2011 as middle_layer_area_2011,
+    record_of_interpreter_information_exists as record_of_interpreter_information,
+    homelessness_exists as homelessness,
+    housebound_exists as housebound,
+    care_home_resident_exists as care_home_resident,
+    cardiovascular_disease_exists as cardiovascular_disease,
+    atrial_fibrillation_exists as atrial_fibrillation,
+    hypertension_exists as hypertension,
+    hyperlipidaemia_exists as hyperlipidaemia,
+    diabetes_exists as diabetes,
+    chronic_kidney_disease_exists as chronic_kidney_disease,
+    na_fatty_liver_disease_exists as na_fatty_liver_disease,
+    copd_exists as copd,
+    asthma_exists as asthma,
+    serious_mi_exists as serious_mi,
+    learning_disability_exists as learning_disability,
+    frailty_exists as frailty,
+    smoking_status_date,
+    smoking_status_code_term as smoking_status_code,
+    smoking_status_value,
+    bmi_date,
+    bmi_code_term as bmi_code,
+    bmi_value,
+    o_e_bp_reading_date,
+    o_e_bp_reading_code_term as o_e_bp_reading_code,
+    o_e_bp_reading_value,
+    o_e_bp_reading_secondary_value,
+    hba1_c_date,
+    hba1_c_code_term as hba1_c_code,
+    hba1_c_value,
+    egfr_date,
+    egfr_code_term as egfr_code,
+    egfr_value,
+    uacr_date,
+    uacr_code_term as uacr_code,
+    uacr_value,
+    tc_date,
+    tc_code_term as tc_code,
+    tc_value,
+    ldl_date,
+    ldl_code_term as ldl_code,
+    ldl_value,
+    moc_check_test_appointment_on_date,
+    moc_follow_up_appointment_on_date,
+    rpt_count_count,
+    record_source,
+    gp_practice_warning_flag,
+    metadata_file_path,
+    metadata_file_row_number,
+    metadata_record_ingestion_timestamp,
+    metadata_file_content_key,
+    metadata_file_last_modified
+from with_pds
+qualify
+    count_if(not registered_practice_mismatch_flag) over (
+        partition by sk_patient_id
+    ) = 0
+    or not registered_practice_mismatch_flag

--- a/models/staging/pid_env/stg_cltcs_emis_emis.yml
+++ b/models/staging/pid_env/stg_cltcs_emis_emis.yml
@@ -5,6 +5,10 @@ models:
       One row per sk_patient_id and usual GP organisation code (practice_code), keeping the
       latest ingested record when duplicates exist. PDS registration filtering is applied in
       cltcs_emis_extract.
+    config:
+      meta:
+        owner:
+          name: em-baldwin
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/staging/pid_env/stg_cltcs_emis_emis.yml
+++ b/models/staging/pid_env/stg_cltcs_emis_emis.yml
@@ -2,35 +2,23 @@ models:
   - name: stg_cltcs_emis_emis
     description: >
       CLTCS EMIS extract (clinical and demographic patient attributes). Source raw_cltcs_emis_emis.
-      Latest ingest per sk_patient_id and usual GP organisation code, then one row per patient when
-      any row matches PDS registered practice_code from dim_person_demographics_basic; if none match,
-      all EMIS GP rows are retained. registered_practice_mismatch_flag is true when EMIS usual GP
-      organisation code is distinct from PDS registered practice_code.
-      data_tests:
-        - not_null
-        - unique:
-            config:
-              severity: warn
+      One row per sk_patient_id and usual GP organisation code (practice_code), keeping the
+      latest ingested record when duplicates exist. PDS registration filtering is applied in
+      cltcs_emis_extract.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - sk_patient_id
+              - practice_code
     columns:
       - name: sk_patient_id
         data_type: varchar
         description: Pseudonymised NHS number (surrogate key for patient)
         data_tests:
           - not_null
-          - unique:
-              config:
-                severity: warn
 
       - name: practice_code
         description: Usual GP organisation code from the EMIS extract
-        data_tests:
-          - not_null
-          
-      - name: registered_practice_code
-        description: GP practice_code from dim_person_demographics_basic (PDS registration)
-      - name: registered_practice_mismatch_flag
-        description: >
-          True when practice_code is distinct from registered_practice_code
-          (including null vs non-null)
         data_tests:
           - not_null

--- a/models/staging/pid_env/stg_cltcs_emis_emis.yml
+++ b/models/staging/pid_env/stg_cltcs_emis_emis.yml
@@ -1,0 +1,36 @@
+models:
+  - name: stg_cltcs_emis_emis
+    description: >
+      CLTCS EMIS extract (clinical and demographic patient attributes). Source raw_cltcs_emis_emis.
+      Latest ingest per sk_patient_id and usual GP organisation code, then one row per patient when
+      any row matches PDS registered practice_code from dim_person_demographics_basic; if none match,
+      all EMIS GP rows are retained. registered_practice_mismatch_flag is true when EMIS usual GP
+      organisation code is distinct from PDS registered practice_code.
+      data_tests:
+        - not_null
+        - unique:
+            config:
+              severity: warn
+    columns:
+      - name: sk_patient_id
+        data_type: varchar
+        description: Pseudonymised NHS number (surrogate key for patient)
+        data_tests:
+          - not_null
+          - unique:
+              config:
+                severity: warn
+
+      - name: practice_code
+        description: Usual GP organisation code from the EMIS extract
+        data_tests:
+          - not_null
+          
+      - name: registered_practice_code
+        description: GP practice_code from dim_person_demographics_basic (PDS registration)
+      - name: registered_practice_mismatch_flag
+        description: >
+          True when practice_code is distinct from registered_practice_code
+          (including null vs non-null)
+        data_tests:
+          - not_null

--- a/models/staging/pid_env/stg_cltcs_emis_ptl.sql
+++ b/models/staging/pid_env/stg_cltcs_emis_ptl.sql
@@ -1,0 +1,16 @@
+select
+    cast(sk_patient_id as varchar) as sk_patient_id,
+    pcn_code,
+    record_source,
+    demographics_date_of_mdt,
+    summaries_desktop_review_outcome,
+    mdt_impact_score,
+    mdt_clinician_value,
+    mdt_suitable_case_study,
+    metadata_file_path,
+    metadata_file_row_number,
+    metadata_record_ingestion_timestamp,
+    metadata_file_content_key,
+    metadata_file_last_modified
+from {{ ref('raw_cltcs_emis_ptl') }}
+where sk_patient_id is not null

--- a/models/staging/pid_env/stg_cltcs_emis_ptl.yml
+++ b/models/staging/pid_env/stg_cltcs_emis_ptl.yml
@@ -1,0 +1,12 @@
+models:
+  - name: stg_cltcs_emis_ptl
+    description: CLTCS EMIS PTL extract (patient tracking list / MDT outcomes). Source raw_cltcs_emis_ptl.
+    columns:
+      - name: sk_patient_id
+        data_type: varchar
+        description: Pseudonymised NHS number (surrogate key for patient)
+        data_tests:
+          - not_null
+          - unique:
+              config:
+                severity: warn

--- a/models/staging/pid_env/stg_cltcs_emis_ptl.yml
+++ b/models/staging/pid_env/stg_cltcs_emis_ptl.yml
@@ -1,6 +1,10 @@
 models:
   - name: stg_cltcs_emis_ptl
     description: CLTCS EMIS PTL extract (patient tracking list / MDT outcomes). Source raw_cltcs_emis_ptl.
+    config:
+      meta:
+        owner:
+          name: em-baldwin
     columns:
       - name: sk_patient_id
         data_type: varchar


### PR DESCRIPTION
Deduplicating EMIS extract (multiple GPs) first via PDS then via OLIDs, keeping both if neither matches (for clinical review)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new CLTCS EMIS data extract for direct care, consolidating patient and practice information with automatic flagging of discrepancies between EMIS and registered practice codes.

* **Tests**
  * Added comprehensive data quality validation including uniqueness checks and null value verification across key patient and practice identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wnl-icb-analytics/dbt-analytics/pull/745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->