### PR TITLE
fix(fusion): connect-retries on native targets + quieter deploy logs

### DIFF
--- a/.github/workflows/dbt-deploy.yml
+++ b/.github/workflows/dbt-deploy.yml
@@ -194,13 +194,13 @@ jobs:
 
               if file_count == 0 or file_count > 50:
                   print(f"Running full build ({file_count} files changed or manual trigger)")
-                  args = "build --target snowflake-prod"
+                  args = "--log-level-file info build --target snowflake-prod"
               else:
                   # Changed models + downstream (append +)
                   models = [get_model_name(f) + '+' for f in changed_files.split() if f]
                   select = ' '.join(models)
                   print(f"Deploying {file_count} changed models + downstream: {select}")
-                  args = f"build --target snowflake-prod --select {select}"
+                  args = f"--log-level-file info build --target snowflake-prod --select {select}"
 
               # Lift the 1h cap on EXECUTE DBT PROJECT. Both are required:
               #   - ALTER SESSION overrides the account-level STATEMENT_TIMEOUT_IN_SECONDS

--- a/profiles.yml
+++ b/profiles.yml
@@ -63,6 +63,12 @@ wnl_analytics:
       threads: 16
       client_session_keep_alive: false
       query_tag: dbt_analytics_dev
+      # Retry transient connection failures. A single Fusion bridge login stall
+      # ("context deadline exceeded" on localhost) failed 36 models in one 90ms
+      # window; retry_all covers timeouts (not just DatabaseErrors).
+      connect_retries: 3
+      connect_timeout: 10
+      retry_all: true
 
     snowflake-prod:
       type: snowflake
@@ -75,6 +81,10 @@ wnl_analytics:
       threads: 16
       client_session_keep_alive: false
       query_tag: dbt_analytics_prod
+      # Retry transient connection failures (see snowflake-dev note).
+      connect_retries: 3
+      connect_timeout: 10
+      retry_all: true
 
     # CI compile gate (key-pair auth, read-only metadata introspection).
     # ci-dev introspects the DEV__ catalog (PR validation); ci-prod the prod


### PR DESCRIPTION
Two related Fusion-native hardening tweaks (combined into one PR per request).

## 1. connect_retries on native targets (profiles.yml)

The first full native daily build failed with **36 errors** that were a *single* transient event: a Fusion bridge login stall (`context deadline exceeded` on the `localhost:17199` session login) hitting **all 36 `raw_dictionary_*` models in one 90ms window**, plus 5 downstream skips. They run as one concurrent batch off the `Dictionary` source, so a momentary stall wipes the whole batch. (The 37th error was unrelated — `raw_reference_myria_enrolled_patients_20250507`, a stale reference table.)

Add to `snowflake-dev` / `snowflake-prod`:

```yaml
connect_retries: 3
connect_timeout: 10
retry_all: true   # retry on any connection error incl. timeouts, not just DatabaseError
```

Verified Fusion `.175` honors these via `dbt debug` (they appear in the resolved connection config; the `flags:` block equivalent is ignored, so it has to be connection config).

## 2. Quieter deploy logs (dbt-deploy.yml)

`EXECUTE DBT PROJECT` writes `dbt.log` at debug by default — unreadable in the Snowflake UI / `SYSTEM$GET_DBT_LOG`. Pass `--log-level-file info` in the deploy build args (~5,581 debug lines -> ~30 locally). Mirrors the same flag added to the scheduled tasks in snowflake-deployment.

## Scope

Native execution paths only. No prod deploy is triggered (no models/macros changes).
