### PR TITLE
feat(sdl): expose the SDL META observability objects in staging

### DIFF
--- a/models/raw/commissioning/raw_sdl_wnl_meta_build_state.sql
+++ b/models/raw/commissioning/raw_sdl_wnl_meta_build_state.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        description="Raw layer (ServicesDataLocal canonical-named feeds, WNL footprint (SLAM contract monitoring)). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE.SDL.META_BUILD_STATE \ndbt: source(''sdl_wnl'', ''META_BUILD_STATE'') \nColumns:\n  FEED -> feed\n  MAX_FILE_ID_LOADED -> max_file_id_loaded\n  LAST_BUILT_AT -> last_built_at\n  LAST_BULK_AT -> last_bulk_at\n  NEEDS_REBUILD -> needs_rebuild\n  LAST_ERROR -> last_error"
+    )
+}}
+select
+    "FEED" as feed,
+    "MAX_FILE_ID_LOADED" as max_file_id_loaded,
+    "LAST_BUILT_AT" as last_built_at,
+    "LAST_BULK_AT" as last_bulk_at,
+    "NEEDS_REBUILD" as needs_rebuild,
+    "LAST_ERROR" as last_error
+from {{ source('sdl_wnl', 'META_BUILD_STATE') }}

--- a/models/raw/commissioning/raw_sdl_wnl_meta_exceptions.sql
+++ b/models/raw/commissioning/raw_sdl_wnl_meta_exceptions.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        description="Raw layer (ServicesDataLocal canonical-named feeds, WNL footprint (SLAM contract monitoring)). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE.SDL.META_EXCEPTIONS \ndbt: source(''sdl_wnl'', ''META_EXCEPTIONS'') \nColumns:\n  FEED -> feed\n  FILE_ID -> file_id\n  BATCH_ID -> batch_id\n  SOURCE_COLUMN_HEADERS -> source_column_headers\n  DETECTED_AT -> detected_at\n  RESOLVED -> resolved"
+    )
+}}
+select
+    "FEED" as feed,
+    "FILE_ID" as file_id,
+    "BATCH_ID" as batch_id,
+    "SOURCE_COLUMN_HEADERS" as source_column_headers,
+    "DETECTED_AT" as detected_at,
+    "RESOLVED" as resolved
+from {{ source('sdl_wnl', 'META_EXCEPTIONS') }}

--- a/models/raw/commissioning/raw_sdl_wnl_meta_file_versions.sql
+++ b/models/raw/commissioning/raw_sdl_wnl_meta_file_versions.sql
@@ -1,0 +1,12 @@
+{{
+    config(
+        description="Raw layer (ServicesDataLocal canonical-named feeds, WNL footprint (SLAM contract monitoring)). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE.SDL.META_FILE_VERSIONS \ndbt: source(''sdl_wnl'', ''META_FILE_VERSIONS'') \nColumns:\n  FEED -> feed\n  FILE_ID -> file_id\n  BATCH_ID -> batch_id\n  VERSION_ID -> version_id\n  MATCH_METHOD -> match_method"
+    )
+}}
+select
+    "FEED" as feed,
+    "FILE_ID" as file_id,
+    "BATCH_ID" as batch_id,
+    "VERSION_ID" as version_id,
+    "MATCH_METHOD" as match_method
+from {{ source('sdl_wnl', 'META_FILE_VERSIONS') }}

--- a/models/raw/commissioning/raw_sdl_wnl_meta_null_rate_profile.sql
+++ b/models/raw/commissioning/raw_sdl_wnl_meta_null_rate_profile.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        description="Raw layer (ServicesDataLocal canonical-named feeds, WNL footprint (SLAM contract monitoring)). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE.SDL.META_NULL_RATE_PROFILE \ndbt: source(''sdl_wnl'', ''META_NULL_RATE_PROFILE'') \nColumns:\n  FEED -> feed\n  TABLE_NAME -> table_name\n  COLUMN_NAME -> column_name\n  ORDINAL_POSITION -> ordinal_position\n  TOTAL_ROWS -> total_rows\n  NON_NULL_ROWS -> non_null_rows\n  NULL_ROWS -> null_rows\n  NULL_RATE -> null_rate\n  IS_ALL_NULL -> is_all_null\n  COMPUTED_AT -> computed_at"
+    )
+}}
+select
+    "FEED" as feed,
+    "TABLE_NAME" as table_name,
+    "COLUMN_NAME" as column_name,
+    "ORDINAL_POSITION" as ordinal_position,
+    "TOTAL_ROWS" as total_rows,
+    "NON_NULL_ROWS" as non_null_rows,
+    "NULL_ROWS" as null_rows,
+    "NULL_RATE" as null_rate,
+    "IS_ALL_NULL" as is_all_null,
+    "COMPUTED_AT" as computed_at
+from {{ source('sdl_wnl', 'META_NULL_RATE_PROFILE') }}

--- a/models/raw/commissioning/raw_sdl_wnl_meta_refresh_log.sql
+++ b/models/raw/commissioning/raw_sdl_wnl_meta_refresh_log.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        description="Raw layer (ServicesDataLocal canonical-named feeds, WNL footprint (SLAM contract monitoring)). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE.SDL.META_REFRESH_LOG \ndbt: source(''sdl_wnl'', ''META_REFRESH_LOG'') \nColumns:\n  RUN_ID -> run_id\n  FEED -> feed\n  STARTED_AT -> started_at\n  COMPLETED_AT -> completed_at\n  NEW_FILES_MATCHED -> new_files_matched\n  NEW_EXCEPTIONS -> new_exceptions\n  TOTAL_MAPPED_FILES -> total_mapped_files\n  TOTAL_EXCEPTIONS -> total_exceptions\n  STATUS -> status\n  ERROR_MESSAGE -> error_message"
+    )
+}}
+select
+    "RUN_ID" as run_id,
+    "FEED" as feed,
+    "STARTED_AT" as started_at,
+    "COMPLETED_AT" as completed_at,
+    "NEW_FILES_MATCHED" as new_files_matched,
+    "NEW_EXCEPTIONS" as new_exceptions,
+    "TOTAL_MAPPED_FILES" as total_mapped_files,
+    "TOTAL_EXCEPTIONS" as total_exceptions,
+    "STATUS" as status,
+    "ERROR_MESSAGE" as error_message
+from {{ source('sdl_wnl', 'META_REFRESH_LOG') }}

--- a/models/raw/commissioning/raw_sdl_wnl_meta_row_count_compare.sql
+++ b/models/raw/commissioning/raw_sdl_wnl_meta_row_count_compare.sql
@@ -1,0 +1,12 @@
+{{
+    config(
+        description="Raw layer (ServicesDataLocal canonical-named feeds, WNL footprint (SLAM contract monitoring)). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE.SDL.META_ROW_COUNT_COMPARE \ndbt: source(''sdl_wnl'', ''META_ROW_COUNT_COMPARE'') \nColumns:\n  FEED -> feed\n  SOURCE_ROWS -> source_rows\n  FINAL_ROWS -> final_rows\n  GAP -> gap\n  COVERAGE_PCT -> coverage_pct"
+    )
+}}
+select
+    "FEED" as feed,
+    "SOURCE_ROWS" as source_rows,
+    "FINAL_ROWS" as final_rows,
+    "GAP" as gap,
+    "COVERAGE_PCT" as coverage_pct
+from {{ source('sdl_wnl', 'META_ROW_COUNT_COMPARE') }}

--- a/models/raw/commissioning/raw_sdl_wnl_meta_schema_versions.sql
+++ b/models/raw/commissioning/raw_sdl_wnl_meta_schema_versions.sql
@@ -1,0 +1,14 @@
+{{
+    config(
+        description="Raw layer (ServicesDataLocal canonical-named feeds, WNL footprint (SLAM contract monitoring)). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE.SDL.META_SCHEMA_VERSIONS \ndbt: source(''sdl_wnl'', ''META_SCHEMA_VERSIONS'') \nColumns:\n  FEED -> feed\n  VERSION_ID -> version_id\n  FILE_COUNT -> file_count\n  FIRST_SEEN -> first_seen\n  LAST_SEEN -> last_seen\n  RAW_MAPPING -> raw_mapping\n  COLUMN_MAPPING -> column_mapping"
+    )
+}}
+select
+    "FEED" as feed,
+    "VERSION_ID" as version_id,
+    "FILE_COUNT" as file_count,
+    "FIRST_SEEN" as first_seen,
+    "LAST_SEEN" as last_seen,
+    "RAW_MAPPING" as raw_mapping,
+    "COLUMN_MAPPING" as column_mapping
+from {{ source('sdl_wnl', 'META_SCHEMA_VERSIONS') }}

--- a/models/raw/commissioning/raw_sdl_wnl_meta_unmapped_files.sql
+++ b/models/raw/commissioning/raw_sdl_wnl_meta_unmapped_files.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        description="Raw layer (ServicesDataLocal canonical-named feeds, WNL footprint (SLAM contract monitoring)). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE.SDL.META_UNMAPPED_FILES \ndbt: source(''sdl_wnl'', ''META_UNMAPPED_FILES'') \nColumns:\n  FEED -> feed\n  FILE_ID -> file_id\n  BATCH_ID -> batch_id\n  HEADER_ID -> header_id\n  PROFILE_CODE -> profile_code\n  ORIGINAL_FILE_NAME -> original_file_name\n  ROW_COUNT -> row_count\n  LOGGED_AT -> logged_at\n  LOADER_JOB_NAME -> loader_job_name\n  HAS_HEADERS -> has_headers\n  EXCEPTION_DETECTED_AT -> exception_detected_at\n  REASON -> reason"
+    )
+}}
+select
+    "FEED" as feed,
+    "FILE_ID" as file_id,
+    "BATCH_ID" as batch_id,
+    "HEADER_ID" as header_id,
+    "PROFILE_CODE" as profile_code,
+    "ORIGINAL_FILE_NAME" as original_file_name,
+    "ROW_COUNT" as row_count,
+    "LOGGED_AT" as logged_at,
+    "LOADER_JOB_NAME" as loader_job_name,
+    "HAS_HEADERS" as has_headers,
+    "EXCEPTION_DETECTED_AT" as exception_detected_at,
+    "REASON" as reason
+from {{ source('sdl_wnl', 'META_UNMAPPED_FILES') }}

--- a/models/raw/shared/raw_reference_wnl.sql
+++ b/models/raw/shared/raw_reference_wnl.sql
@@ -1,0 +1,23 @@
+{{
+    config(
+        description="Raw layer (Data management reference datasets). 1:1 passthrough with cleaned column names. \nSource: DATA_LAKE__NCL.DATA_MANAGEMENT.WNL \ndbt: source(''reference_data_management'', ''WNL'') \nColumns:\n  GP_PRACTICE_CODE -> gp_practice_code\n  Organisation_Name -> organisation_name\n  SUB_ICB_CODE -> sub_icb_code\n  Status -> status\n  Address_Line_1 -> address_line_1\n  Address_Line_2 -> address_line_2\n  Address_Line_3 -> address_line_3\n  Address_Line_4 -> address_line_4\n  Address_Line_5 -> address_line_5\n  Country -> country\n  StartDate -> start_date\n  EndDate -> end_date\n  OrganisationPrimaryRole -> organisation_primary_role\n  Q1_PRACTICE_LIST_SIZE -> q1_practice_list_size\n  Q1_WEIGHTED_LIST_SIZE -> q1_weighted_list_size\n  Q1_LAST_UPDATED -> q1_last_updated"
+    )
+}}
+select
+    "GP_PRACTICE_CODE" as gp_practice_code,
+    "Organisation_Name" as organisation_name,
+    "SUB_ICB_CODE" as sub_icb_code,
+    "Status" as status,
+    "Address_Line_1" as address_line_1,
+    "Address_Line_2" as address_line_2,
+    "Address_Line_3" as address_line_3,
+    "Address_Line_4" as address_line_4,
+    "Address_Line_5" as address_line_5,
+    "Country" as country,
+    "StartDate" as start_date,
+    "EndDate" as end_date,
+    "OrganisationPrimaryRole" as organisation_primary_role,
+    "Q1_PRACTICE_LIST_SIZE" as q1_practice_list_size,
+    "Q1_WEIGHTED_LIST_SIZE" as q1_weighted_list_size,
+    "Q1_LAST_UPDATED" as q1_last_updated
+from {{ source('reference_data_management', 'WNL') }}

--- a/models/sources/auto_data_lake_ncl_data_management.yml
+++ b/models/sources/auto_data_lake_ncl_data_management.yml
@@ -135,6 +135,41 @@ sources:
       data_type: DATE
     - name: RUN_DATE
       data_type: DATE
+  - name: WNL
+    identifier: '"WNL"'
+    columns:
+    - name: GP_PRACTICE_CODE
+      data_type: TEXT
+    - name: Organisation_Name
+      data_type: TEXT
+    - name: SUB_ICB_CODE
+      data_type: TEXT
+    - name: Status
+      data_type: TEXT
+    - name: Address_Line_1
+      data_type: TEXT
+    - name: Address_Line_2
+      data_type: TEXT
+    - name: Address_Line_3
+      data_type: TEXT
+    - name: Address_Line_4
+      data_type: TEXT
+    - name: Address_Line_5
+      data_type: TEXT
+    - name: Country
+      data_type: TEXT
+    - name: StartDate
+      data_type: TIMESTAMP_NTZ
+    - name: EndDate
+      data_type: TIMESTAMP_NTZ
+    - name: OrganisationPrimaryRole
+      data_type: TEXT
+    - name: Q1_PRACTICE_LIST_SIZE
+      data_type: NUMBER(38,0)
+    - name: Q1_WEIGHTED_LIST_SIZE
+      data_type: FLOAT
+    - name: Q1_LAST_UPDATED
+      data_type: TIMESTAMP_NTZ
   - name: WNL_ORGANISATION
     identifier: '"WNL_ORGANISATION"'
     columns:

--- a/models/sources/auto_data_lake_sdl.yml
+++ b/models/sources/auto_data_lake_sdl.yml
@@ -2136,6 +2136,36 @@ sources:
       data_type: TEXT
     - name: YEAR
       data_type: TEXT
+  - name: META_BUILD_STATE
+    identifier: '"META_BUILD_STATE"'
+    columns:
+    - name: FEED
+      data_type: TEXT
+    - name: MAX_FILE_ID_LOADED
+      data_type: NUMBER(38,0)
+    - name: LAST_BUILT_AT
+      data_type: TIMESTAMP_NTZ
+    - name: LAST_BULK_AT
+      data_type: TIMESTAMP_NTZ
+    - name: NEEDS_REBUILD
+      data_type: BOOLEAN
+    - name: LAST_ERROR
+      data_type: TEXT
+  - name: META_EXCEPTIONS
+    identifier: '"META_EXCEPTIONS"'
+    columns:
+    - name: FEED
+      data_type: TEXT
+    - name: FILE_ID
+      data_type: NUMBER(38,0)
+    - name: BATCH_ID
+      data_type: NUMBER(38,0)
+    - name: SOURCE_COLUMN_HEADERS
+      data_type: TEXT
+    - name: DETECTED_AT
+      data_type: TIMESTAMP_NTZ
+    - name: RESOLVED
+      data_type: BOOLEAN
   - name: META_FILE_REGISTRY
     identifier: '"META_FILE_REGISTRY"'
     columns:
@@ -2157,3 +2187,119 @@ sources:
       data_type: TEXT
     - name: LAST_REFRESHED_AT
       data_type: TIMESTAMP_NTZ
+  - name: META_FILE_VERSIONS
+    identifier: '"META_FILE_VERSIONS"'
+    columns:
+    - name: FEED
+      data_type: TEXT
+    - name: FILE_ID
+      data_type: NUMBER(38,0)
+    - name: BATCH_ID
+      data_type: NUMBER(38,0)
+    - name: VERSION_ID
+      data_type: TEXT
+    - name: MATCH_METHOD
+      data_type: TEXT
+  - name: META_NULL_RATE_PROFILE
+    identifier: '"META_NULL_RATE_PROFILE"'
+    columns:
+    - name: FEED
+      data_type: TEXT
+    - name: TABLE_NAME
+      data_type: TEXT
+    - name: COLUMN_NAME
+      data_type: TEXT
+    - name: ORDINAL_POSITION
+      data_type: NUMBER(38,0)
+    - name: TOTAL_ROWS
+      data_type: NUMBER(38,0)
+    - name: NON_NULL_ROWS
+      data_type: NUMBER(38,0)
+    - name: NULL_ROWS
+      data_type: NUMBER(38,0)
+    - name: NULL_RATE
+      data_type: NUMBER(10,6)
+    - name: IS_ALL_NULL
+      data_type: BOOLEAN
+    - name: COMPUTED_AT
+      data_type: TIMESTAMP_NTZ
+  - name: META_REFRESH_LOG
+    identifier: '"META_REFRESH_LOG"'
+    columns:
+    - name: RUN_ID
+      data_type: NUMBER(38,0)
+    - name: FEED
+      data_type: TEXT
+    - name: STARTED_AT
+      data_type: TIMESTAMP_NTZ
+    - name: COMPLETED_AT
+      data_type: TIMESTAMP_NTZ
+    - name: NEW_FILES_MATCHED
+      data_type: NUMBER(38,0)
+    - name: NEW_EXCEPTIONS
+      data_type: NUMBER(38,0)
+    - name: TOTAL_MAPPED_FILES
+      data_type: NUMBER(38,0)
+    - name: TOTAL_EXCEPTIONS
+      data_type: NUMBER(38,0)
+    - name: STATUS
+      data_type: TEXT
+    - name: ERROR_MESSAGE
+      data_type: TEXT
+  - name: META_ROW_COUNT_COMPARE
+    identifier: '"META_ROW_COUNT_COMPARE"'
+    columns:
+    - name: FEED
+      data_type: TEXT
+    - name: SOURCE_ROWS
+      data_type: NUMBER(18,0)
+    - name: FINAL_ROWS
+      data_type: NUMBER(18,0)
+    - name: GAP
+      data_type: NUMBER(19,0)
+    - name: COVERAGE_PCT
+      data_type: FLOAT
+  - name: META_SCHEMA_VERSIONS
+    identifier: '"META_SCHEMA_VERSIONS"'
+    columns:
+    - name: FEED
+      data_type: TEXT
+    - name: VERSION_ID
+      data_type: TEXT
+    - name: FILE_COUNT
+      data_type: NUMBER(38,0)
+    - name: FIRST_SEEN
+      data_type: TIMESTAMP_NTZ
+    - name: LAST_SEEN
+      data_type: TIMESTAMP_NTZ
+    - name: RAW_MAPPING
+      data_type: TEXT
+    - name: COLUMN_MAPPING
+      data_type: VARIANT
+  - name: META_UNMAPPED_FILES
+    identifier: '"META_UNMAPPED_FILES"'
+    columns:
+    - name: FEED
+      data_type: TEXT
+    - name: FILE_ID
+      data_type: NUMBER(38,0)
+    - name: BATCH_ID
+      data_type: NUMBER(38,0)
+    - name: HEADER_ID
+      data_type: NUMBER(38,0)
+    - name: PROFILE_CODE
+      data_type: NUMBER(38,0)
+    - name: ORIGINAL_FILE_NAME
+      data_type: TEXT
+    - name: ROW_COUNT
+      data_type: NUMBER(38,0)
+    - name: LOGGED_AT
+      data_type: TIMESTAMP_NTZ
+    - name: LOADER_JOB_NAME
+      data_type: TEXT
+    - name: HAS_HEADERS
+      data_type: BOOLEAN
+    - name: EXCEPTION_DETECTED_AT
+      data_type: TIMESTAMP_NTZ
+    - name: REASON
+      data_type: TEXT

--- a/models/staging/commissioning/sdl/stg_sdl_meta_build_state.sql
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_build_state.sql
@@ -1,0 +1,12 @@
+-- SDL pipeline metadata: 1:1 view of raw_sdl_wnl_meta_build_state. See docs/slam-data-guide.md
+-- for how these objects drive layout resolution and loading.
+
+select
+    feed,
+    max_file_id_loaded,
+    last_built_at,
+    last_bulk_at,
+    needs_rebuild,
+    last_error
+
+from {{ ref('raw_sdl_wnl_meta_build_state') }}

--- a/models/staging/commissioning/sdl/stg_sdl_meta_build_state.yml
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_build_state.yml
@@ -1,0 +1,23 @@
+version: 2
+
+models:
+  - name: stg_sdl_meta_build_state
+    description: |
+      One row per feed: incremental high-water mark and the needs_rebuild flag that triggers a full rebuild after schema drift.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: feed
+        data_tests:
+          - not_null
+          - unique
+      - name: max_file_id_loaded
+        description: Incremental high-water mark.
+      - name: last_built_at
+      - name: last_bulk_at
+      - name: needs_rebuild
+        description: True when the mapped view schema drifted from the final table; nightly task rebuilds.
+      - name: last_error
+        description: Most recent build error, if any.

--- a/models/staging/commissioning/sdl/stg_sdl_meta_exceptions.sql
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_exceptions.sql
@@ -1,0 +1,12 @@
+-- SDL pipeline metadata: 1:1 view of raw_sdl_wnl_meta_exceptions. See docs/slam-data-guide.md
+-- for how these objects drive layout resolution and loading.
+
+select
+    feed,
+    file_id,
+    batch_id,
+    source_column_headers,
+    detected_at,
+    resolved
+
+from {{ ref('raw_sdl_wnl_meta_exceptions') }}

--- a/models/staging/commissioning/sdl/stg_sdl_meta_exceptions.yml
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_exceptions.yml
@@ -1,0 +1,24 @@
+version: 2
+
+models:
+  - name: stg_sdl_meta_exceptions
+    description: |
+      Files whose header string matched no known layout.
+      They stay invisible downstream until the mapping is extended and resolved flips true.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: feed
+        data_tests:
+          - not_null
+      - name: file_id
+        data_tests:
+          - not_null
+      - name: batch_id
+      - name: source_column_headers
+        description: The unrecognised header string.
+      - name: detected_at
+      - name: resolved
+        description: True once the layout has been mapped.

--- a/models/staging/commissioning/sdl/stg_sdl_meta_file_registry.sql
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_file_registry.sql
@@ -1,0 +1,15 @@
+-- SDL pipeline metadata: 1:1 view of raw_sdl_wnl_meta_file_registry. See docs/slam-data-guide.md
+-- for how these objects drive layout resolution and loading.
+
+select
+    feed,
+    file_id,
+    batch_id,
+    file_name,
+    original_file_name,
+    created_datetime,
+    row_count,
+    loader_job_name,
+    last_refreshed_at
+
+from {{ ref('raw_sdl_wnl_meta_file_registry') }}

--- a/models/staging/commissioning/sdl/stg_sdl_meta_file_registry.yml
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_file_registry.yml
@@ -1,0 +1,39 @@
+version: 2
+
+models:
+  - name: stg_sdl_meta_file_registry
+    description: |
+      One row per file loaded by the SDL pipeline, from the upstream processing log.
+      created_datetime is when ISL processed the file - the ordering used for SLAM latest-submission resolution.
+      Join to feed tables on (meta_file_id, meta_batch_id).
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - feed
+              - file_id
+              - batch_id
+    columns:
+      - name: feed
+        description: Registry feed literal (mixed case, e.g. LSDrPLCM).
+        data_tests:
+          - not_null
+      - name: file_id
+        description: Source file id. Not monotonic with load time.
+        data_tests:
+          - not_null
+      - name: batch_id
+        description: Source batch id; (file_id, batch_id) identifies one loaded file.
+      - name: file_name
+      - name: original_file_name
+        description: Provider file name as received.
+      - name: created_datetime
+        description: When ISL processed the file - the reliable load ordering.
+      - name: row_count
+        description: Rows in the source file per the processing log.
+      - name: loader_job_name
+      - name: last_refreshed_at

--- a/models/staging/commissioning/sdl/stg_sdl_meta_file_versions.sql
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_file_versions.sql
@@ -1,0 +1,11 @@
+-- SDL pipeline metadata: 1:1 view of raw_sdl_wnl_meta_file_versions. See docs/slam-data-guide.md
+-- for how these objects drive layout resolution and loading.
+
+select
+    feed,
+    file_id,
+    batch_id,
+    version_id,
+    match_method
+
+from {{ ref('raw_sdl_wnl_meta_file_versions') }}

--- a/models/staging/commissioning/sdl/stg_sdl_meta_file_versions.yml
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_file_versions.yml
@@ -1,0 +1,28 @@
+version: 2
+
+models:
+  - name: stg_sdl_meta_file_versions
+    description: |
+      One row per loaded file: which layout it matched and how.
+      match_method is headers / header_id / profile_code; NULL version_id means the file is unmapped.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - feed
+              - file_id
+              - batch_id
+    columns:
+      - name: feed
+        data_tests:
+          - not_null
+      - name: file_id
+      - name: batch_id
+      - name: version_id
+        description: Matched layout; NULL when unmapped.
+      - name: match_method
+        description: How the file matched its layout - headers, header_id or profile_code (cascade fallbacks).

--- a/models/staging/commissioning/sdl/stg_sdl_meta_null_rate_profile.sql
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_null_rate_profile.sql
@@ -1,0 +1,16 @@
+-- SDL pipeline metadata: 1:1 view of raw_sdl_wnl_meta_null_rate_profile. See docs/slam-data-guide.md
+-- for how these objects drive layout resolution and loading.
+
+select
+    feed,
+    table_name,
+    column_name,
+    ordinal_position,
+    total_rows,
+    non_null_rows,
+    null_rows,
+    null_rate,
+    is_all_null,
+    computed_at
+
+from {{ ref('raw_sdl_wnl_meta_null_rate_profile') }}

--- a/models/staging/commissioning/sdl/stg_sdl_meta_null_rate_profile.yml
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_null_rate_profile.yml
@@ -1,0 +1,26 @@
+version: 2
+
+models:
+  - name: stg_sdl_meta_null_rate_profile
+    description: |
+      Null rate per (feed, column) over the final tables.
+      Refreshed manually upstream (compute_null_profile.py), so may be empty or stale.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: feed
+        data_tests:
+          - not_null
+      - name: table_name
+      - name: column_name
+      - name: ordinal_position
+      - name: total_rows
+      - name: non_null_rows
+      - name: null_rows
+      - name: null_rate
+        description: Fraction of rows where the column is NULL.
+      - name: is_all_null
+        description: True when no rows populate the column.
+      - name: computed_at

--- a/models/staging/commissioning/sdl/stg_sdl_meta_refresh_log.sql
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_refresh_log.sql
@@ -1,0 +1,16 @@
+-- SDL pipeline metadata: 1:1 view of raw_sdl_wnl_meta_refresh_log. See docs/slam-data-guide.md
+-- for how these objects drive layout resolution and loading.
+
+select
+    run_id,
+    feed,
+    started_at,
+    completed_at,
+    new_files_matched,
+    new_exceptions,
+    total_mapped_files,
+    total_exceptions,
+    status,
+    error_message
+
+from {{ ref('raw_sdl_wnl_meta_refresh_log') }}

--- a/models/staging/commissioning/sdl/stg_sdl_meta_refresh_log.yml
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_refresh_log.yml
@@ -1,0 +1,27 @@
+version: 2
+
+models:
+  - name: stg_sdl_meta_refresh_log
+    description: |
+      Audit log of SDL metadata refresh runs (file-to-layout matching), one row per feed per run.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: run_id
+      - name: feed
+        data_tests:
+          - not_null
+      - name: started_at
+        data_tests:
+          - not_null
+      - name: completed_at
+      - name: new_files_matched
+        description: Files matched to a layout in this run.
+      - name: new_exceptions
+        description: Files added to META_EXCEPTIONS in this run.
+      - name: total_mapped_files
+      - name: total_exceptions
+      - name: status
+      - name: error_message

--- a/models/staging/commissioning/sdl/stg_sdl_meta_row_count_compare.sql
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_row_count_compare.sql
@@ -1,0 +1,11 @@
+-- SDL pipeline metadata: 1:1 view of raw_sdl_wnl_meta_row_count_compare. See docs/slam-data-guide.md
+-- for how these objects drive layout resolution and loading.
+
+select
+    feed,
+    source_rows,
+    final_rows,
+    gap,
+    coverage_pct
+
+from {{ ref('raw_sdl_wnl_meta_row_count_compare') }}

--- a/models/staging/commissioning/sdl/stg_sdl_meta_row_count_compare.yml
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_row_count_compare.yml
@@ -1,0 +1,21 @@
+version: 2
+
+models:
+  - name: stg_sdl_meta_row_count_compare
+    description: |
+      One row per feed: source rows vs rows in the final table, with the coverage fraction.
+      Gaps usually equal the rows of files in meta_unmapped_files.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: feed
+        data_tests:
+          - not_null
+          - unique
+      - name: source_rows
+      - name: final_rows
+      - name: gap
+      - name: coverage_pct
+        description: final_rows / source_rows; 1.0 means fully loaded.

--- a/models/staging/commissioning/sdl/stg_sdl_meta_schema_versions.sql
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_schema_versions.sql
@@ -1,0 +1,13 @@
+-- SDL pipeline metadata: 1:1 view of raw_sdl_wnl_meta_schema_versions. See docs/slam-data-guide.md
+-- for how these objects drive layout resolution and loading.
+
+select
+    feed,
+    version_id,
+    file_count,
+    first_seen,
+    last_seen,
+    raw_mapping,
+    column_mapping
+
+from {{ ref('raw_sdl_wnl_meta_schema_versions') }}

--- a/models/staging/commissioning/sdl/stg_sdl_meta_schema_versions.yml
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_schema_versions.yml
@@ -1,0 +1,31 @@
+version: 2
+
+models:
+  - name: stg_sdl_meta_schema_versions
+    description: |
+      One row per distinct column layout per feed.
+      version_id is the md5 fingerprint of the layout's position-to-name mapping; raw_mapping holds the original T-SQL header string.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - feed
+              - version_id
+    columns:
+      - name: feed
+      - name: version_id
+        description: md5 fingerprint of the layout (16 hex chars).
+        data_tests:
+          - not_null
+      - name: file_count
+        description: Files using this layout.
+      - name: first_seen
+      - name: last_seen
+      - name: raw_mapping
+        description: Original SourceColumnHeaders T-SQL fragment.
+      - name: column_mapping
+        description: Parsed position-to-name mapping.

--- a/models/staging/commissioning/sdl/stg_sdl_meta_unmapped_files.sql
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_unmapped_files.sql
@@ -1,0 +1,18 @@
+-- SDL pipeline metadata: 1:1 view of raw_sdl_wnl_meta_unmapped_files. See docs/slam-data-guide.md
+-- for how these objects drive layout resolution and loading.
+
+select
+    feed,
+    file_id,
+    batch_id,
+    header_id,
+    profile_code,
+    original_file_name,
+    row_count,
+    logged_at,
+    loader_job_name,
+    has_headers,
+    exception_detected_at,
+    reason
+
+from {{ ref('raw_sdl_wnl_meta_unmapped_files') }}

--- a/models/staging/commissioning/sdl/stg_sdl_meta_unmapped_files.yml
+++ b/models/staging/commissioning/sdl/stg_sdl_meta_unmapped_files.yml
@@ -1,0 +1,32 @@
+version: 2
+
+models:
+  - name: stg_sdl_meta_unmapped_files
+    description: |
+      Live view of files not yet loaded into any final table, with the reason.
+      Empty means the pipeline is fully caught up.
+      data_not_logged = the data rows never arrived upstream; not_yet_refreshed = awaiting the nightly metadata refresh.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    columns:
+      - name: feed
+        data_tests:
+          - not_null
+      - name: file_id
+      - name: batch_id
+      - name: header_id
+      - name: profile_code
+      - name: original_file_name
+      - name: row_count
+      - name: logged_at
+      - name: loader_job_name
+      - name: has_headers
+        description: Whether the log row carried a header string.
+      - name: exception_detected_at
+      - name: reason
+        description: >-
+          Why the file is unmapped - exception_unknown_layout, null_headers_no_cascade_sibling, not_yet_refreshed, mapped_but_null_version or data_not_logged.
+        data_tests:
+          - not_null

--- a/scripts/sources/source_mappings.yml
+++ b/scripts/sources/source_mappings.yml
@@ -319,7 +319,8 @@ sources:
 
   # ServicesDataLocal WNL-footprint feeds (permanent home; DATA_LAKE__NCL.SDL
   # and WNL_SDL copies will be retired). Only the SLAM contract-monitoring
-  # feeds + file registry are pulled; the schema holds 20+ other feeds.
+  # feeds + the pipeline META observability objects are pulled; the schema
+  # holds 20+ other feeds (CONTROL_* tables stay in DATA_LAKE only).
   - source_name: sdl_wnl
     database: DATA_LAKE
     schema: SDL
@@ -332,6 +333,14 @@ sources:
       - LSDRPLCM
       - LSDEPLCM
       - META_FILE_REGISTRY
+      - META_SCHEMA_VERSIONS
+      - META_FILE_VERSIONS
+      - META_EXCEPTIONS
+      - META_BUILD_STATE
+      - META_REFRESH_LOG
+      - META_NULL_RATE_PROFILE
+      - META_UNMAPPED_FILES
+      - META_ROW_COUNT_COMPARE
 
   # ANALYST_MANAGED - volatile schema; only explicitly listed tables are used
   - source_name: reference_analyst_managed


### PR DESCRIPTION
Analysts asked for the SDL pipeline metadata to be available in one place. This adds the 9 META_* objects as raw views and staging models in \STAGING.SDL\:

\stg_sdl_meta_file_registry\, \stg_sdl_meta_schema_versions\, \stg_sdl_meta_file_versions\, \stg_sdl_meta_exceptions\, \stg_sdl_meta_build_state\, \stg_sdl_meta_refresh_log\, \stg_sdl_meta_null_rate_profile\, \stg_sdl_meta_unmapped_files\, \stg_sdl_meta_row_count_compare\

- 1:1 views over \DATA_LAKE.SDL\; documented per column (descriptions cover the layout-resolution mechanics, match methods and unmapped reasons)
- Grain tests verified against live data before encoding (registry/file-versions on (feed, file_id, batch_id); build state, row-count compare unique per feed)
- \CONTROL_*\ tables deliberately left in DATA_LAKE only
- Source generation run end to end; includes a DATA_MANAGEMENT drift sync (new \WNL\ practice reference table)

Built clean in dev with tests: 9 views in \DEV__STAGING.SDL\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive data pipeline metadata tracking, including build state monitoring, exception logging, file version history, and refresh run auditing
  * Introduced data quality metrics for null-rate profiling and row-count comparisons across source and final tables
  * Added new WNL reference dataset with GP practice information
  * Implemented staging views with validation tests across all metadata tables for improved data pipeline observability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->