### PR TITLE
fix: GP is the only dataset including DNAs and future appointments in…

### DIFF
--- a/models/reporting/commissioning/person_history/fct_person_activity_by_month.sql
+++ b/models/reporting/commissioning/person_history/fct_person_activity_by_month.sql
@@ -93,6 +93,7 @@ with date_range AS (-- Generate month start dates for 10 years (120 months)
     from 
         {{ ref('obt_appointment_gp') }} gpa
     left join {{ref('dim_person_pseudo')}} pp on pp.person_id = gpa.person_id
+    where gpa.code not in ('3', '0') -- Attended
     group by 
         pp.sk_patient_id, date_trunc('month', start_date)
 )


### PR DESCRIPTION
… encounters and costs. Removing so in line with other data but this position should be reconsidered more broadly as DNAs carry a cost

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated monthly primary care activity reporting to exclude specific appointment types from aggregate counts, ensuring more accurate activity metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->