### PR TITLE
chore: move analysis seed builders into scripts/seeds

### DIFF
--- a/models/modelling/olids/appointments/int_appointment_gp_clean.yml
+++ b/models/modelling/olids/appointments/int_appointment_gp_clean.yml
@@ -246,7 +246,7 @@ models:
             quality artefacts) will therefore have a NULL nominal cost
             even though base_prices cost is populated — the NULL is
             an intentional data quality signal, not a bug. Extend the
-            seed lower bound in analysis/inflation_indices/build_seed.py
+            seed lower bound in scripts/seeds/inflation_indices/build_seed.py
             if genuine pre-2000 coverage is needed.
       - name: patient_wait_mins
         description: >

--- a/scripts/seeds/inflation_indices/build_seed.py
+++ b/scripts/seeds/inflation_indices/build_seed.py
@@ -34,7 +34,7 @@ from pathlib import Path
 import openpyxl
 
 HERE = Path(__file__).resolve().parent
-REPO_ROOT = HERE.parents[1]
+REPO_ROOT = HERE.parents[2]
 SEED_PATH = REPO_ROOT / "seeds" / "uk_cost_indices.csv"
 
 # Metadata for the seed header row

--- a/scripts/seeds/sds_role_groups/build_seed.py
+++ b/scripts/seeds/sds_role_groups/build_seed.py
@@ -664,7 +664,7 @@ def main() -> None:
             desc_out = desc
         rows.append(f"{code},{desc_out},{sds_group},{analytical},{arrs}")
 
-    out_path = Path(__file__).resolve().parents[2] / "seeds" / "sds_role_groups.csv"
+    out_path = Path(__file__).resolve().parents[3] / "seeds" / "sds_role_groups.csv"
     out_path.write_text("\n".join(rows) + "\n", encoding="utf-8")
     print(f"Wrote {len(rows) - 1} rows to {out_path}")
 

--- a/seeds/sds_role_groups.yml
+++ b/seeds/sds_role_groups.yml
@@ -10,7 +10,7 @@ seeds:
 
       Source: https://digital.nhs.uk/data-and-information/publications/statistical/appointments-in-general-practice/sds-role-groups
       The canonical NHS Digital page is updated in-place when SDS publishes
-      new codes. To refresh this seed, re-run analysis/sds_role_groups/build_seed.py
+      new codes. To refresh this seed, re-run scripts/seeds/sds_role_groups/build_seed.py
       after updating the RAW list from the latest HTML table.
 
       Columns:

--- a/seeds/uk_cost_indices.yml
+++ b/seeds/uk_cost_indices.yml
@@ -19,7 +19,7 @@ seeds:
 
       If genuine pre-2000 coverage is needed: the HMT GDP deflator
       series goes back to 1955-56; bump the `>= 2000` filter in
-      analysis/inflation_indices/build_seed.py and regenerate.
+      scripts/seeds/inflation_indices/build_seed.py and regenerate.
 
       Columns:
       * gdp_deflator  — HMT / ONS GDP deflator at market prices, fiscal year,
@@ -54,7 +54,7 @@ seeds:
       forecasts forward to 2030-31. CPI / CPIH are exposed alongside for
       sensitivity analysis or contracts that explicitly specify them.
 
-      Re-run analysis/inflation_indices/build_seed.py after downloading the
+      Re-run scripts/seeds/inflation_indices/build_seed.py after downloading the
       latest HMT GDP deflator XLSX and fresh ONS CPI / CPIH JSON to refresh.
     config:
       meta:


### PR DESCRIPTION
Relocate the `build_seed.py` scripts (and their gitignored source data) from `/analysis` into `scripts/seeds/`. They generate dbt seeds, so they belong with the other tooling under `scripts/`, not in `/analyses` (which is for dbt analysis SQL).

## Changes
- Move `analysis/inflation_indices/` and `analysis/sds_role_groups/` → `scripts/seeds/` (git tracks both as renames; gitignored `.csv`/`.xlsx`/`.pdf` source data moved alongside on disk)
- Fix repo-root path depth in both scripts now they sit one dir deeper (`parents[2]` / `parents[3]`) — verified both resolve to the repo root
- Update 4 doc references to the new path across `int_appointment_gp_clean.yml`, `uk_cost_indices.yml`, `sds_role_groups.yml`

`/analysis` is removed and no longer tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganised internal data seed generation scripts to a new directory structure.
  * Updated documentation references to reflect script location changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->