### PR TITLE
fix(semantic): correct fact/dimension alias direction in sem_olids_observations

### DIFF
--- a/models/semantic/sem_olids_observations.sql
+++ b/models/semantic/sem_olids_observations.sql
@@ -166,9 +166,9 @@ FACTS(
     lft.bilirubin_value AS bilirubin_value COMMENT = 'Latest total bilirubin (umol/L)',
 
     -- Haematology
-    haemoglobin.inferred_value AS haemoglobin_value WITH SYNONYMS = ('Hb', 'haemoglobin') COMMENT = 'Latest haemoglobin (g/L)',
-    platelets.inferred_value AS platelet_count WITH SYNONYMS = ('platelets', 'PLT') COMMENT = 'Latest platelet count (10^9/L)',
-    eosinophils.inferred_value AS eosinophil_count WITH SYNONYMS = ('eosinophils', 'eos') COMMENT = 'Latest blood eosinophil count (10^9/L)',
+    haemoglobin.haemoglobin_value AS inferred_value WITH SYNONYMS = ('Hb', 'haemoglobin') COMMENT = 'Latest haemoglobin (g/L)',
+    platelets.platelet_count AS inferred_value WITH SYNONYMS = ('platelets', 'PLT') COMMENT = 'Latest platelet count (10^9/L)',
+    eosinophils.eosinophil_count AS inferred_value WITH SYNONYMS = ('eosinophils', 'eos') COMMENT = 'Latest blood eosinophil count (10^9/L)',
 
     -- Frailty
     efi.latest_efi_score_preferred AS latest_efi_score_preferred COMMENT = 'Electronic Frailty Index score (0-1). Uses most recent of eFI or eFI2.',
@@ -198,10 +198,10 @@ DIMENSIONS(
     rockwood.latest_rockwood_date AS clinical_effective_date COMMENT = 'Date of latest Rockwood assessment',
     foot_exam.latest_foot_exam_date AS clinical_effective_date COMMENT = 'Date of latest foot examination',
     retinal.latest_retinal_date AS clinical_effective_date COMMENT = 'Date of latest retinal screening',
-    lft.last_lft_date AS clinical_effective_date COMMENT = 'Date of latest liver function test (most recent of ALT/GGT/bilirubin)',
-    haemoglobin.clinical_effective_date AS clinical_effective_date COMMENT = 'Date of latest haemoglobin',
-    platelets.clinical_effective_date AS clinical_effective_date COMMENT = 'Date of latest platelet count',
-    eosinophils.clinical_effective_date AS clinical_effective_date COMMENT = 'Date of latest eosinophil count',
+    lft.last_lft_date AS last_lft_date COMMENT = 'Date of latest liver function test (most recent of ALT/GGT/bilirubin)',
+    haemoglobin.latest_haemoglobin_date AS clinical_effective_date COMMENT = 'Date of latest haemoglobin',
+    platelets.latest_platelets_date AS clinical_effective_date COMMENT = 'Date of latest platelet count',
+    eosinophils.latest_eosinophil_date AS clinical_effective_date COMMENT = 'Date of latest eosinophil count',
 
     -- Core Demographics
     demographics.gender AS gender COMMENT = 'Patient gender (Male, Female, Unknown)',


### PR DESCRIPTION
## Summary

Hotfix for the prod `dbt build` failure introduced by #755:

```
First error in model 'sem_olids_observations':
  invalid identifier 'HAEMOGLOBIN_VALUE'
```

## Root cause

In Snowflake `CREATE SEMANTIC VIEW`, a fact/dimension is `table.LOGICAL_NAME AS physical_expression` — the **physical column goes on the right of `AS`** (see the existing `ldl.ldl_cholesterol_value AS cholesterol_value` and `efi.latest_efi_date AS latest_efi_date` lines). The new biomarker facts in #755 had this reversed, so Snowflake tried to resolve the logical alias (`haemoglobin_value`) as a physical column and failed. Only `sem_olids_observations` was affected; the other six models built fine, and Snowflake reports just the first error, so the sibling date-dimension mistakes hadn't surfaced yet.

## Fix

- **Haematology facts** — physical `inferred_value` moved to the right; logical names `haemoglobin_value` / `platelet_count` / `eosinophil_count` on the left.
- **LFT date** — `int_lft_latest` has no `clinical_effective_date`; use its real `last_lft_date` column (mirrors the `efi` date pattern).
- **Haematology dates** — unique logical names (`latest_haemoglobin_date` etc.) backed by the physical `clinical_effective_date`, matching every other date dimension in the view.

7 lines, no behavioural change to any metric — purely correcting the alias direction.

## Validation

Built the semantic view against Snowflake — `dbt build --select sem_olids_observations` → **success** (`6 total | 6 success`). This is a real warehouse build, not just parse, so the `CREATE SEMANTIC VIEW` DDL is confirmed valid.
