### PR TITLE
fix(adult-imms): dedup person_id in RSV/shingles given+declined

### DIFF
--- a/models/modelling/olids/programme/adult_imms/int_adult_imms_rsv_vaccination_given.sql
+++ b/models/modelling/olids/programme/adult_imms/int_adult_imms_rsv_vaccination_given.sql
@@ -20,4 +20,14 @@ SELECT
         ,VACCINATION_STATUS AS rsv_first_status
         ,AGE_AT_EVENT as  rsv_first_event_age
     FROM {{ ref('int_adult_imms_vaccination_status_current') }}
-    WHERE VACCINE_ID in ('RSV_1','RSV_1B','RSV_1C') and VACCINATION_STATUS in ('Completed', 'OutofSchedule')  
+    WHERE VACCINE_ID in ('RSV_1','RSV_1B','RSV_1C') and VACCINATION_STATUS in ('Completed', 'OutofSchedule')
+-- Guard one row per person. Upstream can leave several applicable RSV variants live when the
+-- 'Not applicable' rules don't cover overlapping eligibility (e.g. care-home AND pregnant).
+-- Keep the most complete, most recent. Real fix is upstream mutual-exclusion in
+-- int_adult_imms_vaccination_events_current.
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY PERSON_ID
+        ORDER BY CASE WHEN VACCINATION_STATUS = 'Completed' THEN 0 ELSE 1 END,
+                 VACCINATION_DATE DESC,
+                 VACCINE_ID
+    ) = 1

--- a/models/modelling/olids/programme/adult_imms/int_adult_imms_shingles_vaccination_declined.sql
+++ b/models/modelling/olids/programme/adult_imms/int_adult_imms_shingles_vaccination_declined.sql
@@ -24,4 +24,14 @@ SELECT
     LEFT JOIN {{ ref('int_adult_imms_vaccination_status_current') }}  v2 
     ON v1.PERSON_ID = v2.PERSON_ID AND v2.VACCINE_ID in ('SHING_2','SHING_2B','SHING_2C') AND v2.VACCINATION_STATUS in ('Declined')  
     AND v1.VACCINATION_DATE <> v2.VACCINATION_DATE
-    WHERE v1.VACCINE_ID in ('SHING_1','SHING_1B','SHING_1C') and v1.VACCINATION_STATUS in ('Declined')  
+    WHERE v1.VACCINE_ID in ('SHING_1','SHING_1B','SHING_1C') and v1.VACCINATION_STATUS in ('Declined')
+-- Guard one row per person. Upstream can leave several applicable SHING_1/SHING_2 variants live when
+-- the 'Not applicable' rules don't cover overlapping eligibility (e.g. turned-65 AND immunosuppressed);
+-- the self-join then multiplies them. Keep the most recent dose pair.
+-- Real fix is upstream mutual-exclusion in int_adult_imms_vaccination_events_current.
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY v1.PERSON_ID
+        ORDER BY v1.VACCINATION_DATE DESC,
+                 v2.VACCINATION_DATE DESC NULLS LAST,
+                 v1.VACCINE_ID
+    ) = 1

--- a/models/modelling/olids/programme/adult_imms/int_adult_imms_shingles_vaccination_given.sql
+++ b/models/modelling/olids/programme/adult_imms/int_adult_imms_shingles_vaccination_given.sql
@@ -24,4 +24,15 @@ SELECT
     LEFT JOIN {{ ref('int_adult_imms_vaccination_status_current') }}  v2 
     ON v1.PERSON_ID = v2.PERSON_ID AND v2.VACCINE_ID in ('SHING_2','SHING_2B','SHING_2C') AND v2.VACCINATION_STATUS in ('Completed', 'OutofSchedule')  
     AND v1.VACCINATION_DATE <> v2.VACCINATION_DATE
-    WHERE v1.VACCINE_ID in ('SHING_1','SHING_1B','SHING_1C') and v1.VACCINATION_STATUS in ('Completed', 'OutofSchedule')  
+    WHERE v1.VACCINE_ID in ('SHING_1','SHING_1B','SHING_1C') and v1.VACCINATION_STATUS in ('Completed', 'OutofSchedule')
+-- Guard one row per person. Upstream can leave several applicable SHING_1/SHING_2 variants live when
+-- the 'Not applicable' rules don't cover overlapping eligibility (e.g. turned-65 AND immunosuppressed);
+-- the self-join then multiplies them (up to 3x3). Keep the most complete, most recent dose pair.
+-- Real fix is upstream mutual-exclusion in int_adult_imms_vaccination_events_current.
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY v1.PERSON_ID
+        ORDER BY CASE WHEN v1.VACCINATION_STATUS = 'Completed' THEN 0 ELSE 1 END,
+                 v1.VACCINATION_DATE DESC,
+                 v2.VACCINATION_DATE DESC NULLS LAST,
+                 v1.VACCINE_ID
+    ) = 1


### PR DESCRIPTION
## What

Adds a one-row-per-person guard (`QUALIFY ROW_NUMBER()`) to three adult-imms intermediates:
- `int_adult_imms_rsv_vaccination_given`
- `int_adult_imms_shingles_vaccination_given`
- `int_adult_imms_shingles_vaccination_declined`

## Why

A full-refresh build failed their `person_id` uniqueness tests, which skipped the RSV/shingles status fcts. Some people match more than one cohort at once, so the `'Not applicable'` rules in #753 don't collapse them to a single vaccine variant and they end up with duplicate rows:
- **RSV** — care-home **and** pregnant
- **Shingles** — turned 65 after Sep 2023 **and** immunosuppressed

## Note for @KateHomer55

This is a downstream patch to unblock the build. The cleaner fix is upstream in `int_adult_imms_vaccination_events_current` — deciding which single variant applies to those overlapping people. That's a clinical call, so flagging it to you. Happy to drop this guard if you'd rather fix it upstream.

Validated on dev: 14/14 pass.
