### PR TITLE
chore(ci): quieter native deploy logs via --log-level-file info

### DIFF
--- a/.github/workflows/dbt-deploy.yml
+++ b/.github/workflows/dbt-deploy.yml
@@ -194,13 +194,13 @@ jobs:
 
               if file_count == 0 or file_count > 50:
                   print(f"Running full build ({file_count} files changed or manual trigger)")
-                  args = "build --target snowflake-prod"
+                  args = "--log-level-file info build --target snowflake-prod"
               else:
                   # Changed models + downstream (append +)
                   models = [get_model_name(f) + '+' for f in changed_files.split() if f]
                   select = ' '.join(models)
                   print(f"Deploying {file_count} changed models + downstream: {select}")
-                  args = f"build --target snowflake-prod --select {select}"
+                  args = f"--log-level-file info build --target snowflake-prod --select {select}"
 
               # Lift the 1h cap on EXECUTE DBT PROJECT. Both are required:
               #   - ALTER SESSION overrides the account-level STATEMENT_TIMEOUT_IN_SECONDS


### PR DESCRIPTION
EXECUTE DBT PROJECT writes `dbt.log` at debug by default — verbose and hard to read in the Snowflake UI / `SYSTEM$GET_DBT_LOG`. Pass `--log-level-file info` in the deploy build args.

Verified locally on Fusion `.175`: `--log-level-file info` drops the log from ~5,581 debug lines to ~30. (The `dbt_project.yml` `flags: log_level_file` equivalent is **not** honored by Fusion `.175`, so it must be the CLI arg.)

Mirrors the same flag applied to the four scheduled `EXECUTE DBT PROJECT` tasks in snowflake-deployment (`Daily build`, `Weekly build`, `Monthly full refresh`, `Daily snapshots`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment build logging by adding detailed file-level logging flags to dbt CLI commands, improving visibility for both full and incremental deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->