### PR TITLE
feat: add hospice person-status dims

### DIFF
--- a/models/modelling/olids/person_attributes/int_hospice_status_all.sql
+++ b/models/modelling/olids/person_attributes/int_hospice_status_all.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All hospice involvement observations from ECL source.
+Uses cluster IDs: HOSPICE_RESIDENT_COD, HOSPICE_FULLCARE_COD, HOSPICE_ATHOME_COD
+(involvement) and HOSPICE_DISCHARGE_COD (resolution).
+HOSPICE_COD is excluded as it is the union of the three involvement clusters
+and would produce duplicate rows.
+*/
+
+SELECT
+    obs.id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS code_description,
+    obs.cluster_id AS source_cluster_id
+FROM ({{ get_observations("'HOSPICE_RESIDENT_COD', 'HOSPICE_FULLCARE_COD', 'HOSPICE_ATHOME_COD', 'HOSPICE_DISCHARGE_COD'", source='ECL_CACHE') }}) obs
+WHERE obs.clinical_effective_date IS NOT NULL
+ORDER BY person_id, clinical_effective_date DESC

--- a/models/modelling/olids/person_attributes/int_hospice_status_all.yml
+++ b/models/modelling/olids/person_attributes/int_hospice_status_all.yml
@@ -1,0 +1,17 @@
+models:
+  - name: int_hospice_status_all
+    description: 'Hospice involvement observations from ECL source.
+
+      One row per hospice observation using HOSPICE_RESIDENT_COD, HOSPICE_FULLCARE_COD,
+      HOSPICE_ATHOME_COD (involvement) and HOSPICE_DISCHARGE_COD (resolution) clusters.
+
+      Hospice involvement is not routinely or consistently coded in OLIDS primary care
+      (GP) data, so volumes are low and undercount the true hospice population.'
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - cluster_ids_exist:
+          arguments:
+            cluster_ids: HOSPICE_RESIDENT_COD, HOSPICE_FULLCARE_COD, HOSPICE_ATHOME_COD, HOSPICE_DISCHARGE_COD

--- a/models/reporting/olids/person_status/dim_person_hospice_care.sql
+++ b/models/reporting/olids/person_status/dim_person_hospice_care.sql
@@ -1,0 +1,100 @@
+{{
+    config(
+        materialized='table',
+        tags=['dimension', 'person', 'hospice', 'care'],
+        cluster_by=['person_id'])
+}}
+
+-- Person Hospice Care Dimension Table
+-- Persons under the care of a hospice service: full clinical care (HOSPICE_FULLCARE_COD)
+-- or hospice-at-home / community service (HOSPICE_ATHOME_COD).
+-- These are services, not residence, so they are resolved by HOSPICE_DISCHARGE_COD only.
+-- Per-service flags are current when the latest service event is not superseded by a discharge.
+
+WITH full_care AS (
+    SELECT
+        person_id,
+        MAX(clinical_effective_date) AS latest_full_care_date
+    FROM {{ ref('int_hospice_status_all') }}
+    WHERE source_cluster_id = 'HOSPICE_FULLCARE_COD'
+    GROUP BY person_id
+),
+
+at_home AS (
+    SELECT
+        person_id,
+        MAX(clinical_effective_date) AS latest_at_home_date
+    FROM {{ ref('int_hospice_status_all') }}
+    WHERE source_cluster_id = 'HOSPICE_ATHOME_COD'
+    GROUP BY person_id
+),
+
+discharge AS (
+    SELECT
+        person_id,
+        MAX(clinical_effective_date) AS latest_discharge_date
+    FROM {{ ref('int_hospice_status_all') }}
+    WHERE source_cluster_id = 'HOSPICE_DISCHARGE_COD'
+    GROUP BY person_id
+),
+
+latest_care AS (
+    -- Latest care event overall (either service) for code/term details
+    SELECT
+        person_id,
+        clinical_effective_date,
+        concept_code,
+        code_description,
+        source_cluster_id
+    FROM {{ ref('int_hospice_status_all') }}
+    WHERE source_cluster_id IN ('HOSPICE_FULLCARE_COD', 'HOSPICE_ATHOME_COD')
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY person_id
+        ORDER BY clinical_effective_date DESC, id DESC
+    ) = 1
+),
+
+person_flags AS (
+    SELECT
+        COALESCE(fc.person_id, ah.person_id) AS person_id,
+        fc.latest_full_care_date,
+        ah.latest_at_home_date,
+        d.latest_discharge_date,
+        -- Service is current when its latest event is not superseded by a later discharge
+        fc.latest_full_care_date IS NOT NULL
+            AND fc.latest_full_care_date >= COALESCE(d.latest_discharge_date, '1900-01-01') AS is_hospice_full_care,
+        ah.latest_at_home_date IS NOT NULL
+            AND ah.latest_at_home_date >= COALESCE(d.latest_discharge_date, '1900-01-01') AS is_hospice_at_home
+    FROM full_care fc
+    FULL OUTER JOIN at_home ah
+        ON fc.person_id = ah.person_id
+    LEFT JOIN discharge d
+        ON COALESCE(fc.person_id, ah.person_id) = d.person_id
+)
+
+SELECT
+    pf.person_id,
+    pp.sk_patient_id,
+    lc.clinical_effective_date AS latest_hospice_care_date,
+    pf.latest_full_care_date,
+    pf.latest_at_home_date,
+    pf.latest_discharge_date,
+    lc.concept_code,
+    lc.code_description,
+    lc.source_cluster_id,
+    pf.is_hospice_full_care,
+    pf.is_hospice_at_home,
+    pf.is_hospice_full_care OR pf.is_hospice_at_home AS is_under_hospice_care,
+    CASE
+        WHEN pf.is_hospice_full_care OR pf.is_hospice_at_home THEN 'Under Hospice Care'
+        ELSE 'Discharged from Hospice'
+    END AS hospice_care_status
+FROM person_flags pf
+JOIN {{ ref('int_patient_person_unique') }} pp
+    ON pf.person_id = pp.person_id
+LEFT JOIN latest_care lc
+    ON pf.person_id = lc.person_id
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY pf.person_id
+    ORDER BY pp.sk_patient_id
+) = 1

--- a/models/reporting/olids/person_status/dim_person_hospice_care.yml
+++ b/models/reporting/olids/person_status/dim_person_hospice_care.yml
@@ -1,0 +1,60 @@
+models:
+  - name: dim_person_hospice_care
+    description: 'Latest hospice care status for persons under a hospice service.
+
+      One row per person with a HOSPICE_FULLCARE_COD or HOSPICE_ATHOME_COD record.
+      Each service flag is current when its latest event is not superseded by a later
+      HOSPICE_DISCHARGE_COD record.
+
+      Hospice involvement is not routinely or consistently coded in OLIDS primary care
+      (GP) data, so counts are low and should be read as a floor, not true prevalence.
+      Deceased persons are retained (no active/death filter) as hospice cohorts are
+      largely end-of-life. For the broader palliative/end-of-life population see
+      fct_person_palliative_care_register (QOF).'
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: person_id
+        description: Person identifier
+        tests:
+          - unique
+          - not_null
+      - name: sk_patient_id
+        description: Surrogate key for patient
+      - name: latest_hospice_care_date
+        description: Date of most recent hospice care observation (either service)
+        tests:
+          - not_null
+      - name: latest_full_care_date
+        description: Date of most recent full clinical care observation (NULL if none)
+      - name: latest_at_home_date
+        description: Date of most recent hospice-at-home / community service observation (NULL if none)
+      - name: latest_discharge_date
+        description: Date of most recent hospice discharge observation (NULL if none)
+      - name: concept_code
+        description: SNOMED concept code of the latest care observation
+      - name: code_description
+        description: Term for the latest care observation
+      - name: source_cluster_id
+        description: Source cluster ID of the latest care observation
+      - name: is_hospice_full_care
+        description: Currently under full clinical care by a hospice
+        tests:
+          - not_null
+      - name: is_hospice_at_home
+        description: Currently under a hospice-at-home / community hospice service
+        tests:
+          - not_null
+      - name: is_under_hospice_care
+        description: Currently under any hospice service (full care or at-home)
+        tests:
+          - not_null
+      - name: hospice_care_status
+        description: Text description of hospice care status
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['Under Hospice Care', 'Discharged from Hospice']

--- a/models/reporting/olids/person_status/dim_person_hospice_resident.sql
+++ b/models/reporting/olids/person_status/dim_person_hospice_resident.sql
@@ -1,0 +1,91 @@
+{{
+    config(
+        materialized='table',
+        tags=['dimension', 'person', 'hospice', 'residence'],
+        cluster_by=['person_id'])
+}}
+
+-- Person Hospice Resident Dimension Table
+-- Latest "lives in hospice" status for persons with a HOSPICE_RESIDENT_COD record.
+-- "Lives in hospice" (1024771000000108) is a member of the RESIDE_COD "type of residence"
+-- cluster, so residence is mutually exclusive: a later RESIDE_COD code of any other type,
+-- or a HOSPICE_DISCHARGE_COD, supersedes hospice residency.
+-- Note: RESIDE_COD mixes places with housing-status findings (e.g. 'Housing adequate'),
+-- so a later finding-type code can supersede residency (same limitation as dim_person_homeless).
+
+WITH hospice_resident AS (
+    -- Latest hospice resident event per person
+    SELECT
+        person_id,
+        clinical_effective_date,
+        concept_code,
+        code_description,
+        source_cluster_id
+    FROM {{ ref('int_hospice_status_all') }}
+    WHERE source_cluster_id = 'HOSPICE_RESIDENT_COD'
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY person_id
+        ORDER BY clinical_effective_date DESC, id DESC
+    ) = 1
+),
+
+other_residence AS (
+    -- Latest non-hospice residence code; supersedes hospice residency when more recent
+    SELECT
+        obs.person_id,
+        MAX(obs.clinical_effective_date) AS latest_other_residence_date
+    FROM ({{ get_observations("'RESIDE_COD'", source='UKHSA_COVID') }}) obs
+    WHERE obs.clinical_effective_date IS NOT NULL
+        AND obs.mapped_concept_code != '1024771000000108'
+    GROUP BY obs.person_id
+),
+
+discharge AS (
+    SELECT
+        person_id,
+        MAX(clinical_effective_date) AS latest_discharge_date
+    FROM {{ ref('int_hospice_status_all') }}
+    WHERE source_cluster_id = 'HOSPICE_DISCHARGE_COD'
+    GROUP BY person_id
+),
+
+resident_status AS (
+    SELECT
+        hr.person_id,
+        hr.clinical_effective_date AS latest_hospice_resident_date,
+        o.latest_other_residence_date,
+        d.latest_discharge_date,
+        hr.concept_code,
+        hr.code_description,
+        hr.source_cluster_id,
+        -- Current resident only if the hospice event is the most recent residence signal
+        hr.clinical_effective_date >= COALESCE(o.latest_other_residence_date, '1900-01-01')
+            AND hr.clinical_effective_date >= COALESCE(d.latest_discharge_date, '1900-01-01') AS is_hospice_resident
+    FROM hospice_resident hr
+    LEFT JOIN other_residence o
+        ON hr.person_id = o.person_id
+    LEFT JOIN discharge d
+        ON hr.person_id = d.person_id
+)
+
+SELECT
+    rs.person_id,
+    pp.sk_patient_id,
+    rs.latest_hospice_resident_date,
+    rs.latest_other_residence_date,
+    rs.latest_discharge_date,
+    rs.concept_code,
+    rs.code_description,
+    rs.source_cluster_id,
+    rs.is_hospice_resident,
+    CASE
+        WHEN rs.is_hospice_resident THEN 'Hospice Resident'
+        ELSE 'No Longer Hospice Resident'
+    END AS hospice_resident_status
+FROM resident_status rs
+JOIN {{ ref('int_patient_person_unique') }} pp
+    ON rs.person_id = pp.person_id
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY rs.person_id
+    ORDER BY pp.sk_patient_id
+) = 1

--- a/models/reporting/olids/person_status/dim_person_hospice_resident.yml
+++ b/models/reporting/olids/person_status/dim_person_hospice_resident.yml
@@ -1,0 +1,50 @@
+models:
+  - name: dim_person_hospice_resident
+    description: 'Latest hospice resident status for persons living in a hospice.
+
+      One row per person with a HOSPICE_RESIDENT_COD record. "Lives in hospice" is a
+      RESIDE_COD residence type, so residency is current only when the hospice event is
+      more recent than any other RESIDE_COD code and any HOSPICE_DISCHARGE_COD record.
+
+      Hospice involvement is not routinely or consistently coded in OLIDS primary care
+      (GP) data, so counts are low and should be read as a floor, not true prevalence.
+      Deceased persons are retained (no active/death filter) as hospice cohorts are
+      largely end-of-life. For the broader palliative/end-of-life population see
+      fct_person_palliative_care_register (QOF).'
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: person_id
+        description: Person identifier
+        tests:
+          - unique
+          - not_null
+      - name: sk_patient_id
+        description: Surrogate key for patient
+      - name: latest_hospice_resident_date
+        description: Date of most recent hospice resident observation
+        tests:
+          - not_null
+      - name: latest_other_residence_date
+        description: Date of most recent non-hospice RESIDE_COD residence code (NULL if none)
+      - name: latest_discharge_date
+        description: Date of most recent hospice discharge observation (NULL if none)
+      - name: concept_code
+        description: SNOMED concept code of the latest resident observation
+      - name: code_description
+        description: Term for the latest resident observation
+      - name: source_cluster_id
+        description: Source cluster ID of the latest resident observation
+      - name: is_hospice_resident
+        description: Currently living in a hospice (hospice event not superseded by a later residence code or discharge)
+        tests:
+          - not_null
+      - name: hospice_resident_status
+        description: Text description of resident status
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['Hospice Resident', 'No Longer Hospice Resident']


### PR DESCRIPTION
## What

New person-status models for hospice involvement, following the existing care-home / housebound / homeless pattern.

**Intermediate** — `int_hospice_status_all` (person_attributes)
- One row per observation across the ECL clusters: `HOSPICE_RESIDENT_COD`, `HOSPICE_FULLCARE_COD`, `HOSPICE_ATHOME_COD` (involvement) and `HOSPICE_DISCHARGE_COD` (resolution). `HOSPICE_COD` excluded (union of the involvement clusters — would double-count).

**Dimensions** (one row per person, `person_id` unique + not_null)
- `dim_person_hospice_resident` — living in a hospice. `1024771000000108 |Lives in hospice|` is a `RESIDE_COD` residence type, so residency is current only when the hospice event is more recent than any other `RESIDE_COD` code **and** any discharge — mirrors `dim_person_homeless`.
- `dim_person_hospice_care` — under a hospice service, with `is_hospice_full_care` / `is_hospice_at_home` / `is_under_hospice_care` flags, resolved by discharge only (services aren't residence).

## Notes
- **Deceased retained**: joins to `int_patient_person_unique` only — no active/death filter — since hospice cohorts are largely end-of-life.
- **Sparse coding**: hospice involvement is not routinely coded in OLIDS GP data — current dev volumes are 7 residents / 32 under care. Docs flag this as a floor and point analysts to `fct_person_palliative_care_register` for the broader cohort (~70% overlap).

## Testing
`dbt build` on all three: 3 models + 15 tests, all pass (unique/not_null `person_id`, accepted_values on status columns, `cluster_ids_exist`).