### PR TITLE
fix(ci): place --log-level-file after subcommand in deploy args

### DIFF
--- a/.github/workflows/dbt-deploy.yml
+++ b/.github/workflows/dbt-deploy.yml
@@ -194,13 +194,13 @@ jobs:
 
               if file_count == 0 or file_count > 50:
                   print(f"Running full build ({file_count} files changed or manual trigger)")
-                  args = "--log-level-file info build --target snowflake-prod"
+                  args = "build --target snowflake-prod --log-level-file info"
               else:
                   # Changed models + downstream (append +)
                   models = [get_model_name(f) + '+' for f in changed_files.split() if f]
                   select = ' '.join(models)
                   print(f"Deploying {file_count} changed models + downstream: {select}")
-                  args = f"--log-level-file info build --target snowflake-prod --select {select}"
+                  args = f"build --target snowflake-prod --select {select} --log-level-file info"
 
               # Lift the 1h cap on EXECUTE DBT PROJECT. Both are required:
               #   - ALTER SESSION overrides the account-level STATEMENT_TIMEOUT_IN_SECONDS


### PR DESCRIPTION
Follow-up to #784. Native `EXECUTE DBT PROJECT` rejects a global flag placed *before* the subcommand:

| ARGS | Result |
|---|---|
| `--log-level-file info build ...` | `error: unexpected argument 'build' found` |
| `build ... --log-level-file info` | SUCCESS |

#784 put the flag first in the deploy args; move it to the end. Same fix applied to the four scheduled task ARGS (live + snowflake-deployment PR #19).