### PR TITLE
fix(ltc_lcs): rename MDT Review to Remote Desktop Review (RDR)

### DIFF
--- a/models/modelling/olids/programme/ltc_lcs/moc/int_ltc_lcs_moc_careplan_sharing.sql
+++ b/models/modelling/olids/programme/ltc_lcs/moc/int_ltc_lcs_moc_careplan_sharing.sql
@@ -1,6 +1,6 @@
 -- LTC LCS: Model of Care activity - Care plan sharing completed
 -- Flags persons with a Long term condition summary sent to patient event in the last 12 months.
--- Used as stage 2 in HRCS2 / HRS2 (alongside MDT review) and as the only stage 2 activity in MRS2 / LRS2.
+-- Used as stage 2 in HRCS2 / HRS2 (alongside Remote Desktop Review (RDR)) and as the only stage 2 activity in MRS2 / LRS2.
 
 with events as (
     select

--- a/models/modelling/olids/programme/ltc_lcs/moc/int_ltc_lcs_moc_remote_desktop_review.sql
+++ b/models/modelling/olids/programme/ltc_lcs/moc/int_ltc_lcs_moc_remote_desktop_review.sql
@@ -1,11 +1,12 @@
--- LTC LCS: Model of Care activity - MDT review completed
+-- LTC LCS: Model of Care activity - Remote Desktop Review (RDR) completed
 -- Flags persons with a Chronic disease management annual review completed event in the last 12 months.
--- Used by HRCS2A / HRS2A EMIS searches (HRCS/HRS pathways only — MRS/LRS do not have an MDT step).
+-- Used by HRCS2A / HRS2A EMIS searches (HRCS/HRS pathways only — MRS/LRS do not have an RDR step).
 
 with events as (
     select
         person_id,
         clinical_effective_date
+    -- 'mdt_review_completed_vs1' is the warehouse valueset identifier for the RDR concept; left unchanged.
     from ({{ get_ltc_lcs_observations_latest("mdt_review_completed_vs1") }})
     where clinical_effective_date >= dateadd(month, -12, current_date())
       and clinical_effective_date <= current_date()
@@ -14,6 +15,6 @@ with events as (
 select
     person_id,
     max(clinical_effective_date) as latest_completed_date,
-    true as mdt_review_completed
+    true as remote_desktop_review_completed
 from events
 group by person_id

--- a/models/modelling/olids/programme/ltc_lcs/moc/int_ltc_lcs_moc_remote_desktop_review.yml
+++ b/models/modelling/olids/programme/ltc_lcs/moc/int_ltc_lcs_moc_remote_desktop_review.yml
@@ -1,7 +1,7 @@
 models:
-  - name: int_ltc_lcs_moc_mdt_review
+  - name: int_ltc_lcs_moc_remote_desktop_review
     description: |
-      LTC LCS Model of Care - MDT review completed.
+      LTC LCS Model of Care - Remote Desktop Review (RDR) completed.
 
       Flags persons with a Chronic disease management annual review completed event
       (<< 888461000000107) recorded in the last 12 months. One row per person.
@@ -24,10 +24,10 @@ models:
           - not_null
           - unique
       - name: latest_completed_date
-        description: Most recent MDT review date within the last 12 months
+        description: Most recent Remote Desktop Review (RDR) date within the last 12 months
         data_tests:
           - not_null
-      - name: mdt_review_completed
-        description: Always true — row presence indicates an MDT review event in the last 12 months
+      - name: remote_desktop_review_completed
+        description: Always true — row presence indicates a Remote Desktop Review (RDR) event in the last 12 months
         data_tests:
           - not_null

--- a/models/published/direct_care/olids/ltc_lcs/ltc_lcs_risk_stratification_base.sql
+++ b/models/published/direct_care/olids/ltc_lcs/ltc_lcs_risk_stratification_base.sql
@@ -119,8 +119,8 @@ select
     -- ============================================================
     rs.moc_check_test_completed,
     rs.moc_check_test_date,
-    rs.moc_mdt_review_completed,
-    rs.moc_mdt_review_date,
+    rs.moc_remote_desktop_review_completed,
+    rs.moc_remote_desktop_review_date,
     rs.moc_careplan_sharing_completed,
     rs.moc_careplan_sharing_date,
     rs.moc_stage_2_completed,

--- a/models/published/direct_care/olids/ltc_lcs/ltc_lcs_risk_stratification_base.yml
+++ b/models/published/direct_care/olids/ltc_lcs/ltc_lcs_risk_stratification_base.yml
@@ -208,18 +208,18 @@ models:
         description: Check & Test appointment completed in last 12 months
       - name: moc_check_test_date
         description: Latest Check & Test appointment date
-      - name: moc_mdt_review_completed
-        description: MDT review completed in last 12 months
-      - name: moc_mdt_review_date
-        description: Latest MDT review date
+      - name: moc_remote_desktop_review_completed
+        description: Remote Desktop Review (RDR) completed in last 12 months
+      - name: moc_remote_desktop_review_date
+        description: Latest Remote Desktop Review (RDR) date
       - name: moc_careplan_sharing_completed
         description: Care plan shared with patient in last 12 months
       - name: moc_careplan_sharing_date
         description: Latest care plan sharing date
       - name: moc_stage_2_completed
-        description: Stage 2 done using pathway-specific rule (HRCS/HRS = MDT review OR careplan sharing; MRS/LRS = careplan sharing only)
+        description: Stage 2 done using pathway-specific rule (HRCS/HRS = Remote Desktop Review (RDR) OR careplan sharing; MRS/LRS = careplan sharing only)
       - name: moc_stage_2_date
-        description: Effective stage 2 date (earliest MDT / careplan for HRCS/HRS; careplan for MRS/LRS)
+        description: Effective stage 2 date (earliest RDR / careplan for HRCS/HRS; careplan for MRS/LRS)
       - name: moc_discussion_completed
         description: Discussion appointment completed in last 12 months
       - name: moc_discussion_date
@@ -243,11 +243,11 @@ models:
       - name: moc_stage_completed
         description: Furthest MOC pathway stage reached in the last 12 months (0-4)
       - name: moc_stage_completed_label
-        description: Readable label for the furthest MOC stage reached (Not started / Check & Test / MDT / Careplan / Careplan sharing / Discussion / Follow-up)
+        description: Readable label for the furthest MOC stage reached (Not started / Check & Test / RDR / Careplan / Careplan sharing / Discussion / Follow-up)
       - name: moc_pathway_status
         description: "Overall MOC cycle state: 'Not started' | 'In progress' | 'Cycle complete' (all four stages recorded, equivalent to moc_cycle_complete=true) | 'Declined'"
       - name: moc_next_action
-        description: "Next MOC action needed (Check & Test / MDT / Careplan / Careplan sharing / Discussion / Follow-up); NULL when no action is required (cycle complete or declined)"
+        description: "Next MOC action needed (Check & Test / RDR / Careplan / Careplan sharing / Discussion / Follow-up); NULL when no action is required (cycle complete or declined)"
       - name: moc_cycle_complete
         description: True if all four MOC stages recorded in the last 12m
 

--- a/models/published/secondary_use/olids/ltc_lcs/ltc_lcs_risk_stratification_base_secondary_use.yml
+++ b/models/published/secondary_use/olids/ltc_lcs/ltc_lcs_risk_stratification_base_secondary_use.yml
@@ -198,18 +198,18 @@ models:
         description: Check & Test appointment completed in last 12 months
       - name: moc_check_test_date
         description: Latest Check & Test appointment date
-      - name: moc_mdt_review_completed
-        description: MDT review completed in last 12 months
-      - name: moc_mdt_review_date
-        description: Latest MDT review date
+      - name: moc_remote_desktop_review_completed
+        description: Remote Desktop Review (RDR) completed in last 12 months
+      - name: moc_remote_desktop_review_date
+        description: Latest Remote Desktop Review (RDR) date
       - name: moc_careplan_sharing_completed
         description: Care plan shared with patient in last 12 months
       - name: moc_careplan_sharing_date
         description: Latest care plan sharing date
       - name: moc_stage_2_completed
-        description: Stage 2 done using pathway-specific rule (HRCS/HRS = MDT review OR careplan sharing; MRS/LRS = careplan sharing only)
+        description: Stage 2 done using pathway-specific rule (HRCS/HRS = Remote Desktop Review (RDR) OR careplan sharing; MRS/LRS = careplan sharing only)
       - name: moc_stage_2_date
-        description: Effective stage 2 date (earliest MDT / careplan for HRCS/HRS; careplan for MRS/LRS)
+        description: Effective stage 2 date (earliest RDR / careplan for HRCS/HRS; careplan for MRS/LRS)
       - name: moc_discussion_completed
         description: Discussion appointment completed in last 12 months
       - name: moc_discussion_date
@@ -233,11 +233,11 @@ models:
       - name: moc_stage_completed
         description: Furthest MOC pathway stage reached in the last 12 months (0-4)
       - name: moc_stage_completed_label
-        description: Readable label for the furthest MOC stage reached (Not started / Check & Test / MDT / Careplan / Careplan sharing / Discussion / Follow-up)
+        description: Readable label for the furthest MOC stage reached (Not started / Check & Test / RDR / Careplan / Careplan sharing / Discussion / Follow-up)
       - name: moc_pathway_status
         description: "Overall MOC cycle state: 'Not started' | 'In progress' | 'Cycle complete' (all four stages recorded, equivalent to moc_cycle_complete=true) | 'Declined'"
       - name: moc_next_action
-        description: "Next MOC action needed (Check & Test / MDT / Careplan / Careplan sharing / Discussion / Follow-up); NULL when no action is required (cycle complete or declined)"
+        description: "Next MOC action needed (Check & Test / RDR / Careplan / Careplan sharing / Discussion / Follow-up); NULL when no action is required (cycle complete or declined)"
       - name: moc_cycle_complete
         description: True if all four MOC stages recorded in the last 12m
 

--- a/models/reporting/olids/programme/ltc_lcs/rs/fct_person_ltc_lcs_risk_summary.sql
+++ b/models/reporting/olids/programme/ltc_lcs/rs/fct_person_ltc_lcs_risk_summary.sql
@@ -24,9 +24,9 @@ moc_check_test as (
     from {{ ref('int_ltc_lcs_moc_check_test') }}
 ),
 
-moc_mdt_review as (
-    select person_id, latest_completed_date, mdt_review_completed
-    from {{ ref('int_ltc_lcs_moc_mdt_review') }}
+moc_remote_desktop_review as (
+    select person_id, latest_completed_date, remote_desktop_review_completed
+    from {{ ref('int_ltc_lcs_moc_remote_desktop_review') }}
 ),
 
 moc_careplan_sharing as (
@@ -66,8 +66,8 @@ joined as (
 
         coalesce(ct.check_test_completed, false) as moc_check_test_completed,
         ct.latest_completed_date as moc_check_test_date,
-        coalesce(mdt.mdt_review_completed, false) as moc_mdt_review_completed,
-        mdt.latest_completed_date as moc_mdt_review_date,
+        coalesce(rdr.remote_desktop_review_completed, false) as moc_remote_desktop_review_completed,
+        rdr.latest_completed_date as moc_remote_desktop_review_date,
         coalesce(cps.careplan_sharing_completed, false) as moc_careplan_sharing_completed,
         cps.latest_completed_date as moc_careplan_sharing_date,
         coalesce(dsc.discussion_completed, false) as moc_discussion_completed,
@@ -79,7 +79,7 @@ joined as (
     from moc_base p
     left join rs on p.person_id = rs.person_id
     left join moc_check_test ct on p.person_id = ct.person_id
-    left join moc_mdt_review mdt on p.person_id = mdt.person_id
+    left join moc_remote_desktop_review rdr on p.person_id = rdr.person_id
     left join moc_careplan_sharing cps on p.person_id = cps.person_id
     left join moc_discussion dsc on p.person_id = dsc.person_id
     left join moc_followup fu on p.person_id = fu.person_id
@@ -97,27 +97,27 @@ with_pathway as (
             when 'MR'  then 'MRS'
             when 'LR'  then 'LRS'
         end as moc_pathway,
-        -- Stage 2 is "MDT review OR careplan sharing" for HRCS / HRS,
-        -- but "careplan sharing only" for MRS / LRS (no MDT step).
+        -- Stage 2 is "Remote Desktop Review (RDR) OR careplan sharing" for HRCS / HRS,
+        -- but "careplan sharing only" for MRS / LRS (no RDR step).
         case
             when upper(j.overall_risk_group) in ('HRC', 'HR')
-                then (j.moc_mdt_review_completed or j.moc_careplan_sharing_completed)
+                then (j.moc_remote_desktop_review_completed or j.moc_careplan_sharing_completed)
             else j.moc_careplan_sharing_completed
         end as moc_stage_2_completed,
         -- Effective stage 2 date: earliest valid stage-2 event per pathway.
         case
             when upper(j.overall_risk_group) in ('HRC', 'HR') then
                 case
-                    when j.moc_mdt_review_date is null then j.moc_careplan_sharing_date
-                    when j.moc_careplan_sharing_date is null then j.moc_mdt_review_date
-                    when j.moc_mdt_review_date <= j.moc_careplan_sharing_date then j.moc_mdt_review_date
+                    when j.moc_remote_desktop_review_date is null then j.moc_careplan_sharing_date
+                    when j.moc_careplan_sharing_date is null then j.moc_remote_desktop_review_date
+                    when j.moc_remote_desktop_review_date <= j.moc_careplan_sharing_date then j.moc_remote_desktop_review_date
                     else j.moc_careplan_sharing_date
                 end
             else j.moc_careplan_sharing_date
         end as moc_stage_2_date,
         (
             j.moc_check_test_completed
-            or j.moc_mdt_review_completed
+            or j.moc_remote_desktop_review_completed
             or j.moc_careplan_sharing_completed
             or j.moc_discussion_completed
             or j.moc_followup_completed
@@ -126,7 +126,7 @@ with_pathway as (
         -- Latest progression activity date (excludes decline)
         greatest(
             coalesce(j.moc_check_test_date, '1900-01-01'),
-            coalesce(j.moc_mdt_review_date, '1900-01-01'),
+            coalesce(j.moc_remote_desktop_review_date, '1900-01-01'),
             coalesce(j.moc_careplan_sharing_date, '1900-01-01'),
             coalesce(j.moc_discussion_date, '1900-01-01'),
             coalesce(j.moc_followup_date, '1900-01-01')
@@ -173,8 +173,8 @@ select
     -- MOC activity flags (last 12 months)
     moc_check_test_completed,
     moc_check_test_date,
-    moc_mdt_review_completed,
-    moc_mdt_review_date,
+    moc_remote_desktop_review_completed,
+    moc_remote_desktop_review_date,
     moc_careplan_sharing_completed,
     moc_careplan_sharing_date,
     moc_discussion_completed,
@@ -200,7 +200,7 @@ select
         when moc_followup_completed then 'Follow-up'
         when moc_discussion_completed then 'Discussion'
         when moc_stage_2_completed then
-            case when moc_pathway in ('HRCS', 'HRS') then 'MDT / Careplan' else 'Careplan sharing' end
+            case when moc_pathway in ('HRCS', 'HRS') then 'RDR / Careplan' else 'Careplan sharing' end
         when moc_check_test_completed then 'Check & Test'
         else 'Not started'
     end as moc_stage_completed_label,
@@ -225,7 +225,7 @@ select
         when moc_discussion_completed then 'Follow-up'
         when moc_stage_2_completed then 'Discussion'
         when moc_check_test_completed then
-            case when moc_pathway in ('HRCS', 'HRS') then 'MDT / Careplan' else 'Careplan sharing' end
+            case when moc_pathway in ('HRCS', 'HRS') then 'RDR / Careplan' else 'Careplan sharing' end
         else 'Check & Test'
     end as moc_next_action,
 

--- a/models/reporting/olids/programme/ltc_lcs/rs/fct_person_ltc_lcs_risk_summary.yml
+++ b/models/reporting/olids/programme/ltc_lcs/rs/fct_person_ltc_lcs_risk_summary.yml
@@ -61,12 +61,12 @@ models:
           - not_null
       - name: moc_check_test_date
         description: Latest Check & Test appointment date (null if none)
-      - name: moc_mdt_review_completed
-        description: MDT review completed in last 12 months
+      - name: moc_remote_desktop_review_completed
+        description: Remote Desktop Review (RDR) completed in last 12 months
         data_tests:
           - not_null
-      - name: moc_mdt_review_date
-        description: Latest MDT review date (null if none)
+      - name: moc_remote_desktop_review_date
+        description: Latest Remote Desktop Review (RDR) date (null if none)
       - name: moc_careplan_sharing_completed
         description: Care plan shared with patient in last 12 months
         data_tests:
@@ -109,8 +109,8 @@ models:
       - name: moc_stage_2_completed
         description: |
           Stage 2 completion using pathway-specific logic. For HRCS/HRS this is
-          MDT review OR care plan sharing in last 12m; for MRS/LRS this is care
-          plan sharing only (MDT review is not part of the MR/LR pathway).
+          Remote Desktop Review (RDR) OR care plan sharing in last 12m; for MRS/LRS
+          this is care plan sharing only (RDR is not part of the MR/LR pathway).
         data_tests:
           - not_null
       - name: moc_stage_completed
@@ -123,9 +123,9 @@ models:
       - name: moc_stage_completed_label
         description: |
           Readable label for the furthest stage reached. One of 'Not started',
-          'Check & Test', 'MDT / Careplan' (HRCS/HRS only), 'Careplan sharing'
+          'Check & Test', 'RDR / Careplan' (HRCS/HRS only), 'Careplan sharing'
           (MRS/LRS only), 'Discussion', 'Follow-up'. Unnumbered because MR/LR
-          pathways skip the MDT step.
+          pathways skip the RDR step.
         data_tests:
           - not_null
       - name: moc_pathway_status
@@ -146,7 +146,7 @@ models:
       - name: moc_next_action
         description: |
           Next pathway action the person needs, or NULL if no action is required
-          (cycle complete or declined). One of 'Check & Test', 'MDT / Careplan'
+          (cycle complete or declined). One of 'Check & Test', 'RDR / Careplan'
           (HRCS/HRS), 'Careplan sharing' (MRS/LRS), 'Discussion', 'Follow-up'.
           Filter WHERE moc_next_action IS NOT NULL to get the action list.
       - name: moc_missing_check_test
@@ -154,7 +154,7 @@ models:
         data_tests:
           - not_null
       - name: moc_missing_stage_2
-        description: True if discussion or follow-up is recorded but stage 2 (MDT/Careplan for HRCS/HRS; Careplan for MRS/LRS) is absent in the last 12m
+        description: True if discussion or follow-up is recorded but stage 2 (RDR/Careplan for HRCS/HRS; Careplan for MRS/LRS) is absent in the last 12m
         data_tests:
           - not_null
       - name: moc_missing_discussion
@@ -170,7 +170,7 @@ models:
         data_tests:
           - not_null
       - name: moc_stage_2_date
-        description: Effective stage 2 date (earliest of MDT review / careplan sharing for HRCS/HRS; careplan sharing for MRS/LRS). Null if stage 2 not done.
+        description: Effective stage 2 date (earliest of Remote Desktop Review (RDR) / careplan sharing for HRCS/HRS; careplan sharing for MRS/LRS). Null if stage 2 not done.
       - name: moc_days_check_test_to_stage_2
         description: Days between check & test and stage 2. Null if either is missing; negative if stage 2 was recorded before check & test.
       - name: moc_days_stage_2_to_discussion


### PR DESCRIPTION
## What

Renames the misleading **MDT Review** concept to **Remote Desktop Review (RDR)** across `LTC_LCS_RISK_STRATIFICATION_BASE` and all upstream models.

The activity these models flag is a Remote Desktop Review, not a multidisciplinary team (MDT) meeting, so the old `mdt_review` naming was misleading to consumers. Renamed using full descriptive words (consistent with sibling MOC activities like `check_test`, `careplan_sharing`).

## Changes

**Model renamed** (history preserved via `git mv`):
- `int_ltc_lcs_moc_mdt_review.{sql,yml}` → `int_ltc_lcs_moc_remote_desktop_review.{sql,yml}`

**Columns renamed** (in `fct_person_ltc_lcs_risk_summary` and both published bases — direct_care + secondary_use):
- `moc_mdt_review_completed` → `moc_remote_desktop_review_completed`
- `moc_mdt_review_date` → `moc_remote_desktop_review_date`

**Internal / cosmetic:**
- CTE `moc_mdt_review` → `moc_remote_desktop_review`, alias `mdt` → `rdr`, flag `mdt_review_completed` → `remote_desktop_review_completed`
- Stage labels `'MDT / Careplan'` → `'RDR / Careplan'` (`moc_stage_completed_label`, `moc_next_action`)
- All comments and YAML descriptions updated, including a stray "MDT review" comment in the sibling `int_ltc_lcs_moc_careplan_sharing.sql`

## Notes for reviewers

- **Valueset identifier left unchanged:** `mdt_review_completed_vs1` is a warehouse valueset id (defined in Snowflake, not this repo), so renaming it here would break the lookup. Kept as-is with a clarifying comment. If the valueset itself should be renamed, that's a separate Snowflake change.
- **Breaking rename on a published table:** downstream BI consumers (Power BI / dashboards) reference the old `moc_mdt_review_*` column names and will need updating once this deploys.
- `dbt parse` passes — all refs resolve and no dangling references to the old model name remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Remote Desktop Review (RDR) activity is now tracked and exposed in place of MDT review across risk stratification datasets and person-level reporting.
  * Stage 2 pathway definitions have been updated for HRCS/HRS pathways to qualify based on RDR completion or care plan sharing.
  * Data model outputs now expose Remote Desktop Review completion indicators and dates in place of MDT review fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->