### PR TITLE
feat(semantic): expand biomarker coverage, observation history view

### DIFF
--- a/models/modelling/olids/observations/int_observation_events_long.sql
+++ b/models/modelling/olids/observations/int_observation_events_long.sql
@@ -1,0 +1,156 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'observation_type'])
+}}
+
+/*
+Long-format biomarker observation history — one row per observation event.
+
+Unions the per-observation "_all" biomarker models into a single tall table
+(person_id, observation_type, clinical_effective_date, value, unit, category)
+so that serial / latest-N / trajectory questions can be answered with window
+functions over a single grain. The latest-only models (int_*_latest) and the
+sem_olids_observations view answer "current value" questions; this model and
+sem_olids_observations_history answer "over time" questions.
+
+Why long, not wide: the source _all models are many-rows-per-person with
+divergent schemas. Co-joining them on person_id would fan out (cartesian).
+Stacking them long keeps a single, safe grain and a uniform shape, at the
+cost of a generic VARCHAR category per type.
+
+Blood pressure emits two rows per reading (Systolic BP, Diastolic BP).
+
+Count-style markers (haemoglobin, platelets, eosinophils, ALT, GGT, bilirubin)
+are filtered to confidence != 'NONE' and non-negative, matching their _latest
+models. Typed markers are included where the value is non-null.
+*/
+
+WITH events AS (
+
+    -- Cardiovascular: Blood Pressure (one row each for systolic and diastolic)
+    SELECT person_id, systolic_observation_id AS source_observation_id,
+        'Systolic BP' AS observation_type, 'Cardiovascular' AS observation_group,
+        clinical_effective_date, systolic_value::FLOAT AS value, 'mmHg' AS unit,
+        (CASE WHEN is_hypertensive_range THEN 'Hypertensive range' ELSE 'Below hypertensive range' END)::VARCHAR AS category
+    FROM {{ ref('int_blood_pressure_all') }}
+    WHERE systolic_value IS NOT NULL
+
+    UNION ALL
+    SELECT person_id, diastolic_observation_id AS source_observation_id,
+        'Diastolic BP', 'Cardiovascular',
+        clinical_effective_date, diastolic_value::FLOAT, 'mmHg',
+        NULL::VARCHAR
+    FROM {{ ref('int_blood_pressure_all') }}
+    WHERE diastolic_value IS NOT NULL
+
+    -- Cardiovascular: Cholesterol, LDL, QRISK
+    UNION ALL
+    SELECT person_id, id, 'Total Cholesterol', 'Cardiovascular',
+        clinical_effective_date, cholesterol_value::FLOAT, 'mmol/L', cholesterol_category::VARCHAR
+    FROM {{ ref('int_cholesterol_all') }}
+    WHERE cholesterol_value IS NOT NULL
+
+    UNION ALL
+    SELECT person_id, id, 'LDL Cholesterol', 'Cardiovascular',
+        clinical_effective_date, cholesterol_value::FLOAT, 'mmol/L', LDL_CVD_Target_Met::VARCHAR
+    FROM {{ ref('int_cholesterol_ldl_all') }}
+    WHERE cholesterol_value IS NOT NULL
+
+    UNION ALL
+    SELECT person_id, id, 'QRISK', 'Cardiovascular',
+        clinical_effective_date, qrisk_score::FLOAT, '%', cvd_risk_category::VARCHAR
+    FROM {{ ref('int_qrisk_all') }}
+    WHERE qrisk_score IS NOT NULL
+
+    -- Metabolic: HbA1c, BMI, Waist circumference
+    UNION ALL
+    SELECT person_id, id, 'HbA1c', 'Metabolic',
+        clinical_effective_date, hba1c_ifcc::FLOAT, 'mmol/mol', hba1c_category::VARCHAR
+    FROM {{ ref('int_hba1c_all') }}
+    WHERE hba1c_ifcc IS NOT NULL
+
+    UNION ALL
+    SELECT person_id, id, 'BMI', 'Metabolic',
+        clinical_effective_date, bmi_value::FLOAT, 'kg/m2', bmi_category::VARCHAR
+    FROM {{ ref('int_bmi_all') }}
+    WHERE bmi_value IS NOT NULL
+
+    UNION ALL
+    SELECT person_id, id, 'Waist Circumference', 'Metabolic',
+        clinical_effective_date, waist_circumference_value::FLOAT, 'cm', waist_risk_category::VARCHAR
+    FROM {{ ref('int_waist_circumference_all') }}
+    WHERE waist_circumference_value IS NOT NULL
+
+    -- Renal: eGFR, Creatinine, Urine ACR
+    UNION ALL
+    SELECT person_id, id, 'eGFR', 'Renal',
+        clinical_effective_date, egfr_value::FLOAT, 'mL/min/1.73m2', ckd_stage::VARCHAR
+    FROM {{ ref('int_egfr_all') }}
+    WHERE egfr_value IS NOT NULL
+
+    UNION ALL
+    SELECT person_id, id, 'Creatinine', 'Renal',
+        clinical_effective_date, creatinine_value::FLOAT, 'umol/L', creatinine_category::VARCHAR
+    FROM {{ ref('int_creatinine_all') }}
+    WHERE creatinine_value IS NOT NULL
+
+    UNION ALL
+    SELECT person_id, id, 'Urine ACR', 'Renal',
+        clinical_effective_date, acr_value::FLOAT, 'mg/mmol', acr_category::VARCHAR
+    FROM {{ ref('int_urine_acr_all') }}
+    WHERE acr_value IS NOT NULL
+
+    -- Liver: ALT, GGT, Bilirubin
+    UNION ALL
+    SELECT person_id, id, 'ALT', 'Liver',
+        clinical_effective_date, inferred_value::FLOAT, inferred_unit::VARCHAR, alt_category::VARCHAR
+    FROM {{ ref('int_alt_all') }}
+    WHERE confidence != 'NONE' AND NOT is_negative AND inferred_value IS NOT NULL
+
+    UNION ALL
+    SELECT person_id, id, 'GGT', 'Liver',
+        clinical_effective_date, inferred_value::FLOAT, inferred_unit::VARCHAR, ggt_category::VARCHAR
+    FROM {{ ref('int_ggt_all') }}
+    WHERE confidence != 'NONE' AND NOT is_negative AND inferred_value IS NOT NULL
+
+    UNION ALL
+    SELECT person_id, id, 'Bilirubin', 'Liver',
+        clinical_effective_date, inferred_value::FLOAT, inferred_unit::VARCHAR, bilirubin_category::VARCHAR
+    FROM {{ ref('int_bilirubin_all') }}
+    WHERE confidence != 'NONE' AND NOT is_negative AND inferred_value IS NOT NULL
+
+    -- Haematology: Haemoglobin, Platelets, Eosinophils
+    UNION ALL
+    SELECT person_id, id, 'Haemoglobin', 'Haematology',
+        clinical_effective_date, inferred_value::FLOAT, inferred_unit::VARCHAR, haemoglobin_category::VARCHAR
+    FROM {{ ref('int_haemoglobin_all') }}
+    WHERE confidence != 'NONE' AND NOT is_negative AND inferred_value IS NOT NULL
+
+    UNION ALL
+    SELECT person_id, id, 'Platelets', 'Haematology',
+        clinical_effective_date, inferred_value::FLOAT, inferred_unit::VARCHAR, platelets_category::VARCHAR
+    FROM {{ ref('int_platelets_all') }}
+    WHERE confidence != 'NONE' AND NOT is_negative AND inferred_value IS NOT NULL
+
+    UNION ALL
+    SELECT person_id, id, 'Eosinophils', 'Haematology',
+        clinical_effective_date, inferred_value::FLOAT, inferred_unit::VARCHAR, eosinophil_category::VARCHAR
+    FROM {{ ref('int_eosinophil_count') }}
+    WHERE confidence != 'NONE' AND NOT is_negative AND inferred_value IS NOT NULL
+)
+
+SELECT
+    {{ dbt_utils.generate_surrogate_key([
+        'person_id', 'observation_type', 'clinical_effective_date',
+        'source_observation_id', 'value'
+    ]) }} AS observation_event_id,
+    person_id,
+    observation_type,
+    observation_group,
+    clinical_effective_date,
+    value,
+    unit,
+    category,
+    source_observation_id
+FROM events

--- a/models/modelling/olids/observations/int_observation_events_long.yml
+++ b/models/modelling/olids/observations/int_observation_events_long.yml
@@ -1,0 +1,56 @@
+version: 2
+
+models:
+  - name: int_observation_events_long
+    description: |
+      Long-format biomarker observation history. One row per observation event
+      across blood pressure (systolic + diastolic), cholesterol, LDL, QRISK,
+      HbA1c, BMI, waist circumference, eGFR, creatinine, urine ACR, ALT, GGT,
+      bilirubin, haemoglobin, platelets, and eosinophils.
+
+      Backs sem_olids_observations_history. Supports serial / latest-N /
+      trajectory questions via window functions over (person_id,
+      observation_type) ordered by clinical_effective_date.
+
+      Full history, not capped at 60 months. OLIDS retains full history for
+      currently-registered persons but only ~5 years for left/deceased, so
+      pre-5-year rows are survivor-biased toward current registrants — fine for
+      per-person trajectories, not for long-run population cross-sections.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: observation_event_id
+        description: Surrogate key per observation event. Best-effort unique across person/type/date/source id/value.
+        tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: Person identifier (joins to dim_person_demographics).
+        tests:
+          - not_null
+      - name: observation_type
+        description: >
+          Biomarker label (Systolic BP, Diastolic BP, Total Cholesterol,
+          LDL Cholesterol, QRISK, HbA1c, BMI, Waist Circumference, eGFR,
+          Creatinine, Urine ACR, ALT, GGT, Bilirubin, Haemoglobin, Platelets,
+          Eosinophils). Filter to a single type before aggregating value.
+        tests:
+          - not_null
+      - name: observation_group
+        description: Clinical group (Cardiovascular, Metabolic, Renal, Liver, Haematology).
+        tests:
+          - not_null
+      - name: clinical_effective_date
+        description: Date of the observation.
+        tests:
+          - not_null
+      - name: value
+        description: Numeric result in the unit given by `unit`. Only comparable within a single observation_type.
+      - name: unit
+        description: Unit of measure for `value`.
+      - name: category
+        description: Type-specific clinical category label for this reading (VARCHAR; meaning varies by observation_type).
+      - name: source_observation_id
+        description: Source observation id from the originating _all model (traceability).

--- a/models/modelling/olids/observations/int_observation_events_long.yml
+++ b/models/modelling/olids/observations/int_observation_events_long.yml
@@ -23,12 +23,12 @@ models:
     columns:
       - name: observation_event_id
         description: Surrogate key per observation event. Best-effort unique across person/type/date/source id/value.
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: person_id
         description: Person identifier (joins to dim_person_demographics).
-        tests:
+        data_tests:
           - not_null
       - name: observation_type
         description: >
@@ -36,15 +36,15 @@ models:
           LDL Cholesterol, QRISK, HbA1c, BMI, Waist Circumference, eGFR,
           Creatinine, Urine ACR, ALT, GGT, Bilirubin, Haemoglobin, Platelets,
           Eosinophils). Filter to a single type before aggregating value.
-        tests:
+        data_tests:
           - not_null
       - name: observation_group
         description: Clinical group (Cardiovascular, Metabolic, Renal, Liver, Haematology).
-        tests:
+        data_tests:
           - not_null
       - name: clinical_effective_date
         description: Date of the observation.
-        tests:
+        data_tests:
           - not_null
       - name: value
         description: Numeric result in the unit given by `unit`. Only comparable within a single observation_type.

--- a/models/semantic/sem_olids_appointments.sql
+++ b/models/semantic/sem_olids_appointments.sql
@@ -98,7 +98,6 @@ DIMENSIONS(
     appt.practitioner_role_group AS practitioner_role_group WITH SYNONYMS = ('HCP type', 'staff type', 'role') COMMENT = 'Analytical role grouping (GP, Nurse, Pharmacist, HCA, Physician Associate, Paramedic, Physiotherapist, Care Navigator, Counsellor, Mental Health Practitioner, Health & Wellbeing Coach, Social Prescriber, Dietitian, Podiatrist, Occupational Therapist, Other Direct Patient Care, Admin/Non-Clinical, Unknown)',
     appt.sds_role_group AS sds_role_group WITH SYNONYMS = ('SDS group', 'NHS role group') COMMENT = 'Official NHS Digital SDS role group (GP, Nurses, Other Direct Patient Care, Admin/Data Quality, Unknown) — aligns with national GPAD publications',
     appt.role_name AS role_name COMMENT = 'Raw practitioner role name as recorded by the practice',
-    appt.practitioner_name AS practitioner_name COMMENT = 'Clinician full name — personal data, restrict access accordingly',
     appt.is_arrs_role AS is_arrs_role WITH SYNONYMS = ('ARRS', 'additional roles') COMMENT = 'TRUE where the SDS code unambiguously identifies an ARRS-scheme role',
     appt.schedule_type AS schedule_type COMMENT = 'Raw schedule type from OLIDS',
     appt.is_untimed_session AS is_untimed_session COMMENT = 'TRUE if parent schedule is an open/untimed session (duty doctor, eConsult list). Duration is NULL for these.',
@@ -127,7 +126,9 @@ DIMENSIONS(
     demographics.age_life_stage AS age_life_stage COMMENT = 'Current life stage (Infant, Toddler, Child, Adolescent, Young Adult, Adult, Older Adult, Elderly, Very Elderly, Unknown). Drifts — use age_at_event for historical.',
     demographics.ethnicity_category AS ethnicity_category COMMENT = 'Ethnicity category (Asian or Asian British, Black or Black British, Mixed, Other, White, Unknown)',
     demographics.ethnicity_subcategory AS ethnicity_subcategory COMMENT = 'Ethnicity subcategory (White: British, White: Irish, White: Roma, White: Traveller, White: Other White, Mixed: White and Black Caribbean, Mixed: White and Black African, Mixed: White and Asian, Mixed: Other Mixed, Asian: Indian, Asian: Pakistani, Asian: Bangladeshi, Asian: Chinese, Asian: Other Asian, Black: African, Black: Caribbean, Black: Other Black, Other: Arab, Other: Other, Unknown, Not Stated, Not Recorded, Recorded Not Known, Refused)',
+    demographics.ethnicity_granular AS ethnicity_granular COMMENT = 'Detailed ethnicity classification (Unknown if not recorded)',
     demographics.main_language AS main_language COMMENT = 'Main spoken language (Not Recorded if unknown)',
+    demographics.interpreter_needed AS interpreter_needed COMMENT = 'Whether interpreter is required',
 
     -- Patient registration status
     demographics.is_active AS is_active COMMENT = 'Patient currently registered with an NCL GP practice',
@@ -137,6 +138,7 @@ DIMENSIONS(
     demographics.ward_code AS ward_code COMMENT = 'Patient electoral ward 2025 code (residence-based)',
     demographics.ward_name AS ward_name COMMENT = 'Patient electoral ward 2025 name (residence-based)',
     demographics.borough_resident AS borough_resident COMMENT = 'Patient borough of residence',
+    demographics.is_london_resident AS is_london_resident COMMENT = 'Patient resides in Greater London',
     demographics.neighbourhood_resident AS neighbourhood_resident COMMENT = 'Patient NCL neighbourhood of residence',
 
     -- Deprivation (patient residence)

--- a/models/semantic/sem_olids_observations.sql
+++ b/models/semantic/sem_olids_observations.sql
@@ -26,6 +26,8 @@
     - Cardiovascular: BP, BP control, cholesterol, LDL, QRISK
     - Metabolic: HbA1c, BMI, waist circumference
     - Renal: eGFR (CKD staging), creatinine, urine ACR
+    - Liver: ALT, GGT, bilirubin, composite high-LFT flag
+    - Haematology: haemoglobin (anaemia), platelets, eosinophils
     - Frailty: Electronic Frailty Index (eFI/eFI2), Rockwood Clinical Frailty Scale
     - Diabetes care: Foot examination, retinal screening, DM 8 care processes
 #}
@@ -97,7 +99,23 @@ TABLES(
 
     dm8cp AS {{ ref('fct_person_diabetes_8_care_processes') }}
         PRIMARY KEY (person_id)
-        COMMENT = 'Diabetes 8 care processes completion status (12-month lookback). Only populated for persons on the diabetes register.'
+        COMMENT = 'Diabetes 8 care processes completion status (12-month lookback). Only populated for persons on the diabetes register.',
+
+    lft AS {{ ref('int_lft_latest') }}
+        PRIMARY KEY (person_id)
+        COMMENT = 'Latest liver function tests (ALT, GGT, bilirubin) with high flags vs clinical upper reference limits. Pairs with NAFLD/chronic liver disease registers.',
+
+    haemoglobin AS {{ ref('int_haemoglobin_latest') }}
+        PRIMARY KEY (person_id)
+        COMMENT = 'Latest haemoglobin with anaemia category',
+
+    platelets AS {{ ref('int_platelets_latest') }}
+        PRIMARY KEY (person_id)
+        COMMENT = 'Latest platelet count with category',
+
+    eosinophils AS {{ ref('int_eosinophil_count_latest') }}
+        PRIMARY KEY (person_id)
+        COMMENT = 'Latest blood eosinophil count with category. Relevant to asthma/COPD phenotyping and biologic eligibility.'
 )
 
 RELATIONSHIPS(
@@ -116,7 +134,11 @@ RELATIONSHIPS(
     rockwood (person_id) REFERENCES demographics,
     foot_exam (person_id) REFERENCES demographics,
     retinal (person_id) REFERENCES demographics,
-    dm8cp (person_id) REFERENCES demographics
+    dm8cp (person_id) REFERENCES demographics,
+    lft (person_id) REFERENCES demographics,
+    haemoglobin (person_id) REFERENCES demographics,
+    platelets (person_id) REFERENCES demographics,
+    eosinophils (person_id) REFERENCES demographics
 )
 
 FACTS(
@@ -137,6 +159,16 @@ FACTS(
     egfr.egfr_value AS egfr_value COMMENT = 'eGFR value (mL/min/1.73m2)',
     creatinine.creatinine_value AS creatinine_value COMMENT = 'Serum creatinine (umol/L)',
     acr.acr_value AS acr_value COMMENT = 'Urine ACR (mg/mmol)',
+
+    -- Liver function
+    lft.alt_value AS alt_value WITH SYNONYMS = ('ALT', 'alanine aminotransferase') COMMENT = 'Latest ALT (U/L)',
+    lft.ggt_value AS ggt_value WITH SYNONYMS = ('GGT', 'gamma GT') COMMENT = 'Latest GGT (U/L)',
+    lft.bilirubin_value AS bilirubin_value COMMENT = 'Latest total bilirubin (umol/L)',
+
+    -- Haematology
+    haemoglobin.inferred_value AS haemoglobin_value WITH SYNONYMS = ('Hb', 'haemoglobin') COMMENT = 'Latest haemoglobin (g/L)',
+    platelets.inferred_value AS platelet_count WITH SYNONYMS = ('platelets', 'PLT') COMMENT = 'Latest platelet count (10^9/L)',
+    eosinophils.inferred_value AS eosinophil_count WITH SYNONYMS = ('eosinophils', 'eos') COMMENT = 'Latest blood eosinophil count (10^9/L)',
 
     -- Frailty
     efi.latest_efi_score_preferred AS latest_efi_score_preferred COMMENT = 'Electronic Frailty Index score (0-1). Uses most recent of eFI or eFI2.',
@@ -166,6 +198,10 @@ DIMENSIONS(
     rockwood.latest_rockwood_date AS clinical_effective_date COMMENT = 'Date of latest Rockwood assessment',
     foot_exam.latest_foot_exam_date AS clinical_effective_date COMMENT = 'Date of latest foot examination',
     retinal.latest_retinal_date AS clinical_effective_date COMMENT = 'Date of latest retinal screening',
+    lft.last_lft_date AS clinical_effective_date COMMENT = 'Date of latest liver function test (most recent of ALT/GGT/bilirubin)',
+    haemoglobin.clinical_effective_date AS clinical_effective_date COMMENT = 'Date of latest haemoglobin',
+    platelets.clinical_effective_date AS clinical_effective_date COMMENT = 'Date of latest platelet count',
+    eosinophils.clinical_effective_date AS clinical_effective_date COMMENT = 'Date of latest eosinophil count',
 
     -- Core Demographics
     demographics.gender AS gender COMMENT = 'Patient gender (Male, Female, Unknown)',
@@ -177,13 +213,18 @@ DIMENSIONS(
     demographics.age_life_stage AS age_life_stage COMMENT = 'Life stage (Infant, Toddler, Child, Adolescent, Young Adult, Adult, Older Adult, Elderly, Very Elderly, Unknown)',
     demographics.ethnicity_category AS ethnicity_category COMMENT = 'Ethnicity category (Asian or Asian British, Black or Black British, Mixed, Other, White, Unknown)',
     demographics.ethnicity_subcategory AS ethnicity_subcategory COMMENT = 'Ethnicity subcategory (White: British, White: Irish, White: Roma, White: Traveller, White: Other White, Mixed: White and Black Caribbean, Mixed: White and Black African, Mixed: White and Asian, Mixed: Other Mixed, Asian: Indian, Asian: Pakistani, Asian: Bangladeshi, Asian: Chinese, Asian: Other Asian, Black: African, Black: Caribbean, Black: Other Black, Other: Arab, Other: Other, Unknown, Not Stated, Not Recorded, Recorded Not Known, Refused)',
+    demographics.ethnicity_granular AS ethnicity_granular COMMENT = 'Detailed ethnicity classification (Unknown if not recorded)',
+    demographics.main_language AS main_language COMMENT = 'Main spoken language (Not Recorded if unknown)',
+    demographics.interpreter_needed AS interpreter_needed COMMENT = 'Whether interpreter is required',
     demographics.is_active AS is_active COMMENT = 'Currently registered',
+    demographics.is_deceased AS is_deceased COMMENT = 'Deceased status',
 
     -- Organisation
     demographics.practice_code AS practice_code COMMENT = 'GP practice ODS code',
     demographics.practice_name AS practice_name COMMENT = 'GP practice name',
     demographics.pcn_code AS pcn_code COMMENT = 'Primary Care Network code',
     demographics.pcn_name AS pcn_name COMMENT = 'Primary Care Network name',
+    demographics.pcn_name_with_borough AS pcn_name_with_borough COMMENT = 'PCN name with borough prefix',
     demographics.borough_registered AS borough_registered COMMENT = 'Registration borough',
     demographics.sub_icb_code AS sub_icb_code COMMENT = 'Sub-ICB / place-based partnership ODS code of the registered practice: QMJ = NHS North Central London (Camden, Islington, Barnet, Enfield, Haringey); QRV = NHS North West London (Brent, Ealing, Hammersmith and Fulham, Harrow, Hillingdon, Hounslow, Kensington and Chelsea, Westminster). NULL outside the WNL footprint.',
     demographics.sub_icb_name AS sub_icb_name COMMENT = 'Sub-ICB display name (NHS North Central London or NHS North West London) of the registered practice. NULL outside the WNL footprint.',
@@ -194,6 +235,7 @@ DIMENSIONS(
     demographics.ward_code AS ward_code COMMENT = 'Electoral ward 2025 code',
     demographics.ward_name AS ward_name COMMENT = 'Electoral ward 2025 name',
     demographics.borough_resident AS borough_resident COMMENT = 'Residence borough',
+    demographics.is_london_resident AS is_london_resident COMMENT = 'Resides in Greater London',
     demographics.neighbourhood_resident AS neighbourhood_resident COMMENT = 'Residence neighbourhood',
 
     -- Deprivation
@@ -261,6 +303,17 @@ DIMENSIONS(
     acr.is_microalbuminuria AS is_microalbuminuria COMMENT = 'Microalbuminuria present',
     acr.is_macroalbuminuria AS is_macroalbuminuria COMMENT = 'Macroalbuminuria present',
 
+    -- Liver Function
+    lft.is_high_alt AS is_high_alt COMMENT = 'ALT above clinical upper reference limit',
+    lft.is_high_ggt AS is_high_ggt COMMENT = 'GGT above clinical upper reference limit',
+    lft.is_high_bilirubin AS is_high_bilirubin COMMENT = 'Bilirubin above clinical upper reference limit',
+    lft.high_lft AS high_lft WITH SYNONYMS = ('abnormal LFT', 'deranged LFTs') COMMENT = 'Any of ALT/GGT/bilirubin above its upper reference limit',
+
+    -- Haematology
+    haemoglobin.haemoglobin_category AS haemoglobin_category WITH SYNONYMS = ('anaemia category') COMMENT = 'Haemoglobin category (e.g. Anaemia, Normal, High)',
+    platelets.platelets_category AS platelets_category WITH SYNONYMS = ('thrombocytopenia category') COMMENT = 'Platelet count category (e.g. Low, Normal, High)',
+    eosinophils.eosinophil_category AS eosinophil_category COMMENT = 'Eosinophil count category (e.g. Normal, Raised). Raised eosinophils inform asthma/COPD biologic eligibility.',
+
     -- Electronic Frailty Index
     efi.latest_efi_type_preferred AS latest_efi_type_preferred COMMENT = 'eFI algorithm type (EFI, EFI2). Uses most recent available. Only where explicitly GP-coded.',
     efi.latest_efi_category_preferred AS latest_efi_category_preferred WITH SYNONYMS = ('frailty category', 'eFI category') COMMENT = 'eFI frailty category (Fit, Mildly Frail, Moderately Frail, Severely Frail). Only where explicitly GP-coded — not dynamically estimated. Coverage is incomplete. For population frailty prevalence, use has_frailty from sem_olids_population instead.',
@@ -311,7 +364,7 @@ METRICS(
     -- HbA1c
     hba1c.patients_with_hba1c AS COUNT(DISTINCT hba1c.person_id) COMMENT = 'Patients with HbA1c',
     hba1c.hba1c_at_target_count AS COUNT(DISTINCT CASE WHEN hba1c.meets_qof_target THEN hba1c.person_id END) COMMENT = 'Patients with HbA1c at QOF target',
-    hba1c.hba1c_above_target_count AS COUNT(DISTINCT CASE WHEN NOT hba1c.meets_qof_target AND hba1c.person_id IS NOT NULL THEN hba1c.person_id END) COMMENT = 'Patients with HbA1c above QOF target',
+    hba1c.hba1c_above_target_count AS COUNT(DISTINCT CASE WHEN NOT hba1c.meets_qof_target THEN hba1c.person_id END) COMMENT = 'Patients with HbA1c above QOF target',
     hba1c.hba1c_high_risk_count AS COUNT(DISTINCT CASE WHEN hba1c.hba1c_category = 'Diabetes - High Risk' THEN hba1c.person_id END) COMMENT = 'Patients with HbA1c 75-85 (high risk)',
     hba1c.hba1c_very_high_risk_count AS COUNT(DISTINCT CASE WHEN hba1c.hba1c_category = 'Diabetes - Very High Risk' THEN hba1c.person_id END) COMMENT = 'Patients with HbA1c >=86 (very high risk)',
     hba1c.hba1c_poor_control_count AS COUNT(DISTINCT CASE WHEN hba1c.hba1c_category IN ('Diabetes - High Risk', 'Diabetes - Very High Risk') THEN hba1c.person_id END) COMMENT = 'Patients with HbA1c >=75 (poor control)',
@@ -381,6 +434,15 @@ METRICS(
     dm8cp.dm_patients_count AS COUNT(DISTINCT dm8cp.person_id) COMMENT = 'Patients on diabetes register (in DM 8CP model)',
     dm8cp.dm_all_8cp_count AS COUNT(DISTINCT CASE WHEN dm8cp.all_processes_completed THEN dm8cp.person_id END) COMMENT = 'DM patients with all 8 care processes completed',
 
+    -- Liver Function
+    lft.patients_with_lft AS COUNT(DISTINCT lft.person_id) COMMENT = 'Patients with any liver function test',
+    lft.high_lft_count AS COUNT(DISTINCT CASE WHEN lft.high_lft THEN lft.person_id END) COMMENT = 'Patients with any abnormal LFT (ALT/GGT/bilirubin above reference)',
+
+    -- Haematology
+    haemoglobin.patients_with_haemoglobin AS COUNT(DISTINCT haemoglobin.person_id) COMMENT = 'Patients with haemoglobin',
+    platelets.patients_with_platelets AS COUNT(DISTINCT platelets.person_id) COMMENT = 'Patients with platelet count',
+    eosinophils.patients_with_eosinophils AS COUNT(DISTINCT eosinophils.person_id) COMMENT = 'Patients with eosinophil count',
+
     -- Averages
     bp.avg_systolic_bp AS AVG(bp.systolic_value) COMMENT = 'Average systolic BP',
     bp.avg_diastolic_bp AS AVG(bp.diastolic_value) COMMENT = 'Average diastolic BP',
@@ -393,9 +455,14 @@ METRICS(
     acr.avg_acr AS AVG(acr.acr_value) COMMENT = 'Average ACR',
     efi.avg_efi_score AS AVG(efi.latest_efi_score_preferred) COMMENT = 'Average eFI score',
     rockwood.avg_rockwood AS AVG(rockwood.rockwood_score) COMMENT = 'Average Rockwood score',
-    dm8cp.avg_dm_care_processes AS AVG(dm8cp.care_processes_completed) COMMENT = 'Average DM care processes completed (of 8)'
+    dm8cp.avg_dm_care_processes AS AVG(dm8cp.care_processes_completed) COMMENT = 'Average DM care processes completed (of 8)',
+    lft.avg_alt AS AVG(lft.alt_value) COMMENT = 'Average ALT (U/L)',
+    lft.avg_ggt AS AVG(lft.ggt_value) COMMENT = 'Average GGT (U/L)',
+    haemoglobin.avg_haemoglobin AS AVG(haemoglobin.inferred_value) COMMENT = 'Average haemoglobin (g/L)',
+    platelets.avg_platelets AS AVG(platelets.inferred_value) COMMENT = 'Average platelet count (10^9/L)',
+    eosinophils.avg_eosinophils AS AVG(eosinophils.inferred_value) COMMENT = 'Average eosinophil count (10^9/L)'
 )
 
-COMMENT = 'OLIDS Clinical Observations Semantic View - Biomarkers, frailty scores, diabetes care processes, and screening with category-based metrics. Includes patient-specific BP thresholds, eFI/Rockwood frailty, DM 8 care processes, foot exam and retinal screening. Grain: one row per person (latest values). ESP 2013 weights available via age_band_esp.'
+COMMENT = 'OLIDS Clinical Observations Semantic View - Biomarkers, frailty scores, diabetes care processes, and screening with category-based metrics. Includes patient-specific BP thresholds, liver function (ALT/GGT/bilirubin), haematology (haemoglobin/platelets/eosinophils), eFI/Rockwood frailty, DM 8 care processes, foot exam and retinal screening. Grain: one row per person (latest values). ESP 2013 weights available via age_band_esp.'
 AI_SQL_GENERATION 'Always filter to is_active = TRUE unless asked otherwise. For BP control queries, use bp_controlled_count and patients_with_bp_assessment to calculate control rate. Prefer category-based counts over averages for population health questions. BP control uses patient-specific thresholds based on T2DM, CKD, and age. DM 8 care processes (dm8cp table) are only populated for persons on the diabetes register — filter to dm8cp metrics when analysing diabetes care. The 8 processes are: HbA1c, BP, cholesterol, creatinine, urine ACR, foot exam, BMI, and smoking status — each checked within last 12 months. AGE-STANDARDISED RATES: To calculate an age-standardised rate (ASR) using ESP 2013 (the standard used by ONS/OHID/Fingertips), use this pattern: WITH strata AS (SELECT <area_column>, age_band_esp, COUNT(DISTINCT CASE WHEN <condition_or_category> THEN person_id END) AS cases, COUNT(DISTINCT person_id) AS pop, ANY_VALUE(esp_proportion) AS esp_prop FROM <this_view> WHERE is_active = TRUE GROUP BY <area_column>, age_band_esp) SELECT <area_column>, SUM(cases) AS crude_cases, SUM(pop) AS crude_pop, ROUND(SUM((cases / NULLIF(pop, 0)) * esp_prop) * 100000, 1) AS asr_per_100k FROM strata GROUP BY <area_column>. For internal NCL comparison instead of ESP, replace esp_prop with (pop / SUM(pop) OVER ()) to use the NCL population structure as the standard.'
-AI_QUESTION_CATEGORIZATION 'Use this view for questions about: BP control, HbA1c control, cholesterol, BMI, waist circumference, eGFR, CKD staging, creatinine, QRISK, ACR, frailty (eFI, Rockwood), diabetic foot examination, retinal screening, diabetes 8 care processes, and all clinical biomarkers. For condition prevalence and demographics use sem_olids_population. For trends over time use sem_olids_trends.'
+AI_QUESTION_CATEGORIZATION 'Use this view for questions about: BP control, HbA1c control, cholesterol, BMI, waist circumference, eGFR, CKD staging, creatinine, QRISK, ACR, liver function (ALT, GGT, bilirubin, abnormal LFTs), haemoglobin/anaemia, platelets, eosinophils, frailty (eFI, Rockwood), diabetic foot examination, retinal screening, diabetes 8 care processes, and all latest clinical biomarkers. This view holds the LATEST value per biomarker only — for serial readings, latest-2, or trajectory over time use sem_olids_observations_history. For condition prevalence and demographics use sem_olids_population. For condition trends over time use sem_olids_trends.'

--- a/models/semantic/sem_olids_observations.yml
+++ b/models/semantic/sem_olids_observations.yml
@@ -32,6 +32,10 @@ models:
       - int_creatinine_latest: Serum creatinine
       - int_qrisk_latest: QRISK cardiovascular risk
       - int_urine_acr_latest: Urine ACR
+      - int_lft_latest: Liver function (ALT, GGT, bilirubin) with high flags
+      - int_haemoglobin_latest: Haemoglobin with anaemia category
+      - int_platelets_latest: Platelet count with category
+      - int_eosinophil_count_latest: Blood eosinophil count with category
       - int_efi_latest: Electronic Frailty Index (GP-coded only, incomplete coverage)
       - int_rockwood_latest: Rockwood Clinical Frailty Scale
       - int_foot_examination_latest: Diabetic foot examination

--- a/models/semantic/sem_olids_observations_history.sql
+++ b/models/semantic/sem_olids_observations_history.sql
@@ -1,0 +1,126 @@
+{{
+    config(
+        materialized='semantic_view',
+        schema='SEMANTIC'
+    )
+}}
+
+{#
+    OLIDS Clinical Observations History Semantic View
+    =================================================
+
+    Serial / over-time companion to sem_olids_observations. Where that view
+    holds the LATEST value per biomarker (one row per person), this view holds
+    EVERY recorded reading (one row per observation event) so you can answer
+    "latest 2", trajectory, variability, and recheck-interval questions.
+
+    OLIDS is the One London Integrated Data Set — primary care data from system
+    suppliers (currently EMIS Web, with TPP to follow), unified by the One
+    London team.
+
+    Grain: One row per observation event (person x biomarker x date).
+
+    Retention asymmetry (important):
+    OLIDS keeps FULL history for currently-registered persons, but only ~5
+    years (60 months) for persons who have left or died. Unlike
+    sem_olids_appointments and sem_olids_trends, this view is deliberately NOT
+    capped at 60 months — that is the point of it, so long-run trajectories for
+    current registrants (e.g. a 55-year-old's BMI over 10 years) are usable.
+    Consequence: readings older than ~5 years exist mainly for people still
+    registered now, so long-run POPULATION cross-sections (e.g. average BMI by
+    calendar year over a decade) are survivor-biased. Use this view for
+    per-person trajectories and change within the currently-registered cohort
+    (filter is_active = TRUE); do not read pre-5-year population averages as
+    representative of the population at that time.
+
+    Design:
+    - Long format: filter to ONE observation_type before reading `value`.
+      Values are only comparable within a single biomarker.
+    - For "latest N", window with ROW_NUMBER() OVER (PARTITION BY person_id,
+      observation_type ORDER BY clinical_effective_date DESC).
+    - Blood pressure is split into 'Systolic BP' and 'Diastolic BP' rows.
+
+    Biomarkers: Systolic BP, Diastolic BP, Total Cholesterol, LDL Cholesterol,
+    QRISK, HbA1c, BMI, Waist Circumference, eGFR, Creatinine, Urine ACR, ALT,
+    GGT, Bilirubin, Haemoglobin, Platelets, Eosinophils.
+#}
+
+TABLES(
+    obs AS {{ ref('int_observation_events_long') }}
+        PRIMARY KEY (observation_event_id)
+        COMMENT = 'One row per biomarker observation event. Filter to a single observation_type before aggregating value.',
+
+    demographics AS {{ ref('dim_person_demographics') }}
+        PRIMARY KEY (person_id)
+        COMMENT = 'Patient demographics, geography, ethnicity, deprivation (current snapshot)'
+)
+
+RELATIONSHIPS(
+    obs (person_id) REFERENCES demographics
+)
+
+FACTS(
+    obs.value AS value COMMENT = 'Numeric result. Only comparable within a single observation_type (see unit).'
+)
+
+DIMENSIONS(
+    -- Observation
+    obs.observation_type AS observation_type WITH SYNONYMS = ('biomarker', 'measurement', 'test') COMMENT = 'Biomarker label. Filter to one value before aggregating: Systolic BP, Diastolic BP, Total Cholesterol, LDL Cholesterol, QRISK, HbA1c, BMI, Waist Circumference, eGFR, Creatinine, Urine ACR, ALT, GGT, Bilirubin, Haemoglobin, Platelets, Eosinophils.',
+    obs.observation_group AS observation_group COMMENT = 'Clinical group (Cardiovascular, Metabolic, Renal, Liver, Haematology)',
+    obs.clinical_effective_date AS clinical_effective_date WITH SYNONYMS = ('observation date', 'test date', 'date') COMMENT = 'Date of the reading',
+    obs.unit AS unit COMMENT = 'Unit of measure for value',
+    obs.category AS category COMMENT = 'Type-specific clinical category for this reading (meaning varies by observation_type)',
+
+    -- Core Demographics
+    demographics.gender AS gender COMMENT = 'Patient gender (Male, Female, Unknown)',
+    demographics.age AS age COMMENT = 'Current age in years (drifts — reading dates are event-time)',
+    demographics.age_band_5y AS age_band_5y COMMENT = '5-year age bands (0-4, 5-9, ..., 80-84, 85+, Unknown)',
+    demographics.age_band_10y AS age_band_10y COMMENT = '10-year age bands (0-9, 10-19, ..., 70-79, 80+, Unknown)',
+    demographics.age_band_nhs AS age_band_nhs COMMENT = 'NHS Digital standard age bands (0-4, 5-14, 15-24, ..., 75-84, 85+)',
+    demographics.age_band_esp AS age_band_esp COMMENT = 'ESP 2013 age bands (<1, 1-4, 5-9, ..., 80-84, 85-89, 90-94, 95+)',
+    demographics.age_life_stage AS age_life_stage COMMENT = 'Life stage (Infant, Toddler, Child, Adolescent, Young Adult, Adult, Older Adult, Elderly, Very Elderly, Unknown)',
+    demographics.ethnicity_category AS ethnicity_category COMMENT = 'Ethnicity category (Asian or Asian British, Black or Black British, Mixed, Other, White, Unknown)',
+    demographics.ethnicity_subcategory AS ethnicity_subcategory COMMENT = 'Ethnicity subcategory (detailed groupings; Unknown/Not Stated/Not Recorded/Refused where missing)',
+    demographics.ethnicity_granular AS ethnicity_granular COMMENT = 'Detailed ethnicity classification (Unknown if not recorded)',
+    demographics.main_language AS main_language COMMENT = 'Main spoken language (Not Recorded if unknown)',
+    demographics.interpreter_needed AS interpreter_needed COMMENT = 'Whether interpreter is required',
+    demographics.is_active AS is_active COMMENT = 'Currently registered with NCL GP practice',
+    demographics.is_deceased AS is_deceased COMMENT = 'Deceased status',
+
+    -- Organisation
+    demographics.practice_code AS practice_code COMMENT = 'GP practice ODS code',
+    demographics.practice_name AS practice_name COMMENT = 'GP practice name',
+    demographics.pcn_code AS pcn_code COMMENT = 'Primary Care Network code',
+    demographics.pcn_name AS pcn_name COMMENT = 'Primary Care Network name',
+    demographics.pcn_name_with_borough AS pcn_name_with_borough COMMENT = 'PCN name with borough prefix',
+    demographics.borough_registered AS borough_registered COMMENT = 'Registration borough',
+    demographics.sub_icb_code AS sub_icb_code COMMENT = 'Sub-ICB / place-based partnership ODS code of the registered practice: QMJ = NHS North Central London; QRV = NHS North West London. NULL outside the WNL footprint.',
+    demographics.sub_icb_name AS sub_icb_name COMMENT = 'Sub-ICB display name (NHS North Central London or NHS North West London). NULL outside the WNL footprint.',
+    demographics.neighbourhood_registered AS neighbourhood_registered COMMENT = 'Registration neighbourhood',
+
+    -- Geography (residence)
+    demographics.lsoa_code_21 AS lsoa_code_21 COMMENT = 'Lower Super Output Area 2021 code',
+    demographics.ward_code AS ward_code COMMENT = 'Electoral ward 2025 code',
+    demographics.ward_name AS ward_name COMMENT = 'Electoral ward 2025 name',
+    demographics.borough_resident AS borough_resident COMMENT = 'Residence borough',
+    demographics.is_london_resident AS is_london_resident COMMENT = 'Resides in Greater London',
+    demographics.neighbourhood_resident AS neighbourhood_resident COMMENT = 'Residence neighbourhood',
+
+    -- Deprivation
+    demographics.imd_decile_19 AS imd_decile_19 COMMENT = 'IMD 2019 decile (1=most deprived, 10=least). NULL if LSOA not mapped.',
+    demographics.imd_quintile_19 AS imd_quintile_19 COMMENT = 'IMD 2019 quintile (1 - Most Deprived to 5 - Least Deprived, Unknown)',
+    demographics.imd_decile_25 AS imd_decile_25 COMMENT = 'IMD 2025 decile (1=most deprived, 10=least). Preferred over 2019.',
+    demographics.imd_quintile_25 AS imd_quintile_25 COMMENT = 'IMD 2025 quintile (1 - Most Deprived to 5 - Least Deprived, Unknown)'
+)
+
+METRICS(
+    obs.observation_count AS COUNT(obs.observation_event_id) COMMENT = 'Number of observation events (filter to one observation_type)',
+    obs.patient_count AS COUNT(DISTINCT obs.person_id) COMMENT = 'Distinct patients with a reading (filter to one observation_type)',
+    obs.avg_value AS AVG(obs.value) COMMENT = 'Average value — only meaningful when filtered to a single observation_type',
+    obs.min_value AS MIN(obs.value) COMMENT = 'Minimum value (filter to one observation_type)',
+    obs.max_value AS MAX(obs.value) COMMENT = 'Maximum value (filter to one observation_type)'
+)
+
+COMMENT = 'OLIDS Clinical Observations History Semantic View - every recorded biomarker reading (one row per person x biomarker x date) for serial, latest-N, trajectory, variability, and recheck-interval analysis. Long format: filter to a single observation_type before reading value. Biomarkers: BP (systolic/diastolic), cholesterol, LDL, QRISK, HbA1c, BMI, waist, eGFR, creatinine, urine ACR, ALT, GGT, bilirubin, haemoglobin, platelets, eosinophils.'
+AI_SQL_GENERATION 'Always filter to a single observation_type before aggregating or comparing value — values across types are not comparable (different units). For latest-N questions ("last 2 HbA1c"), use ROW_NUMBER() OVER (PARTITION BY person_id, observation_type ORDER BY clinical_effective_date DESC) and filter the rank. For CHANGE / trajectory questions ("whose BMI or waist circumference rose in the last X months"), per person take the latest reading and a baseline reading (the most recent reading on or before DATEADD(month, -X, latest_date)), then difference them; require both to exist. Blood pressure is two types: Systolic BP and Diastolic BP. Always filter to is_active = TRUE unless asked otherwise. RETENTION: full history is retained for currently-registered persons but only ~5 years for left/deceased persons, so this view is NOT capped at 60 months — use it for per-person trajectories and change within the currently-registered cohort. Do NOT compute long-run population cross-sections (e.g. average value by calendar year going back >5 years) as if representative — pre-5-year data is survivor-biased toward people still registered. This view is for over-time analysis; for the single latest value per biomarker use sem_olids_observations.'
+AI_QUESTION_CATEGORIZATION 'Use this view for: serial biomarker readings, latest-2 / last-N values, trends in an individual or cohort over time, variability, rate of change, time between readings, and recheck intervals. For the single most recent value per biomarker (current state) use sem_olids_observations. For condition prevalence/demographics use sem_olids_population. For condition incidence/prevalence trends use sem_olids_trends.'

--- a/models/semantic/sem_olids_observations_history.sql
+++ b/models/semantic/sem_olids_observations_history.sql
@@ -37,7 +37,9 @@
     - Long format: filter to ONE observation_type before reading `value`.
       Values are only comparable within a single biomarker.
     - For "latest N", window with ROW_NUMBER() OVER (PARTITION BY person_id,
-      observation_type ORDER BY clinical_effective_date DESC).
+      observation_type ORDER BY clinical_effective_date DESC,
+      observation_event_id DESC) — the event id breaks ties when a person has
+      multiple readings of one biomarker on the same date.
     - Blood pressure is split into 'Systolic BP' and 'Diastolic BP' rows.
 
     Biomarkers: Systolic BP, Diastolic BP, Total Cholesterol, LDL Cholesterol,
@@ -65,6 +67,7 @@ FACTS(
 
 DIMENSIONS(
     -- Observation
+    obs.observation_event_id AS observation_event_id COMMENT = 'Stable per-event surrogate key. Use as the final ORDER BY tiebreaker in latest-N windows so tied clinical_effective_dates rank deterministically.',
     obs.observation_type AS observation_type WITH SYNONYMS = ('biomarker', 'measurement', 'test') COMMENT = 'Biomarker label. Filter to one value before aggregating: Systolic BP, Diastolic BP, Total Cholesterol, LDL Cholesterol, QRISK, HbA1c, BMI, Waist Circumference, eGFR, Creatinine, Urine ACR, ALT, GGT, Bilirubin, Haemoglobin, Platelets, Eosinophils.',
     obs.observation_group AS observation_group COMMENT = 'Clinical group (Cardiovascular, Metabolic, Renal, Liver, Haematology)',
     obs.clinical_effective_date AS clinical_effective_date WITH SYNONYMS = ('observation date', 'test date', 'date') COMMENT = 'Date of the reading',
@@ -122,5 +125,5 @@ METRICS(
 )
 
 COMMENT = 'OLIDS Clinical Observations History Semantic View - every recorded biomarker reading (one row per person x biomarker x date) for serial, latest-N, trajectory, variability, and recheck-interval analysis. Long format: filter to a single observation_type before reading value. Biomarkers: BP (systolic/diastolic), cholesterol, LDL, QRISK, HbA1c, BMI, waist, eGFR, creatinine, urine ACR, ALT, GGT, bilirubin, haemoglobin, platelets, eosinophils.'
-AI_SQL_GENERATION 'Always filter to a single observation_type before aggregating or comparing value — values across types are not comparable (different units). For latest-N questions ("last 2 HbA1c"), use ROW_NUMBER() OVER (PARTITION BY person_id, observation_type ORDER BY clinical_effective_date DESC) and filter the rank. For CHANGE / trajectory questions ("whose BMI or waist circumference rose in the last X months"), per person take the latest reading and a baseline reading (the most recent reading on or before DATEADD(month, -X, latest_date)), then difference them; require both to exist. Blood pressure is two types: Systolic BP and Diastolic BP. Always filter to is_active = TRUE unless asked otherwise. RETENTION: full history is retained for currently-registered persons but only ~5 years for left/deceased persons, so this view is NOT capped at 60 months — use it for per-person trajectories and change within the currently-registered cohort. Do NOT compute long-run population cross-sections (e.g. average value by calendar year going back >5 years) as if representative — pre-5-year data is survivor-biased toward people still registered. This view is for over-time analysis; for the single latest value per biomarker use sem_olids_observations.'
+AI_SQL_GENERATION 'Always filter to a single observation_type before aggregating or comparing value — values across types are not comparable (different units). For latest-N questions ("last 2 HbA1c"), use ROW_NUMBER() OVER (PARTITION BY person_id, observation_type ORDER BY clinical_effective_date DESC, observation_event_id DESC) and filter the rank — the event id is a deterministic tiebreaker for multiple readings on the same date. For CHANGE / trajectory questions ("whose BMI or waist circumference rose in the last X months"), per person take the latest reading and a baseline reading (the most recent reading on or before DATEADD(month, -X, latest_date)), then difference them; require both to exist. Blood pressure is two types: Systolic BP and Diastolic BP. Always filter to is_active = TRUE unless asked otherwise. RETENTION: full history is retained for currently-registered persons but only ~5 years for left/deceased persons, so this view is NOT capped at 60 months — use it for per-person trajectories and change within the currently-registered cohort. Do NOT compute long-run population cross-sections (e.g. average value by calendar year going back >5 years) as if representative — pre-5-year data is survivor-biased toward people still registered. This view is for over-time analysis; for the single latest value per biomarker use sem_olids_observations.'
 AI_QUESTION_CATEGORIZATION 'Use this view for: serial biomarker readings, latest-2 / last-N values, trends in an individual or cohort over time, variability, rate of change, time between readings, and recheck intervals. For the single most recent value per biomarker (current state) use sem_olids_observations. For condition prevalence/demographics use sem_olids_population. For condition incidence/prevalence trends use sem_olids_trends.'

--- a/models/semantic/sem_olids_observations_history.yml
+++ b/models/semantic/sem_olids_observations_history.yml
@@ -26,6 +26,11 @@ models:
       - int_observation_events_long: long-format biomarker history
       - dim_person_demographics: patient demographics, geography, deprivation
 
+      Column-level dbt tests are intentionally not defined on this semantic_view.
+      Uniqueness / not-null integrity is enforced upstream on
+      int_observation_events_long, because semantic_view models are not
+      validated as standard queryable relations.
+
     config:
       materialized: semantic_view
       schema: SEMANTIC

--- a/models/semantic/sem_olids_observations_history.yml
+++ b/models/semantic/sem_olids_observations_history.yml
@@ -1,0 +1,34 @@
+version: 2
+
+models:
+  - name: sem_olids_observations_history
+    description: |
+      OLIDS Clinical Observations History semantic view. OLIDS is the One
+      London Integrated Data Set — primary care data from system suppliers,
+      unified by the One London team.
+
+      Serial / over-time companion to sem_olids_observations. Holds every
+      recorded biomarker reading (one row per person x biomarker x date) so
+      that latest-N, trajectory, variability, and recheck-interval questions
+      can be answered with window functions. Long format — filter to a single
+      observation_type before reading value.
+
+      Not capped at 60 months (unlike sem_olids_appointments/sem_olids_trends):
+      full history is retained for currently-registered persons, enabling
+      long-run per-person trajectories. Left/deceased persons retain only ~5
+      years, so pre-5-year population cross-sections are survivor-biased — use
+      for per-person and currently-registered-cohort change, not long-run
+      population averages.
+
+      Grain: One row per observation event.
+
+      Tables Included:
+      - int_observation_events_long: long-format biomarker history
+      - dim_person_demographics: patient demographics, geography, deprivation
+
+    config:
+      materialized: semantic_view
+      schema: SEMANTIC
+      meta:
+        owner:
+          name: Eddie Davison

--- a/models/semantic/sem_olids_population.sql
+++ b/models/semantic/sem_olids_population.sql
@@ -49,12 +49,17 @@ TABLES(
 
     status AS {{ ref('dim_person_status_summary') }}
         PRIMARY KEY (person_id)
-        COMMENT = 'Vulnerability factors, polypharmacy, smoking, alcohol, and data sharing status'
+        COMMENT = 'Vulnerability factors, polypharmacy, smoking, alcohol, and data sharing status',
+
+    ccms AS {{ ref('dim_person_ccms') }}
+        PRIMARY KEY (person_id)
+        COMMENT = 'Cambridge Comorbidity Score (2022 modified, 20-category weighted sum). Continuous score only — the CCMS literature does not define risk bands. Only populated for persons aged 16+.'
 )
 
 RELATIONSHIPS(
     conditions (person_id) REFERENCES demographics,
-    status (person_id) REFERENCES demographics
+    status (person_id) REFERENCES demographics,
+    ccms (person_id) REFERENCES demographics
 )
 
 FACTS(
@@ -66,6 +71,10 @@ FACTS(
     conditions.respiratory_conditions AS respiratory_conditions COMMENT = 'Count of respiratory conditions (Asthma, COPD)',
     conditions.mental_health_conditions AS mental_health_conditions COMMENT = 'Count of mental health conditions (Depression, SMI, Dementia, Anxiety)',
     conditions.metabolic_conditions AS metabolic_conditions COMMENT = 'Count of metabolic conditions (Diabetes, NDH, CKD, Obesity)',
+    conditions.musculoskeletal_conditions AS musculoskeletal_conditions COMMENT = 'Count of musculoskeletal conditions (RA, Osteoporosis, Osteoarthritis)',
+    conditions.neurology_conditions AS neurology_conditions COMMENT = 'Count of neurology conditions (Epilepsy, Stroke/TIA, Parkinsons, Cerebral Palsy, MND, MS)',
+    conditions.geriatric_conditions AS geriatric_conditions COMMENT = 'Count of geriatric conditions (Frailty)',
+    ccms.cambridge_comorbidity_score AS cambridge_comorbidity_score WITH SYNONYMS = ('CCMS', 'comorbidity score', 'Cambridge score') COMMENT = 'Cambridge Comorbidity Score (2022 modified, 20-category weighted sum). Higher = greater comorbidity burden; can be negative. Continuous score per the CCMS literature — no external clinical cut-points exist. Only populated for persons aged 16+.',
     status.medication_count AS medication_count COMMENT = 'Number of current medications',
     status.behavioural_risk_count AS behavioural_risk_count COMMENT = 'Count of behavioural risk factors',
     demographics.esp_weight AS esp_weight COMMENT = 'ESP 2013 population weight for this persons age band (out of 100,000 total). Use with age_band_esp for age-standardised rate calculation.',
@@ -279,6 +288,10 @@ METRICS(
     conditions.multimorbidity_count AS COUNT(DISTINCT CASE WHEN conditions.total_conditions >= 2 THEN conditions.person_id END) COMMENT = 'Patients with 2+ conditions',
     conditions.complex_multimorbidity_count AS COUNT(DISTINCT CASE WHEN conditions.total_conditions >= 4 THEN conditions.person_id END) COMMENT = 'Patients with 4+ conditions',
 
+    -- Comorbidity Burden (CCMS)
+    ccms.avg_ccms AS AVG(ccms.cambridge_comorbidity_score) COMMENT = 'Average Cambridge Comorbidity Score (16+ cohort)',
+    ccms.patients_with_ccms AS COUNT(DISTINCT ccms.person_id) COMMENT = 'Patients with a CCMS (aged 16+)',
+
     -- Smoking
     status.current_smoker_count AS COUNT(DISTINCT CASE WHEN status.smoking_status = 'Current Smoker' THEN status.person_id END) COMMENT = 'Current smokers',
     status.ex_smoker_count AS COUNT(DISTINCT CASE WHEN status.smoking_status = 'Ex-Smoker' THEN status.person_id END) COMMENT = 'Ex-smokers',
@@ -298,4 +311,4 @@ METRICS(
 
 COMMENT = 'OLIDS Population Health Semantic View - NCL registered population with demographics, all condition registers (QOF v50), diabetes type, vulnerability factors, and risk behaviours. Source: OLIDS (One London Integrated Data Set — primary care data from system suppliers, unified by the One London team). Grain: one row per person (current state). ESP 2013 weights available via age_band_esp for age-standardised rate calculation.'
 AI_SQL_GENERATION 'Always filter to is_active = TRUE unless the user explicitly asks about deceased or inactive patients. Use borough_registered for practice-based geography and borough_resident for residence-based geography. IMD 2025 (imd_decile_25, imd_quintile_25) is preferred over IMD 2019. Condition registers are built to QOF Business Rules v50. AGE-STANDARDISED RATES: To calculate an age-standardised rate (ASR) using ESP 2013 (the standard used by ONS/OHID/Fingertips), use this pattern: WITH strata AS (SELECT <area_column>, age_band_esp, COUNT(DISTINCT CASE WHEN <condition> THEN person_id END) AS cases, COUNT(DISTINCT person_id) AS pop, ANY_VALUE(esp_proportion) AS esp_prop FROM <this_view> WHERE is_active = TRUE GROUP BY <area_column>, age_band_esp) SELECT <area_column>, SUM(cases) AS crude_cases, SUM(pop) AS crude_pop, ROUND(SUM((cases / NULLIF(pop, 0)) * esp_prop) * 100000, 1) AS asr_per_100k FROM strata GROUP BY <area_column>. For age-AND-sex standardisation, add gender to the GROUP BY in both the strata CTE and the outer query dimensions, or group strata by age_band_esp+gender and collapse in the outer sum. For internal NCL comparison instead of ESP, replace esp_prop with (pop / SUM(pop) OVER ()) to use the NCL population structure as the standard.'
-AI_QUESTION_CATEGORIZATION 'Use this view for questions about: condition prevalence (all 38 conditions), diabetes type (T1/T2), demographics, multimorbidity, vulnerability, smoking, polypharmacy, and population counts. For clinical biomarkers (BP, HbA1c, BMI, cholesterol) use sem_olids_observations. For trends over time use sem_olids_trends.'
+AI_QUESTION_CATEGORIZATION 'Use this view for questions about: condition prevalence (all 38 conditions), diabetes type (T1/T2), demographics, multimorbidity, Cambridge Comorbidity Score (CCMS), vulnerability, smoking, polypharmacy, and population counts. CCMS (cambridge_comorbidity_score) is a continuous weighted score (higher = greater comorbidity burden, can be negative) with NO published risk bands and is NULL for under-16s — report it as a number or average, do not invent thresholds. For clinical biomarkers (BP, HbA1c, BMI, cholesterol) use sem_olids_observations. For serial/over-time biomarker readings use sem_olids_observations_history. For trends over time use sem_olids_trends.'

--- a/models/semantic/sem_olids_population.yml
+++ b/models/semantic/sem_olids_population.yml
@@ -21,6 +21,7 @@ models:
       - dim_person_demographics: Core demographics, registration, geography
       - dim_person_conditions: Boolean flags for all 38 conditions + diabetes type + summary counts
       - dim_person_status_summary: Vulnerability, risk behaviours, polypharmacy, data sharing
+      - dim_person_ccms: Cambridge Comorbidity Score + NCL-relative quintile band (16+ only)
       - esp_2013: European Standard Population weights
 
     config:

--- a/models/semantic/sem_olids_population.yml
+++ b/models/semantic/sem_olids_population.yml
@@ -21,7 +21,7 @@ models:
       - dim_person_demographics: Core demographics, registration, geography
       - dim_person_conditions: Boolean flags for all 38 conditions + diabetes type + summary counts
       - dim_person_status_summary: Vulnerability, risk behaviours, polypharmacy, data sharing
-      - dim_person_ccms: Cambridge Comorbidity Score + NCL-relative quintile band (16+ only)
+      - dim_person_ccms: Cambridge Comorbidity Score (continuous weighted score, 16+ only)
       - esp_2013: European Standard Population weights
 
     config:

--- a/models/semantic/sem_olids_prescribing.sql
+++ b/models/semantic/sem_olids_prescribing.sql
@@ -208,7 +208,9 @@ DIMENSIONS(
     demographics.age_life_stage AS age_life_stage COMMENT = 'Life stage (Infant, Toddler, Child, Adolescent, Young Adult, Adult, Older Adult, Elderly, Very Elderly, Unknown)',
     demographics.ethnicity_category AS ethnicity_category COMMENT = 'Ethnicity category (Asian or Asian British, Black or Black British, Mixed, Other, White, Unknown)',
     demographics.ethnicity_subcategory AS ethnicity_subcategory COMMENT = 'Ethnicity subcategory (White: British, White: Irish, White: Roma, White: Traveller, White: Other White, Mixed: White and Black Caribbean, Mixed: White and Black African, Mixed: White and Asian, Mixed: Other Mixed, Asian: Indian, Asian: Pakistani, Asian: Bangladeshi, Asian: Chinese, Asian: Other Asian, Black: African, Black: Caribbean, Black: Other Black, Other: Arab, Other: Other, Unknown, Not Stated, Not Recorded, Recorded Not Known, Refused)',
+    demographics.ethnicity_granular AS ethnicity_granular COMMENT = 'Detailed ethnicity classification (Unknown if not recorded)',
     demographics.main_language AS main_language COMMENT = 'Main spoken language (Not Recorded if unknown)',
+    demographics.interpreter_needed AS interpreter_needed COMMENT = 'Whether interpreter is required',
     demographics.is_active AS is_active COMMENT = 'Patient currently registered',
 
     -- Patient geography (residence)

--- a/models/semantic/sem_olids_trends.sql
+++ b/models/semantic/sem_olids_trends.sql
@@ -63,6 +63,9 @@ DIMENSIONS(
     -- Ethnicity
     trends.ethnicity_category AS ethnicity_category COMMENT = 'Ethnicity category (Asian or Asian British, Black or Black British, Mixed, Other, White, Unknown)',
     trends.ethnicity_subcategory AS ethnicity_subcategory COMMENT = 'Ethnicity subcategory (White: British, White: Irish, White: Roma, White: Traveller, White: Other White, Mixed: White and Black Caribbean, Mixed: White and Black African, Mixed: White and Asian, Mixed: Other Mixed, Asian: Indian, Asian: Pakistani, Asian: Bangladeshi, Asian: Chinese, Asian: Other Asian, Black: African, Black: Caribbean, Black: Other Black, Other: Arab, Other: Other, Unknown, Not Stated, Not Recorded, Recorded Not Known, Refused)',
+    trends.ethnicity_granular AS ethnicity_granular COMMENT = 'Detailed ethnicity classification (Unknown if not recorded)',
+    trends.main_language AS main_language COMMENT = 'Main spoken language (Not Recorded if unknown)',
+    trends.interpreter_needed AS interpreter_needed COMMENT = 'Whether interpreter is required',
 
     -- Organisation
     trends.practice_code AS practice_code COMMENT = 'GP practice code',
@@ -79,6 +82,7 @@ DIMENSIONS(
     trends.lsoa_code_21 AS lsoa_code_21 COMMENT = 'LSOA 2021 code',
     trends.ward_code AS ward_code COMMENT = 'Electoral ward code',
     trends.ward_name AS ward_name COMMENT = 'Electoral ward name',
+    trends.is_london_resident AS is_london_resident COMMENT = 'Resides in Greater London',
     trends.neighbourhood_resident AS neighbourhood_resident COMMENT = 'Residence neighbourhood',
 
     -- Deprivation


### PR DESCRIPTION
## Summary

Closes coverage and consistency gaps across the OLIDS semantic views (the layer consumed by the WNL Semantic Layer app), and adds a new over-time observations view.

Motivation: not all views exposed the LTC/observation lenses that exist in the underlying models, demographics had drifted between views, and there was no way to ask serial / "latest-2" / trajectory questions about biomarkers.

## Changes

### Population (`sem_olids_population`)
- **Cambridge Comorbidity Score** added via `dim_person_ccms` — exposed as a continuous `cambridge_comorbidity_score` fact with `avg_ccms` / `patients_with_ccms` metrics. **No banding**: the CCMS literature ([Payne 2020](https://www.cmaj.ca/content/192/5/E107), [Ruby 2023](https://bjgp.org/content/73/731/e435)) validates the score continuously and defines no clinical cut-points, so the AI hint instructs reporting it as a number rather than inventing thresholds.
- Exposed the `musculoskeletal_conditions`, `neurology_conditions`, `geriatric_conditions` domain counts that already existed in `dim_person_conditions` but weren't surfaced.

### Observations (`sem_olids_observations`)
- Added biomarkers that existed as models but weren't exposed: **liver** (ALT, GGT, bilirubin + composite `high_lft`), **haemoglobin**, **platelets**, **eosinophils** — tables, facts, category dimensions, and count/avg metrics. Closes the "NAFLD/CLD register but no liver biomarker" mismatch.
- Removed a redundant `person_id IS NOT NULL` guard from `hba1c_above_target_count` (`person_id` is `not_null`-tested and `meets_qof_target` is non-nullable, so it was dead code — result unchanged).

### Demographics consistency (all four person-linked views)
- Standardised the patient-attribute block so equity dimensions are uniform: `ethnicity_granular`, `main_language`, `interpreter_needed`, `is_london_resident` added where missing (plus `is_deceased` / `pcn_name_with_borough` on observations). Verified each attribute exists in the relevant backing model first (incl. `person_month_analysis_base` for trends).

### New: `sem_olids_observations_history`
- One row per observation event, backed by a new `int_observation_events_long` model — a long-format union of 17 biomarker streams (BP split into systolic/diastolic). Supports latest-N, serial, trajectory, variability, and recheck-interval questions via window functions.
- **Long format chosen deliberately**: the source `_all` models are many-rows-per-person with divergent schemas; co-joining them on `person_id` would fan out. A single fact-grain view avoids that.
- **Not capped at 60 months** (unlike appointments/trends): full history is retained for currently-registered persons, which is the point of the view. The retention asymmetry (left/deceased truncated to ~5y → pre-5y data is survivor-biased) is documented in the view header, `AI_SQL_GENERATION` hint, and the backing model so it isn't misused for long-run population cross-sections.

### Appointments (`sem_olids_appointments`)
- Removed the `practitioner_name` dimension (personal data — shouldn't be exposed to the AI consumer).

## Validation
- `dbt parse` ✅ and `dbt compile` ✅ (static column analysis) across all 8 touched models + 15 tests.
- A full `dbt build` is **pending a healthy Snowflake connection** — it failed locally on an environmental DNS timeout when creating the schema, not on anything in this change.

## Reviewer notes
- `int_observation_events_long.observation_event_id` is a best-effort surrogate key (person/type/date/source-id/value) with a `unique` test — the first build will confirm no biomarker stream produces collisions (watch BP, where the id is the systolic/diastolic observation id).
- Worth confirming after build that the new biomarker code clusters (`EOS_COUNT`, LFT clusters, haemoglobin/platelets) surface in the app's Codes/provenance panel for `sem_olids_observations` the same way `BP_COD` does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded clinical observation history tracking with comprehensive biomarker event records
  * Added liver function and haematology measurements (ALT, GGT, bilirubin, haemoglobin, platelets, eosinophils)
  * Introduced Cambridge Comorbidity Score for population analysis
  * Enhanced demographic attributes: detailed ethnicity classification, language and interpreter requirements, London residency indicator

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wnl-icb-analytics/dbt-analytics/pull/755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->