### PR TITLE
fix(demographics): retain deceased patients in dim_person_demographics (#744)

### DIFF
--- a/models/reporting/olids/person_demographics/dim_person_demographics_historical.sql
+++ b/models/reporting/olids/person_demographics/dim_person_demographics_historical.sql
@@ -274,7 +274,18 @@ SELECT
     -- SCD-2 fields
     pwa.effective_start_date,
     pwa.effective_end_date,
-    pwa.is_current,
+    -- is_current = latest retained period per person (computed after the
+    -- practice_code filter below; window functions evaluate after WHERE).
+    -- Deceased patients' open-ended ghost period lacks a registration and is
+    -- dropped, so flagging the open period (effective_end_date IS NULL) would
+    -- leave them with no current row. See issue #744.
+    CASE
+        WHEN ROW_NUMBER() OVER (
+            PARTITION BY pwa.person_id
+            ORDER BY pwa.effective_start_date DESC
+        ) = 1 THEN TRUE
+        ELSE FALSE
+    END AS is_current,
     pwa.period_sequence,
 
     -- Status flags (temporal: was the registration active at the END of this period?)

--- a/models/reporting/olids/person_demographics/dim_person_demographics_historical.yml
+++ b/models/reporting/olids/person_demographics/dim_person_demographics_historical.yml
@@ -58,7 +58,7 @@ models:
         description: 'End date of this demographic period (NULL if current, SCD-2)'
 
       - name: is_current
-        description: 'Flag indicating if this is the current period for the person (SCD-2)'
+        description: 'Flag for the latest retained period per person. Computed after the registration filter, so deceased patients (whose open-ended period is dropped) keep a current row (SCD-2).'
         tests:
           - not_null
 


### PR DESCRIPTION
@
Closes #744

## Problem
Deceased patients had `IS_CURRENT = FALSE` on every period in `dim_person_demographics_historical`, so they were silently dropped from `dim_person_demographics` (which filters `WHERE is_current = TRUE`).

Cause: the SCD-2 builder created an open-ended period starting at the deregistration date. For deceased patients the registration `effective_end_date` (death date) is earlier than that period start, so no registration matched and the row was removed by the `practice_code IS NOT NULL` filter. The remaining periods all had a populated `effective_end_date`, so `IS_CURRENT` was `FALSE` everywhere.

## Fix
Compute `is_current` as the latest retained period per person using `ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY effective_start_date DESC)` in the final `SELECT`. Window functions evaluate after `WHERE`, so this runs over the filtered set — no extra CTE needed. The most recent valid period is now flagged current, including for deceased patients.

## Validation
- `dbt build` on `dim_person_demographics_historical` + `dim_person_demographics`: all 23 tests pass (uniqueness on `person_id`/`effective_start_date`, `not_null` on `is_current`).
- All 46,208 deceased patients now have exactly one current row (previously zero).
@