### PR TITLE
fix(qof): retain recently-deceased in QOF register comparison denominator

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -25,6 +25,7 @@ vars:
   dbt_audit_schema: "test_audit"
   auto_schema_domains: ['olids']
   qof_reference_date: "2025-11-04"  # EMIS QOF extract date, override via --vars
+  qof_recent_death_months: 3  # register comparison retains patients who died within this many months before qof_reference_date (mirrors EMIS deregistration lag); override via --vars
   # Elementary observability
   disable_dbt_artifacts_autoupload: "{{ target.name not in ['prod', 'snowflake-prod'] }}"
   disable_run_results: "{{ target.name not in ['prod', 'snowflake-prod'] }}"

--- a/models/published/direct_care/olids/db_utils/compare_emis_qof_vs_pit_registers.sql
+++ b/models/published/direct_care/olids/db_utils/compare_emis_qof_vs_pit_registers.sql
@@ -32,7 +32,13 @@ WITH validated_practices AS (
 ),
 
 person_practices AS (
-    -- Filter to patients actively registered at reference date, at validated practices only
+    -- Filter to patients registered at the reference date, at validated practices only.
+    -- Death handling: QOF registers retain patients who died within the reporting period
+    -- (death is not deregistration), and EMIS extracts run on the live practice list where
+    -- the recently deceased have not yet been deregistered. So we keep a patient if they are
+    -- currently active OR died within qof_recent_death_months before the reference date.
+    -- Excluding all deceased (the previous behaviour) under-counted death-heavy registers,
+    -- most visibly Palliative Care (~-9%). Window anchored on qof_reference_date().
     SELECT
         h.person_id,
         h.practice_code,
@@ -41,8 +47,13 @@ person_practices AS (
     INNER JOIN validated_practices vp ON h.practice_code = vp.practice_code
     WHERE h.effective_start_date <= {{ qof_reference_date() }}
       AND (h.effective_end_date IS NULL OR h.effective_end_date > {{ qof_reference_date() }})
-      AND h.is_active = TRUE
-      AND (h.is_deceased = FALSE OR h.death_date_approx > {{ qof_reference_date() }})
+      AND (
+          h.is_active = TRUE
+          OR (
+              h.death_date_approx > DATEADD('month', -{{ var('qof_recent_death_months') }}, {{ qof_reference_date() }})
+              AND h.death_date_approx <= {{ qof_reference_date() }}
+          )
+      )
 ),
 
 -- Get pit register data for each person

--- a/models/published/direct_care/olids/db_utils/compare_emis_qof_vs_pit_registers_summary.sql
+++ b/models/published/direct_care/olids/db_utils/compare_emis_qof_vs_pit_registers_summary.sql
@@ -42,7 +42,7 @@ person_practices AS (
     FROM {{ ref('dim_person_demographics_historical') }} h
     INNER JOIN validated_practices vp ON h.practice_code = vp.practice_code
     WHERE h.effective_start_date <= {{ qof_reference_date() }}
-      AND (h.effective_end_date IS NULL OR h.effective_end_date >= {{ qof_reference_date() }})
+      AND (h.effective_end_date IS NULL OR h.effective_end_date > {{ qof_reference_date() }})
       AND (
           h.is_active = TRUE
           OR (

--- a/models/published/direct_care/olids/db_utils/compare_emis_qof_vs_pit_registers_summary.sql
+++ b/models/published/direct_care/olids/db_utils/compare_emis_qof_vs_pit_registers_summary.sql
@@ -28,7 +28,13 @@ WITH validated_practices AS (
 ),
 
 person_practices AS (
-    -- Filter to patients actively registered at reference date, at validated practices only
+    -- Filter to patients registered at the reference date, at validated practices only.
+    -- Death handling: QOF registers retain patients who died within the reporting period
+    -- (death is not deregistration), and EMIS extracts run on the live practice list where
+    -- the recently deceased have not yet been deregistered. So we keep a patient if they are
+    -- currently active OR died within qof_recent_death_months before the reference date.
+    -- Excluding all deceased (the previous behaviour) under-counted death-heavy registers,
+    -- most visibly Palliative Care (~-9%). Window anchored on qof_reference_date().
     SELECT
         h.person_id,
         h.practice_code,
@@ -37,8 +43,13 @@ person_practices AS (
     INNER JOIN validated_practices vp ON h.practice_code = vp.practice_code
     WHERE h.effective_start_date <= {{ qof_reference_date() }}
       AND (h.effective_end_date IS NULL OR h.effective_end_date >= {{ qof_reference_date() }})
-      AND h.is_active = TRUE
-      AND (h.is_deceased = FALSE OR h.death_date_approx > {{ qof_reference_date() }})
+      AND (
+          h.is_active = TRUE
+          OR (
+              h.death_date_approx > DATEADD('month', -{{ var('qof_recent_death_months') }}, {{ qof_reference_date() }})
+              AND h.death_date_approx <= {{ qof_reference_date() }}
+          )
+      )
 ),
 
 -- Get pit register data for each person


### PR DESCRIPTION
## Problem

The EMIS-vs-OLIDS QOF register comparison (`compare_emis_qof_vs_pit_registers` and `_summary`) excluded **all** deceased patients from the denominator:

```sql
AND h.is_active = TRUE
AND (h.is_deceased = FALSE OR h.death_date_approx > {{ qof_reference_date() }})
```

This has no basis in the QOF v50 patient-selection rules, which gate inclusion on **GMS registration status only** (registered on/before the achievement date, not deregistered before it). Death is not deregistration — and EMIS extracts run on the live practice list, where recently-deceased patients have not yet been deregistered, so EMIS still counts them.

Excluding all deceased systematically under-counted death-heavy registers. **Palliative Care was -9.0%** vs EMIS (the worst register), because end-of-life patients die within the reporting period by definition.

Verified against the QOF v50 Palliative Care spec: the register rule (`PALCARE_DAT ≠ Null AND PALCARENI_DAT = Null`, NI only counting if after the latest diagnosis) is implemented correctly; the discrepancy is purely the comparison denominator's death exclusion.

## Fix

Keep a patient in the denominator if they are **currently active OR died within `qof_recent_death_months` before `qof_reference_date`**. `is_active` is retained (it's the current-registration gate; removing it inflates every register 10-25%). New var `qof_recent_death_months` (default 3) anchors the window on the same reference date as the comparison.

## Effect (aggregate, ref date 2025-11-04, validated practices)

| register | before | after |
|---|---|---|
| Palliative Care | -9.0% | **-2.8%** |
| Heart Failure | -3.1% | -2.0% |
| Stroke/TIA | -2.0% | -1.2% |
| Cancer | -1.0% | -0.3% |
| Diabetes | -0.4% | -0.04% |

Registers without a death-driven undercount are essentially unchanged. (COPD/Osteoporosis remain ~+3% over for a separate, pre-existing register-logic reason unrelated to this change; investigated, no safe fix.)

## Notes / follow-up

- The 3-month window is **empirically calibrated** to EMIS deregistration lag at this reference date (QOF itself has no death logic). It's exposed as `qof_recent_death_months` so it can be revalidated against the per-patient EMIS extract (incoming) — ~4 months lands palliative almost exactly; 3 chosen as the rounder, conservative default.
- Residual -2.8% on palliative needs the per-patient EMIS match to resolve fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable parameter to retain patients who died within a specified timeframe before the reference date, defaulting to 3 months and customisable via configuration.

* **Improvements**
  * Updated patient validation models to include recently deceased patients within the configured window, alongside currently active patients, enhancing cohort analysis accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->