### PR TITLE
feat(ltc_lcs): HTN BP control outcomes layer + dashboard surfacing

### DIFF
--- a/macros/clinical/get_ltc_lcs_htn_bp_control.sql
+++ b/macros/clinical/get_ltc_lcs_htn_bp_control.sql
@@ -1,0 +1,81 @@
+{% macro get_ltc_lcs_htn_bp_control(window_start, window_end) %}
+-- LTC LCS Outcomes: Hypertension good blood pressure control (window-parameterised).
+--
+-- One row per person on the hypertension register, flagged for whether their LAST KNOWN
+-- paired BP reading WITHIN the supplied window meets the strict good-control thresholds:
+--   - age <= 80: systolic <= 140 AND diastolic <= 90
+--   - age >  80: systolic <= 150 AND diastolic <= 90
+--
+-- Deliberately simplified vs NICE/NG136: NO clinic-vs-home/ABPM split and NO ACR/CKD/diabetes
+-- target tightening. Every reading is scored on the same clinic thresholds. (fct_person_bp_control
+-- does the full NG136 logic — this outcome is intentionally the simpler QOF-style good-control rule.)
+--
+-- window_start / window_end are SQL date expressions injected into the BP date filter, so the
+-- same logic serves the rolling and FY variants. The macro itself stays window-agnostic.
+with hypertension_register as (
+    select
+        person_id,
+        age
+    from {{ ref('fct_person_hypertension_register') }}
+    where is_on_register = true
+),
+
+-- Last known paired reading within the window. Tie-break mirrors int_blood_pressure_latest
+-- (lowest-of-day) so a multi-reading final date resolves deterministically.
+bp_in_window as (
+    select
+        person_id,
+        effective_date as latest_bp_date,
+        systolic_value as latest_systolic_value,
+        diastolic_value as latest_diastolic_value,
+        is_home_bp_event,
+        is_abpm_bp_event
+    from {{ ref('int_blood_pressure_all') }}
+    where effective_date >= ({{ window_start }})
+      and effective_date <= ({{ window_end }})
+      and systolic_value is not null
+      and diastolic_value is not null
+    qualify row_number() over (
+        partition by person_id
+        order by effective_date desc, systolic_value asc, diastolic_value asc
+    ) = 1
+),
+
+control as (
+    select
+        hr.person_id,
+        hr.age,
+        bp.latest_bp_date,
+        bp.latest_systolic_value,
+        bp.latest_diastolic_value,
+        bp.is_home_bp_event,
+        bp.is_abpm_bp_event,
+        -- Strict, age-based thresholds; diastolic target is 90 for both age bands.
+        case when hr.age > 80 then 150 else 140 end as systolic_threshold,
+        90 as diastolic_threshold,
+        (bp.person_id is not null) as has_bp_in_window
+    from hypertension_register hr
+    left join bp_in_window bp
+        on hr.person_id = bp.person_id
+)
+
+select
+    person_id,
+    age,
+    latest_bp_date,
+    latest_systolic_value,
+    latest_diastolic_value,
+    is_home_bp_event,
+    is_abpm_bp_event,
+    systolic_threshold,
+    diastolic_threshold,
+    has_bp_in_window,
+    -- Good control: both systolic AND diastolic at/below target (QOF <= semantics).
+    -- Register members with no reading in window are uncontrolled (false), flagged via has_bp_in_window.
+    coalesce(
+        latest_systolic_value <= systolic_threshold
+        and latest_diastolic_value <= diastolic_threshold,
+        false
+    ) as is_bp_controlled
+from control
+{% endmacro %}

--- a/macros/clinical/get_ltc_lcs_htn_bp_control.yml
+++ b/macros/clinical/get_ltc_lcs_htn_bp_control.yml
@@ -1,0 +1,17 @@
+version: 2
+
+macros:
+  - name: get_ltc_lcs_htn_bp_control
+    description: >
+      Generates the LTC LCS hypertension good blood-pressure-control outcome for a supplied
+      date window. Returns one row per person on the hypertension register with their last
+      known paired BP reading in the window and a strict good-control flag
+      (age <= 80: <= 140/90; age > 80: <= 150/90). No clinic/home/ABPM split and no
+      ACR/CKD/diabetes target tightening. Shared by the rolling and financial-year variant models.
+    arguments:
+      - name: window_start
+        type: string
+        description: SQL date expression for the inclusive start of the BP lookup window (e.g. "dateadd(month, -12, current_date())").
+      - name: window_end
+        type: string
+        description: SQL date expression for the inclusive end of the BP lookup window (e.g. "current_date()").

--- a/models/published/direct_care/olids/ltc_lcs/ltc_lcs_risk_stratification_base.sql
+++ b/models/published/direct_care/olids/ltc_lcs/ltc_lcs_risk_stratification_base.sql
@@ -166,6 +166,22 @@ select
     rs.moc_next_expiry_date,
 
     -- ============================================================
+    -- Outcome: hypertension BP control (HTN register members only; null otherwise)
+    -- Rolling = current position (last known BP, trailing 12 months);
+    -- FY = current financial year YTD (last known BP since 1 April).
+    -- ============================================================
+    htn_roll.is_bp_controlled as htn_bp_controlled_rolling,
+    htn_roll.has_bp_in_window as htn_bp_control_rolling_has_reading,
+    htn_roll.latest_bp_date as htn_bp_control_rolling_bp_date,
+    htn_roll.latest_systolic_value as htn_bp_control_rolling_systolic,
+    htn_roll.latest_diastolic_value as htn_bp_control_rolling_diastolic,
+    htn_fy.is_bp_controlled as htn_bp_controlled_fy,
+    htn_fy.has_bp_in_window as htn_bp_control_fy_has_reading,
+    htn_fy.latest_bp_date as htn_bp_control_fy_bp_date,
+    htn_fy.latest_systolic_value as htn_bp_control_fy_systolic,
+    htn_fy.latest_diastolic_value as htn_bp_control_fy_diastolic,
+
+    -- ============================================================
     -- Metadata
     -- ============================================================
     rs.table_refresh_date
@@ -178,3 +194,7 @@ left join {{ ref('dim_person_conditions') }} cond
     on rs.person_id = cond.person_id
 left join {{ ref('fct_person_pregnancy_status') }} preg
     on rs.person_id = preg.person_id
+left join {{ ref('fct_person_ltc_lcs_outcomes_htn_bp_control') }} htn_roll
+    on rs.person_id = htn_roll.person_id
+left join {{ ref('fct_person_ltc_lcs_outcomes_htn_bp_control_fy') }} htn_fy
+    on rs.person_id = htn_fy.person_id

--- a/models/published/direct_care/olids/ltc_lcs/ltc_lcs_risk_stratification_base.yml
+++ b/models/published/direct_care/olids/ltc_lcs/ltc_lcs_risk_stratification_base.yml
@@ -284,6 +284,30 @@ models:
         description: Earliest date on which any currently-counted MOC event drops out of the 12m rolling window; NULL if no MOC activity
 
       # ============================================================
+      # Outcome: hypertension BP control
+      # ============================================================
+      - name: htn_bp_controlled_rolling
+        description: "Current position: true if the HTN register member's last known BP in the trailing 12 months is well controlled (<= 140/90 if age <= 80, <= 150/90 if age > 80). Null for non-HTN-register persons. False if on register but no qualifying reading in window."
+      - name: htn_bp_control_rolling_has_reading
+        description: True if the person has a qualifying paired BP reading in the trailing 12 months. Null for non-HTN-register persons.
+      - name: htn_bp_control_rolling_bp_date
+        description: Date of the last known paired BP reading in the trailing 12 months (null if none / not on register)
+      - name: htn_bp_control_rolling_systolic
+        description: Systolic value (mmHg) of the last known reading in the trailing 12 months
+      - name: htn_bp_control_rolling_diastolic
+        description: Diastolic value (mmHg) of the last known reading in the trailing 12 months
+      - name: htn_bp_controlled_fy
+        description: "Current financial year: true if the HTN register member's last known BP since 1 April (current FY) is well controlled (<= 140/90 if age <= 80, <= 150/90 if age > 80). Null for non-HTN-register persons. False if on register but no qualifying reading in window."
+      - name: htn_bp_control_fy_has_reading
+        description: True if the person has a qualifying paired BP reading in the current FY. Null for non-HTN-register persons.
+      - name: htn_bp_control_fy_bp_date
+        description: Date of the last known paired BP reading in the current FY (null if none / not on register)
+      - name: htn_bp_control_fy_systolic
+        description: Systolic value (mmHg) of the last known reading in the current FY
+      - name: htn_bp_control_fy_diastolic
+        description: Diastolic value (mmHg) of the last known reading in the current FY
+
+      # ============================================================
       # Metadata
       # ============================================================
       - name: table_refresh_date

--- a/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control.sql
+++ b/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'],
+        tags=['ltc_lcs', 'outcomes', 'hypertension'])
+}}
+
+-- LTC LCS Outcomes: Hypertension good blood pressure control - ROLLING (default).
+-- Window: last known paired BP in the trailing 12 months ending today.
+-- This is the "current position" view of the register's BP control.
+-- See macro get_ltc_lcs_htn_bp_control for the control logic and threshold rules.
+
+{{ get_ltc_lcs_htn_bp_control(
+    window_start="dateadd(month, -12, current_date())",
+    window_end="current_date()"
+) }}

--- a/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control.yml
+++ b/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control.yml
@@ -1,0 +1,75 @@
+version: 2
+
+models:
+  - name: fct_person_ltc_lcs_outcomes_htn_bp_control
+    description: |
+      LTC LCS outcome: hypertension good blood pressure control - ROLLING (current position).
+
+      One row per person on the hypertension register (is_on_register = true). is_bp_controlled
+      is true when the person's last known paired BP reading in the trailing 12 months meets the
+      strict good-control target:
+        - age <= 80: systolic <= 140 AND diastolic <= 90
+        - age >  80: systolic <= 150 AND diastolic <= 90
+
+      Deliberately simplified vs NICE/NG136: no clinic-vs-home/ABPM threshold split and no
+      ACR/CKD/diabetes target tightening - every reading is scored on the same clinic thresholds.
+      Register members with no qualifying reading in the window are uncontrolled
+      (is_bp_controlled = false, has_bp_in_window = false). Control logic lives in the shared
+      get_ltc_lcs_htn_bp_control macro; the _fy and _fy_last variants apply the same logic over
+      financial-year windows.
+    config:
+      meta:
+        indicator:
+          id: "LTC_LCS_OUTCOMES_HTN_BP_CONTROL"
+          type: "OUTCOME"
+          category: "OUTCOMES"
+          clinical_domain: "Cardiovascular"
+          name_short: "HTN BP control (rolling)"
+          description_short: "Hypertension register members with well-controlled BP (last known reading, rolling 12 months)"
+          description_long: >
+            Percentage of people on the hypertension register whose last known blood pressure in
+            the trailing 12 months is well controlled: systolic <= 140 and diastolic <= 90 for
+            those aged <= 80, or systolic <= 150 and diastolic <= 90 for those aged > 80.
+            Strict QOF-style good-control rule; does not adjust thresholds for home/ABPM
+            measurement context or for ACR/CKD/diabetes.
+          is_qof: false
+          source_column: "is_bp_controlled"
+          sort_order: "LTC_LCS_OUTCOME_001"
+          usage_contexts:
+            - "LTC_LCS_DASHBOARD"
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.at_least_one:
+          arguments:
+            column_name: person_id
+    columns:
+      - name: person_id
+        description: Unique person identifier (one row per hypertension register member)
+        data_tests:
+          - not_null
+          - unique
+      - name: age
+        description: Current age in years (from the hypertension register / dim_person_age)
+      - name: latest_bp_date
+        description: Date of the last known paired BP reading within the window (null if none)
+      - name: latest_systolic_value
+        description: Systolic value (mmHg) of the last known paired reading in the window (null if none)
+      - name: latest_diastolic_value
+        description: Diastolic value (mmHg) of the last known paired reading in the window (null if none)
+      - name: is_home_bp_event
+        description: True if the representative reading was a home BP measurement (carried for traceability; not used to alter thresholds)
+      - name: is_abpm_bp_event
+        description: True if the representative reading was an ABPM measurement (carried for traceability; not used to alter thresholds)
+      - name: systolic_threshold
+        description: Applied systolic good-control threshold (140 if age <= 80, else 150)
+      - name: diastolic_threshold
+        description: Applied diastolic good-control threshold (always 90)
+      - name: has_bp_in_window
+        description: True if the person has at least one qualifying paired BP reading within the window
+        data_tests:
+          - not_null
+      - name: is_bp_controlled
+        description: True if the last known reading in the window is at/below both the systolic and diastolic targets. False (not null) for register members with no reading in window.
+        data_tests:
+          - not_null

--- a/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control_fy.sql
+++ b/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control_fy.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'],
+        tags=['ltc_lcs', 'outcomes', 'hypertension'])
+}}
+
+-- LTC LCS Outcomes: Hypertension good blood pressure control - CURRENT FINANCIAL YEAR.
+-- Window: last known paired BP since 1 April of the current (in-progress) FY, pinned to the
+-- FY end (31 March of next year). Matches the QOF-style "FY year-to-date since 1st April"
+-- denominator; no future readings exist, so the numerator is effectively YTD.
+-- FY bounds are computed inline from current_date() (project convention: month >= 4 = new FY)
+-- and passed to the shared get_ltc_lcs_htn_bp_control macro as date expressions.
+
+{% set fy_start = "date_from_parts(case when month(current_date()) >= 4 then year(current_date()) else year(current_date()) - 1 end, 4, 1)" %}
+{% set fy_end = "dateadd(day, -1, dateadd(year, 1, " ~ fy_start ~ "))" %}
+
+{{ get_ltc_lcs_htn_bp_control(
+    window_start=fy_start,
+    window_end=fy_end
+) }}

--- a/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control_fy.yml
+++ b/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control_fy.yml
@@ -1,0 +1,62 @@
+version: 2
+
+models:
+  - name: fct_person_ltc_lcs_outcomes_htn_bp_control_fy
+    description: |
+      LTC LCS outcome: hypertension good blood pressure control - CURRENT FINANCIAL YEAR.
+
+      Same strict good-control logic as fct_person_ltc_lcs_outcomes_htn_bp_control (see that
+      model for full threshold detail), but the last-known-BP window is the current in-progress
+      financial year: since 1 April of this FY, pinned to the FY end (31 March of next year).
+      Matches the QOF-style "FY year-to-date since 1st April" denominator; the numerator is
+      effectively YTD since no future readings exist.
+    config:
+      meta:
+        indicator:
+          id: "LTC_LCS_OUTCOMES_HTN_BP_CONTROL_FY"
+          type: "OUTCOME"
+          category: "OUTCOMES"
+          clinical_domain: "Cardiovascular"
+          name_short: "HTN BP control (current FY)"
+          description_short: "Hypertension register members with well-controlled BP (last known reading, current FY year-to-date)"
+          is_qof: false
+          source_column: "is_bp_controlled"
+          sort_order: "LTC_LCS_OUTCOME_002"
+          usage_contexts:
+            - "LTC_LCS_DASHBOARD"
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.at_least_one:
+          arguments:
+            column_name: person_id
+    columns:
+      - name: person_id
+        description: Unique person identifier (one row per hypertension register member)
+        data_tests:
+          - not_null
+          - unique
+      - name: age
+        description: Current age in years (from the hypertension register / dim_person_age)
+      - name: latest_bp_date
+        description: Date of the last known paired BP reading within the current FY (null if none)
+      - name: latest_systolic_value
+        description: Systolic value (mmHg) of the last known paired reading in the current FY (null if none)
+      - name: latest_diastolic_value
+        description: Diastolic value (mmHg) of the last known paired reading in the current FY (null if none)
+      - name: is_home_bp_event
+        description: True if the representative reading was a home BP measurement (traceability only)
+      - name: is_abpm_bp_event
+        description: True if the representative reading was an ABPM measurement (traceability only)
+      - name: systolic_threshold
+        description: Applied systolic good-control threshold (140 if age <= 80, else 150)
+      - name: diastolic_threshold
+        description: Applied diastolic good-control threshold (always 90)
+      - name: has_bp_in_window
+        description: True if the person has at least one qualifying paired BP reading in the current FY
+        data_tests:
+          - not_null
+      - name: is_bp_controlled
+        description: True if the last known reading in the current FY is at/below both targets. False (not null) for register members with no reading in window.
+        data_tests:
+          - not_null

--- a/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control_fy_last.sql
+++ b/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control_fy_last.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id'],
+        tags=['ltc_lcs', 'outcomes', 'hypertension'])
+}}
+
+-- LTC LCS Outcomes: Hypertension good blood pressure control - LAST COMPLETED FINANCIAL YEAR.
+-- Window: last known paired BP within the previous complete FY (1 April -> 31 March).
+-- Useful as the fixed end-of-year achievement baseline alongside the rolling/current-FY views.
+-- FY bounds are computed inline from current_date() and passed to the shared
+-- get_ltc_lcs_htn_bp_control macro as date expressions.
+
+{% set cur_fy_start = "date_from_parts(case when month(current_date()) >= 4 then year(current_date()) else year(current_date()) - 1 end, 4, 1)" %}
+{% set last_fy_start = "dateadd(year, -1, " ~ cur_fy_start ~ ")" %}
+{% set last_fy_end = "dateadd(day, -1, " ~ cur_fy_start ~ ")" %}
+
+{{ get_ltc_lcs_htn_bp_control(
+    window_start=last_fy_start,
+    window_end=last_fy_end
+) }}

--- a/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control_fy_last.yml
+++ b/models/reporting/olids/programme/ltc_lcs/outcomes/fct_person_ltc_lcs_outcomes_htn_bp_control_fy_last.yml
@@ -1,0 +1,61 @@
+version: 2
+
+models:
+  - name: fct_person_ltc_lcs_outcomes_htn_bp_control_fy_last
+    description: |
+      LTC LCS outcome: hypertension good blood pressure control - LAST COMPLETED FINANCIAL YEAR.
+
+      Same strict good-control logic as fct_person_ltc_lcs_outcomes_htn_bp_control (see that
+      model for full threshold detail), but the last-known-BP window is the previous complete
+      financial year (1 April -> 31 March). Provides the fixed end-of-year achievement baseline
+      to compare against the rolling and current-FY views.
+    config:
+      meta:
+        indicator:
+          id: "LTC_LCS_OUTCOMES_HTN_BP_CONTROL_FY_LAST"
+          type: "OUTCOME"
+          category: "OUTCOMES"
+          clinical_domain: "Cardiovascular"
+          name_short: "HTN BP control (last FY)"
+          description_short: "Hypertension register members with well-controlled BP (last known reading, last completed FY)"
+          is_qof: false
+          source_column: "is_bp_controlled"
+          sort_order: "LTC_LCS_OUTCOME_003"
+          usage_contexts:
+            - "LTC_LCS_DASHBOARD"
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.at_least_one:
+          arguments:
+            column_name: person_id
+    columns:
+      - name: person_id
+        description: Unique person identifier (one row per hypertension register member)
+        data_tests:
+          - not_null
+          - unique
+      - name: age
+        description: Current age in years (from the hypertension register / dim_person_age)
+      - name: latest_bp_date
+        description: Date of the last known paired BP reading within the last completed FY (null if none)
+      - name: latest_systolic_value
+        description: Systolic value (mmHg) of the last known paired reading in the last completed FY (null if none)
+      - name: latest_diastolic_value
+        description: Diastolic value (mmHg) of the last known paired reading in the last completed FY (null if none)
+      - name: is_home_bp_event
+        description: True if the representative reading was a home BP measurement (traceability only)
+      - name: is_abpm_bp_event
+        description: True if the representative reading was an ABPM measurement (traceability only)
+      - name: systolic_threshold
+        description: Applied systolic good-control threshold (140 if age <= 80, else 150)
+      - name: diastolic_threshold
+        description: Applied diastolic good-control threshold (always 90)
+      - name: has_bp_in_window
+        description: True if the person has at least one qualifying paired BP reading in the last completed FY
+        data_tests:
+          - not_null
+      - name: is_bp_controlled
+        description: True if the last known reading in the last completed FY is at/below both targets. False (not null) for register members with no reading in window.
+        data_tests:
+          - not_null


### PR DESCRIPTION
## Context

The LTC LCS programme has **case finding (`cf/`)** and **risk stratification (`rs/`)** layers but no **outcomes** layer measuring whether register members are actually controlled. This adds the first outcomes model: well-controlled blood pressure for the hypertension register, modelled on the QOF-style "ICS_HTN_21" good-control indicator.

## What's included

**New `outcomes/` layer** (alongside `cf/`, `rs/`, `moc/`), logic shared via one macro:

| Model | Window |
|---|---|
| `fct_person_ltc_lcs_outcomes_htn_bp_control` | **Rolling** (default) — last known BP, trailing 12 months ("current position") |
| `fct_person_ltc_lcs_outcomes_htn_bp_control_fy` | **Current FY** — since 1 Apr, pinned to FY end (31 Mar of next year) |
| `fct_person_ltc_lcs_outcomes_htn_bp_control_fy_last` | **Last completed FY** (1 Apr → 31 Mar) |

- Macro `get_ltc_lcs_htn_bp_control(window_start, window_end)` reuses `fct_person_hypertension_register` (register + age) and `int_blood_pressure_all` (windowed last-known paired reading).
- **Strict criteria** (deliberately *not* full NG136): `systolic <= 140 AND diastolic <= 90` for age <= 80; `<= 150/90` for age > 80. **No** clinic/home/ABPM threshold split and **no** ACR/CKD/diabetes target tightening — every reading scored on clinic thresholds. (`fct_person_bp_control` keeps the full NG136 logic; this is intentionally simpler.)
- Register members with no qualifying reading in the window are `is_bp_controlled = false`, flagged by `has_bp_in_window = false`.

**Dashboard surfacing** — rolling ("current position") + current-FY flags added to `ltc_lcs_risk_stratification_base` (NULL for non-HTN-register persons). The `_secondary_use` variant inherits via `select base.*`.

## Verification

- `dbt build` — 4 models, **18 tests pass** (not_null / unique / at_least_one).
- All three outcomes models = 262,239 rows = HTN register size (one row per member).
- Control rate of those with a reading: rolling 83.6%, current-FY 77.4% (FY ~10 weeks old, sparsest), last-FY 85.5% (full-year coverage) — windows differ sensibly.

## Follow-ups (not in this PR)

- FY bounds anchored on `current_date()`; a `--vars` reference-date override (like `qof_reference_date`) could be added for reproducible point-in-time runs.
- No aggregate denominator/numerator rollup model yet (person-grain only).
- Last-FY variant is built but not surfaced on the dashboard (only current position + current FY requested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hypertension blood pressure control outcome tracking across multiple time windows: rolling 12-month, current financial year, and previous financial year periods.
  * New hypertension outcome metrics now available including blood pressure control status, latest reading dates, systolic and diastolic values, and measurement type flags.
  * Enhanced risk stratification data with comprehensive hypertension blood pressure control indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->