### PR TITLE
fix(profiles): non-empty account on snowflake-* native targets

### DIFF
--- a/profiles.yml
+++ b/profiles.yml
@@ -47,11 +47,15 @@ wnl_analytics:
       client_session_keep_alive: true
       query_tag: dbt_analytics_prod
 
-    # Snowflake native execution targets (empty credentials - runs in Snowflake context)
+    # Snowflake native execution targets (runs in the Snowflake session context).
+    # account/user are placeholders, NOT real credentials: native execution uses
+    # the in-session connection and ignores their values, but Fusion's compile-time
+    # metadata introspection rejects an empty account ("260000: account is empty"),
+    # so they must be non-empty.
     snowflake-dev:
       type: snowflake
-      account: ''
-      user: ''
+      account: placeholder
+      user: placeholder
       role: DBT_ADMIN
       database: MODELLING
       schema: DBT_DEV
@@ -62,8 +66,8 @@ wnl_analytics:
 
     snowflake-prod:
       type: snowflake
-      account: ''
-      user: ''
+      account: placeholder
+      user: placeholder
       role: DBT_ADMIN
       database: MODELLING
       schema: DBT_PROD


### PR DESCRIPTION
## Root cause

The native 5am Daily build (and `ADD VERSION`) failed on Fusion with `260000: account is empty`.

Fusion runs **compile-time static analysis**, which opens a Snowflake metadata connection. The `snowflake-dev`/`snowflake-prod` native targets had `account: ''` (empty), which Fusion rejects. dbt-core never opened that connection, so the empty value worked for years — the Fusion migration changed the contract.

Diagnosed from the account event table (`snowflake.telemetry.events`, `dbt-fusion` scope): the single compile error across both MAIN (`snowflake-prod`) and CI (`snowflake-dev`) runs was `[Snowflake] 260000: account is empty` (code 1308).

## Fix

Set `account`/`user` to a non-empty placeholder on both native targets. Native execution ignores the values (it uses the in-session connection) but requires them non-empty — confirmed by the `dev` target, whose `placeholder` default already connects fine natively. Snowflake docs: native execution accepts "an arbitrary string".

## Verification

Will be verified by `ADD VERSION` on `DBT_NCL_ANALYTICS__MAIN` (now `DEFAULT_TARGET='snowflake-prod'`) after merge. The key-pair CI compile gate uses the `ci-*` targets, so it does not exercise these.