### PR TITLE
feat(observability): add source freshness current-state models

### DIFF
--- a/models/published/direct_care/olids/db_utils/metadata_pipeline_health_current.sql
+++ b/models/published/direct_care/olids/db_utils/metadata_pipeline_health_current.sql
@@ -1,0 +1,66 @@
+{{
+    config(
+        materialized='view',
+        enabled=target.name in ['prod', 'snowflake-prod']
+    )
+}}
+
+/*
+Current dbt project health for semantic-layer freshness surfaces.
+
+Elementary observability is only enabled in prod/snowflake-prod. In non-prod
+targets this model returns no rows rather than failing to compile against
+disabled package refs.
+*/
+
+WITH latest_invocation AS (
+    SELECT *
+    FROM {{ ref('dbt_invocations') }}
+    WHERE target_name IN ('prod', 'snowflake-prod')
+    QUALIFY ROW_NUMBER() OVER (ORDER BY generated_at DESC) = 1
+),
+
+invocation_run_results AS (
+    SELECT *
+    FROM {{ ref('dbt_run_results') }}
+    WHERE invocation_id = (SELECT invocation_id FROM latest_invocation)
+),
+
+run_summary AS (
+    SELECT
+        COUNT_IF(resource_type = 'model') AS model_result_count,
+        COUNT_IF(resource_type = 'model' AND status = 'success') AS model_success_count,
+        COUNT_IF(resource_type = 'model' AND status != 'success') AS model_non_success_count,
+        COUNT_IF(resource_type = 'test') AS test_result_count,
+        COUNT_IF(resource_type = 'test' AND status IN ('fail', 'error')) AS failing_test_count,
+        COUNT_IF(status = 'error') AS error_result_count,
+        MAX(execute_completed_at) AS latest_result_completed_at
+    FROM invocation_run_results
+)
+
+SELECT
+    'dbt_project' AS pipeline_key,
+    'dbt project health' AS display_name,
+    inv.invocation_id,
+    inv.command,
+    inv.target_name,
+    inv.full_refresh,
+    inv.run_started_at,
+    inv.run_completed_at,
+    inv.generated_at,
+    summary.latest_result_completed_at,
+    summary.model_result_count,
+    summary.model_success_count,
+    summary.model_non_success_count,
+    summary.test_result_count,
+    summary.failing_test_count,
+    summary.error_result_count,
+    DATEDIFF('hour', COALESCE(inv.run_completed_at, inv.generated_at), CURRENT_TIMESTAMP()) AS lag_hours,
+    CASE
+        WHEN summary.error_result_count > 0 THEN 'error'
+        WHEN summary.model_non_success_count > 0 THEN 'breach'
+        WHEN summary.failing_test_count > 0 THEN 'stale'
+        ELSE 'fresh'
+    END AS pipeline_status
+FROM latest_invocation inv
+CROSS JOIN run_summary summary

--- a/models/published/direct_care/olids/db_utils/metadata_pipeline_health_current.yml
+++ b/models/published/direct_care/olids/db_utils/metadata_pipeline_health_current.yml
@@ -1,0 +1,49 @@
+models:
+  - name: metadata_pipeline_health_current
+    description: |
+      Current dbt project health rollup for the semantic-layer freshness UI.
+
+      Reads the latest prod Elementary invocation and summarises model/test
+      outcomes so the app can surface whether downstream refreshes were blocked
+      by dbt failures even when source data itself is fresh.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: pipeline_key
+        description: Stable identifier for the pipeline rollup row.
+      - name: display_name
+        description: Human-friendly label for the pipeline-health surface.
+      - name: invocation_id
+        description: Latest Elementary/dbt invocation identifier.
+      - name: command
+        description: dbt command used for the latest invocation.
+      - name: target_name
+        description: Target environment name for the latest invocation.
+      - name: full_refresh
+        description: Whether the latest invocation was executed with full refresh.
+      - name: run_started_at
+        description: Start time of the latest invocation.
+      - name: run_completed_at
+        description: Completion time of the latest invocation.
+      - name: generated_at
+        description: Timestamp when Elementary uploaded the invocation record.
+      - name: latest_result_completed_at
+        description: Latest completion timestamp among the invocation's run results.
+      - name: model_result_count
+        description: Number of model results captured for the latest invocation.
+      - name: model_success_count
+        description: Number of successful model results in the latest invocation.
+      - name: model_non_success_count
+        description: Number of non-success model results in the latest invocation.
+      - name: test_result_count
+        description: Number of test results captured for the latest invocation.
+      - name: failing_test_count
+        description: Number of failed or errored tests in the latest invocation.
+      - name: error_result_count
+        description: Number of errored run results across all resource types.
+      - name: lag_hours
+        description: Hours since the latest invocation completed.
+      - name: pipeline_status
+        description: Derived current pipeline-health state.

--- a/models/published/direct_care/olids/db_utils/metadata_source_freshness_current.sql
+++ b/models/published/direct_care/olids/db_utils/metadata_source_freshness_current.sql
@@ -1,0 +1,293 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+
+/*
+Current-state source freshness for the semantic layer.
+
+This first pass intentionally focuses on the logical sources we currently care
+about in the semantic layer:
+  - OLIDS, split into core operational subdomains
+  - PDS
+  - Deaths Registry
+
+For the OLIDS subdomains we prefer consensus business/event dates over
+warehouse table metadata. That mirrors the existing global refresh-date
+approach: future-dated records are excluded, stale/non-flowing practices are
+filtered out by requiring consensus, and the resulting signal better reflects
+true source-data currency than LAST_ALTERED alone.
+*/
+
+WITH source_config AS (
+    SELECT
+        source_key,
+        display_name,
+        NULLIF(parent_source_key, '') AS parent_source_key,
+        source_group,
+        sort_order,
+        include_in_rollup,
+        is_reference_data,
+        warn_after_hours,
+        breach_after_hours,
+        basis_models
+    FROM {{ ref('source_freshness_config') }}
+),
+
+olids_observation_dates AS (
+    SELECT
+        clinical_effective_date::date AS effective_date,
+        publisher_organisation_code
+    FROM {{ ref('stg_olids_observation') }}
+    WHERE clinical_effective_date < CURRENT_DATE()
+      AND clinical_effective_date >= DATEADD('month', -3, CURRENT_DATE())
+      AND publisher_organisation_code IS NOT NULL
+),
+olids_observation_consensus AS (
+    SELECT
+        'olids_observations' AS source_key,
+        effective_date AS freshness_date,
+        effective_date::timestamp_ntz AS freshness_ts,
+        practice_count AS contributing_organisation_count,
+        150 AS consensus_threshold,
+        'consensus_business_date' AS freshness_basis,
+        'Latest clinical_effective_date with at least 150 publisher organisations contributing observations.' AS basis_detail
+    FROM (
+        SELECT
+            effective_date,
+            COUNT(DISTINCT publisher_organisation_code) AS practice_count
+        FROM olids_observation_dates
+        GROUP BY effective_date
+    )
+    WHERE practice_count >= 150
+    QUALIFY ROW_NUMBER() OVER (ORDER BY effective_date DESC) = 1
+),
+
+olids_appointment_dates AS (
+    SELECT
+        start_date::date AS effective_date,
+        publisher_organisation_code
+    FROM {{ ref('stg_olids_appointment') }}
+    WHERE start_date < CURRENT_DATE()
+      AND start_date >= DATEADD('month', -3, CURRENT_DATE())
+      AND publisher_organisation_code IS NOT NULL
+),
+olids_appointment_consensus AS (
+    SELECT
+        'olids_appointments' AS source_key,
+        effective_date AS freshness_date,
+        effective_date::timestamp_ntz AS freshness_ts,
+        practice_count AS contributing_organisation_count,
+        150 AS consensus_threshold,
+        'consensus_business_date' AS freshness_basis,
+        'Latest appointment start_date with at least 150 publisher organisations contributing non-future appointments.' AS basis_detail
+    FROM (
+        SELECT
+            effective_date,
+            COUNT(DISTINCT publisher_organisation_code) AS practice_count
+        FROM olids_appointment_dates
+        GROUP BY effective_date
+    )
+    WHERE practice_count >= 150
+    QUALIFY ROW_NUMBER() OVER (ORDER BY effective_date DESC) = 1
+),
+
+olids_medication_dates AS (
+    SELECT
+        COALESCE(clinical_effective_date::date, date_recorded::date) AS effective_date,
+        publisher_organisation_code
+    FROM {{ ref('stg_olids_medication_order') }}
+    WHERE COALESCE(clinical_effective_date::date, date_recorded::date) < CURRENT_DATE()
+      AND COALESCE(clinical_effective_date::date, date_recorded::date) >= DATEADD('month', -3, CURRENT_DATE())
+      AND publisher_organisation_code IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+        COALESCE(clinical_effective_date::date, date_recorded::date) AS effective_date,
+        publisher_organisation_code
+    FROM {{ ref('stg_olids_medication_statement') }}
+    WHERE COALESCE(clinical_effective_date::date, date_recorded::date) < CURRENT_DATE()
+      AND COALESCE(clinical_effective_date::date, date_recorded::date) >= DATEADD('month', -3, CURRENT_DATE())
+      AND publisher_organisation_code IS NOT NULL
+),
+olids_medication_consensus AS (
+    SELECT
+        'olids_medications' AS source_key,
+        effective_date AS freshness_date,
+        effective_date::timestamp_ntz AS freshness_ts,
+        practice_count AS contributing_organisation_count,
+        150 AS consensus_threshold,
+        'consensus_business_date' AS freshness_basis,
+        'Latest medication clinical_effective_date/date_recorded with at least 150 publisher organisations contributing medication data.' AS basis_detail
+    FROM (
+        SELECT
+            effective_date,
+            COUNT(DISTINCT publisher_organisation_code) AS practice_count
+        FROM olids_medication_dates
+        GROUP BY effective_date
+    )
+    WHERE practice_count >= 150
+    QUALIFY ROW_NUMBER() OVER (ORDER BY effective_date DESC) = 1
+),
+
+olids_registration_dates AS (
+    SELECT
+        COALESCE(
+            lds_datetime_update_acquired::date,
+            episode_of_care_start_date::date,
+            episode_of_care_end_date::date
+        ) AS effective_date,
+        publisher_organisation_code
+    FROM {{ ref('stg_olids_episode_of_care') }}
+    WHERE COALESCE(
+            lds_datetime_update_acquired::date,
+            episode_of_care_start_date::date,
+            episode_of_care_end_date::date
+        ) < CURRENT_DATE()
+      AND COALESCE(
+            lds_datetime_update_acquired::date,
+            episode_of_care_start_date::date,
+            episode_of_care_end_date::date
+        ) >= DATEADD('month', -3, CURRENT_DATE())
+      AND publisher_organisation_code IS NOT NULL
+),
+olids_episode_of_care_consensus AS (
+    SELECT
+        'olids_episode_of_care' AS source_key,
+        effective_date AS freshness_date,
+        effective_date::timestamp_ntz AS freshness_ts,
+        practice_count AS contributing_organisation_count,
+        150 AS consensus_threshold,
+        'consensus_update_date' AS freshness_basis,
+        'Latest episode-of-care update date with at least 150 publisher organisations contributing episode-of-care records.' AS basis_detail
+    FROM (
+        SELECT
+            effective_date,
+            COUNT(DISTINCT publisher_organisation_code) AS practice_count
+        FROM olids_registration_dates
+        GROUP BY effective_date
+    )
+    WHERE practice_count >= 150
+    QUALIFY ROW_NUMBER() OVER (ORDER BY effective_date DESC) = 1
+),
+
+non_olids_metadata AS (
+    SELECT
+        'pds' AS source_key,
+        last_altered::date AS freshness_date,
+        last_altered AS freshness_ts,
+        NULL::integer AS contributing_organisation_count,
+        NULL::integer AS consensus_threshold,
+        'snowflake_last_altered' AS freshness_basis,
+        'Last altered timestamp for DATA_LAKE.PDS.PDS_PERSON.' AS basis_detail
+    FROM DATA_LAKE.INFORMATION_SCHEMA.TABLES
+    WHERE table_schema = 'PDS'
+      AND UPPER(table_name) = 'PDS_PERSON'
+
+    UNION ALL
+
+    SELECT
+        'registries_deaths' AS source_key,
+        last_altered::date AS freshness_date,
+        last_altered AS freshness_ts,
+        NULL::integer AS contributing_organisation_count,
+        NULL::integer AS consensus_threshold,
+        'snowflake_last_altered' AS freshness_basis,
+        'Last altered timestamp for DATA_LAKE.DEATHS.DEATHS.' AS basis_detail
+    FROM DATA_LAKE.INFORMATION_SCHEMA.TABLES
+    WHERE table_schema = 'DEATHS'
+      AND UPPER(table_name) = 'DEATHS'
+),
+
+atomic_current AS (
+    SELECT * FROM olids_observation_consensus
+    UNION ALL
+    SELECT * FROM olids_appointment_consensus
+    UNION ALL
+    SELECT * FROM olids_medication_consensus
+    UNION ALL
+    SELECT * FROM olids_episode_of_care_consensus
+    UNION ALL
+    SELECT * FROM non_olids_metadata
+),
+
+rollup_current AS (
+    SELECT
+        'olids' AS source_key,
+        MIN(freshness_date) AS freshness_date,
+        MIN(freshness_ts) AS freshness_ts,
+        NULL::integer AS contributing_organisation_count,
+        NULL::integer AS consensus_threshold,
+        'rollup_floor' AS freshness_basis,
+        'Floor of OLIDS episode-of-care, appointments, observations, and medications freshness.' AS basis_detail
+    FROM atomic_current
+    WHERE source_key IN (
+        'olids_episode_of_care',
+        'olids_appointments',
+        'olids_observations',
+        'olids_medications'
+    )
+),
+
+combined_current AS (
+    SELECT * FROM atomic_current
+    UNION ALL
+    SELECT * FROM rollup_current
+),
+
+enriched AS (
+    SELECT
+        cfg.source_key,
+        cfg.display_name,
+        cfg.parent_source_key,
+        cfg.source_group,
+        cfg.sort_order,
+        cfg.include_in_rollup,
+        cfg.is_reference_data,
+        cfg.warn_after_hours,
+        cfg.breach_after_hours,
+        cfg.basis_models,
+        cur.freshness_date,
+        cur.freshness_ts,
+        cur.contributing_organisation_count,
+        cur.consensus_threshold,
+        cur.freshness_basis,
+        cur.basis_detail,
+        CURRENT_TIMESTAMP() AS measured_at,
+        DATEDIFF('hour', cur.freshness_ts, CURRENT_TIMESTAMP()) AS lag_hours,
+        DATEDIFF('day', cur.freshness_date, CURRENT_DATE()) AS lag_days
+    FROM source_config cfg
+    LEFT JOIN combined_current cur
+      ON cfg.source_key = cur.source_key
+)
+
+SELECT
+    source_key,
+    display_name,
+    parent_source_key,
+    source_group,
+    sort_order,
+    include_in_rollup,
+    is_reference_data,
+    warn_after_hours,
+    breach_after_hours,
+    basis_models,
+    freshness_date,
+    freshness_ts,
+    contributing_organisation_count,
+    consensus_threshold,
+    freshness_basis,
+    basis_detail,
+    measured_at,
+    lag_hours,
+    lag_days,
+    CASE
+        WHEN freshness_ts IS NULL THEN 'error'
+        WHEN lag_hours <= warn_after_hours THEN 'fresh'
+        WHEN lag_hours <= breach_after_hours THEN 'stale'
+        ELSE 'breach'
+    END AS freshness_status
+FROM enriched
+ORDER BY sort_order, source_key

--- a/models/published/direct_care/olids/db_utils/metadata_source_freshness_current.yml
+++ b/models/published/direct_care/olids/db_utils/metadata_source_freshness_current.yml
@@ -1,0 +1,67 @@
+models:
+  - name: metadata_source_freshness_current
+    description: |
+      Current-state freshness signals for the semantic-layer's logical source
+      systems and OLIDS core subdomains.
+
+      OLIDS freshness is split across episode-of-care, appointments,
+      observations, and medications. Those subdomains use consensus event/update
+      dates across publisher organisations, excluding future-dated records, so
+      the signal reflects true source-data currency rather than warehouse table
+      modification timestamps.
+
+      Top-level `olids` is a rollup row using the floor of those four
+      subdomains. PDS and Deaths Registry currently use source-table
+      `LAST_ALTERED` as a first-pass technical freshness signal.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 7
+    columns:
+      - name: source_key
+        description: Stable identifier for the logical source or sub-source.
+        tests:
+          - unique
+          - not_null
+      - name: display_name
+        description: Human-friendly source label for UI surfaces.
+      - name: parent_source_key
+        description: Parent rollup source key, where applicable.
+      - name: source_group
+        description: Broad source grouping.
+      - name: sort_order
+        description: Display ordering for app-facing views.
+      - name: include_in_rollup
+        description: Whether the source should contribute to freshness rollups.
+      - name: is_reference_data
+        description: Whether the source is reference data rather than an operational data feed.
+      - name: warn_after_hours
+        description: Hours since the latest freshness timestamp before the status turns amber.
+      - name: breach_after_hours
+        description: Hours since the latest freshness timestamp before the status turns red.
+      - name: basis_models
+        description: Pipe-delimited list of staging models used to derive the freshness signal.
+      - name: freshness_date
+        description: Date-level freshness signal for the source.
+      - name: freshness_ts
+        description: Timestamp used for lag and status derivation.
+      - name: contributing_organisation_count
+        description: Number of publisher organisations contributing to the chosen consensus date.
+      - name: consensus_threshold
+        description: Minimum contributing-organisation threshold for OLIDS consensus rows.
+      - name: freshness_basis
+        description: High-level description of how freshness was measured.
+      - name: basis_detail
+        description: Human-readable explanation of the specific freshness calculation.
+      - name: measured_at
+        description: Timestamp when the row was evaluated.
+      - name: lag_hours
+        description: Hours between freshness timestamp and evaluation time.
+      - name: lag_days
+        description: Whole-day lag between freshness date and evaluation date.
+      - name: freshness_status
+        description: Derived green/amber/red/error state based on configured thresholds.

--- a/seeds/source_freshness_config.csv
+++ b/seeds/source_freshness_config.csv
@@ -1,0 +1,8 @@
+source_key,display_name,parent_source_key,source_group,sort_order,include_in_rollup,is_reference_data,warn_after_hours,breach_after_hours,basis_models
+olids,OLIDS,,olids,10,true,false,96,504,stg_olids_episode_of_care|stg_olids_appointment|stg_olids_observation|stg_olids_medication_order|stg_olids_medication_statement
+olids_episode_of_care,OLIDS episode of care,olids,olids,11,true,false,96,504,stg_olids_episode_of_care
+olids_appointments,OLIDS appointments,olids,olids,12,true,false,96,504,stg_olids_appointment
+olids_observations,OLIDS observations,olids,olids,13,true,false,96,504,stg_olids_observation
+olids_medications,OLIDS medications,olids,olids,14,true,false,96,504,stg_olids_medication_order|stg_olids_medication_statement
+pds,PDS,,pds,20,true,false,72,168,stg_pds_pds_person
+registries_deaths,Deaths Registry,,deaths,30,true,false,168,336,stg_registries_deaths

--- a/seeds/source_freshness_config.yml
+++ b/seeds/source_freshness_config.yml
@@ -1,0 +1,46 @@
+version: 2
+
+seeds:
+  - name: source_freshness_config
+    description: |
+      Lightweight configuration for semantic-layer source freshness.
+
+      Defines the logical sources and sub-sources we want to surface, how they
+      roll up, and the expected freshness thresholds used to derive
+      green/amber/red status in downstream models.
+    config:
+      column_types:
+        source_key: varchar(100)
+        display_name: varchar(200)
+        parent_source_key: varchar(100)
+        source_group: varchar(100)
+        sort_order: integer
+        include_in_rollup: boolean
+        is_reference_data: boolean
+        warn_after_hours: integer
+        breach_after_hours: integer
+        basis_models: varchar(500)
+    columns:
+      - name: source_key
+        description: Stable identifier for the logical source or sub-source.
+        tests:
+          - unique
+          - not_null
+      - name: display_name
+        description: Human-friendly label for UI surfaces.
+      - name: parent_source_key
+        description: Parent source for rollups (for example OLIDS subdomains roll up to `olids`).
+      - name: source_group
+        description: Broad domain grouping used for ordering and future filtering.
+      - name: sort_order
+        description: Display order in app-facing freshness views.
+      - name: include_in_rollup
+        description: Whether this source should contribute to a user-facing freshness rollup.
+      - name: is_reference_data
+        description: Marks sources that should not be treated as operational data freshness signals.
+      - name: warn_after_hours
+        description: Hours since latest freshness timestamp before the status turns amber.
+      - name: breach_after_hours
+        description: Hours since latest freshness timestamp before the status turns red.
+      - name: basis_models
+        description: Pipe-delimited list of staging models that underpin the freshness signal.


### PR DESCRIPTION
## Summary
- add a lightweight source freshness config seed for semantic-layer-facing source groups and thresholds
- add a current-state source freshness model covering core OLIDS subdomains plus PDS and Deaths Registry
- add a prod-only current pipeline health rollup from Elementary observability

## Notes
- OLIDS freshness currently rolls up from episode of care, appointments, observations, and medications
- OLIDS thresholds are currently configured to warn after 4 days and breach after 21 days
- this PR is the first dbt-only phase before Snowflake logging/history objects and app consumption
