### PR TITLE
feat(analyses): query-history performance reports

### DIFF
--- a/analyses/performance/model_last_run_timing.sql
+++ b/analyses/performance/model_last_run_timing.sql
@@ -1,0 +1,69 @@
+/*
+  Model Last Run Timing
+
+  Last successful build query per dbt model (attributed via the node_id in
+  the dbt query comment), with elapsed time split into:
+  - queued_secs:    warehouse queueing (overload + provisioning + repair)
+  - blocked_secs:   waiting on transaction locks
+  - compile_secs:   Snowflake query compilation
+  - exec_secs:      actual execution on the warehouse
+
+  High queued_secs with modest exec_secs = warehouse contention (concurrency),
+  not a slow query - fix scheduling/warehouse size, not the model.
+
+  Caveats:
+  - SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY lags up to 45 minutes and needs an
+    elevated role (run with DBT_ADMIN / DATA_PLATFORM_MANAGER)
+  - views appear with their (trivial) CREATE VIEW statement; tables and
+    incrementals with CTAS / INSERT / MERGE
+
+  Run via: dbt compile then execute target/.../model_last_run_timing.sql,
+  or paste directly into snow sql / a worksheet (plain SQL, no Jinja).
+*/
+
+WITH model_queries AS (
+    SELECT
+        -- wnl_analytics only: excludes upstream dbt-olids (stable_*) builds
+        REGEXP_SUBSTR(query_text, '"node_id":\\s*"model\\.wnl_analytics\\.([^"]+)"', 1, 1, 'e', 1) AS model_name,
+        query_type,
+        warehouse_name,
+        start_time,
+        total_elapsed_time / 1000 AS total_secs,
+        (queued_overload_time + queued_provisioning_time + queued_repair_time) / 1000 AS queued_secs,
+        transaction_blocked_time / 1000 AS blocked_secs,
+        compilation_time / 1000 AS compile_secs,
+        execution_time / 1000 AS exec_secs,
+        partitions_scanned,
+        partitions_total,
+        bytes_scanned / 1e9 AS gb_scanned
+    FROM snowflake.account_usage.query_history
+    WHERE start_time > DATEADD('day', -30, CURRENT_TIMESTAMP)
+        AND query_type IN ('CREATE_TABLE_AS_SELECT', 'INSERT', 'MERGE', 'CREATE_VIEW')
+        AND execution_status = 'SUCCESS'
+)
+
+SELECT
+    model_name,
+    query_type,
+    warehouse_name,
+    start_time AS last_success_at,
+    ROUND(total_secs, 1) AS total_secs,
+    ROUND(queued_secs, 1) AS queued_secs,
+    ROUND(blocked_secs, 1) AS blocked_secs,
+    ROUND(compile_secs, 1) AS compile_secs,
+    ROUND(exec_secs, 1) AS exec_secs,
+    ROUND(queued_secs / NULLIF(total_secs, 0) * 100, 0) AS pct_queued,
+    partitions_scanned,
+    partitions_total,
+    ROUND(gb_scanned, 2) AS gb_scanned,
+    CASE
+        WHEN queued_secs > exec_secs AND queued_secs > 30
+            THEN 'Mostly queueing - warehouse contention, not a slow query'
+        WHEN exec_secs > 300 THEN 'Slow execution (>5min) - optimise query'
+        WHEN exec_secs > 120 THEN 'Moderate execution (>2min)'
+        ELSE 'OK'
+    END AS assessment
+FROM model_queries
+WHERE model_name IS NOT NULL
+QUALIFY ROW_NUMBER() OVER (PARTITION BY model_name ORDER BY start_time DESC) = 1
+ORDER BY total_secs DESC

--- a/analyses/performance/model_spill_report.sql
+++ b/analyses/performance/model_spill_report.sql
@@ -1,0 +1,68 @@
+/*
+  Model Spill Report
+
+  Models ranked by bytes spilled during their last successful build.
+  Spilling means a sort/window/join intermediate exceeded warehouse memory;
+  every spilled GB is written and re-read mid-query, multiplying execution
+  time. Remote spill (cloud storage) is far slower than local (SSD).
+
+  spill_ratio = spilled / scanned. A ratio well above 1 means an operator
+  inflates the data far beyond its input - usually a wide column set dragged
+  through a window function or sort. Fixes, in order:
+  1. narrow the columns entering the sort/window/dedup, rejoin payload after
+  2. pre-aggregate or split the heavy operator
+  3. route the model to a larger warehouse (snowflake_warehouse config)
+
+  Caveats:
+  - SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY lags up to 45 minutes and needs an
+    elevated role (run with DBT_ADMIN / DATA_PLATFORM_MANAGER)
+
+  Run via: dbt compile then execute target/.../model_spill_report.sql,
+  or paste directly into snow sql / a worksheet (plain SQL, no Jinja).
+*/
+
+WITH model_queries AS (
+    SELECT
+        -- wnl_analytics only: excludes upstream dbt-olids (stable_*) builds
+        REGEXP_SUBSTR(query_text, '"node_id":\\s*"model\\.wnl_analytics\\.([^"]+)"', 1, 1, 'e', 1) AS model_name,
+        warehouse_name,
+        start_time,
+        execution_time / 1000 AS exec_secs,
+        bytes_scanned / 1e9 AS gb_scanned,
+        bytes_spilled_to_local_storage / 1e9 AS gb_spilled_local,
+        bytes_spilled_to_remote_storage / 1e9 AS gb_spilled_remote
+    FROM snowflake.account_usage.query_history
+    WHERE start_time > DATEADD('day', -30, CURRENT_TIMESTAMP)
+        AND query_type IN ('CREATE_TABLE_AS_SELECT', 'INSERT', 'MERGE', 'CREATE_VIEW')
+        AND execution_status = 'SUCCESS'
+),
+
+last_runs AS (
+    SELECT *
+    FROM model_queries
+    WHERE model_name IS NOT NULL
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY model_name ORDER BY start_time DESC) = 1
+)
+
+SELECT
+    model_name,
+    warehouse_name,
+    start_time AS last_success_at,
+    ROUND(exec_secs, 1) AS exec_secs,
+    ROUND(gb_scanned, 2) AS gb_scanned,
+    ROUND(gb_spilled_local, 2) AS gb_spilled_local,
+    ROUND(gb_spilled_remote, 2) AS gb_spilled_remote,
+    ROUND(gb_spilled_local + gb_spilled_remote, 2) AS gb_spilled_total,
+    ROUND((gb_spilled_local + gb_spilled_remote) / NULLIF(gb_scanned, 0), 1) AS spill_ratio,
+    CASE
+        WHEN gb_spilled_remote > 1
+            THEN 'Remote spill - severe memory pressure, fix or upsize warehouse'
+        WHEN (gb_spilled_local + gb_spilled_remote) / NULLIF(gb_scanned, 0) > 3
+            THEN 'Intermediate blow-up - narrow columns entering sort/window'
+        WHEN gb_spilled_local + gb_spilled_remote > 5
+            THEN 'Heavy local spill - review sort/window width'
+        ELSE 'Minor'
+    END AS assessment
+FROM last_runs
+WHERE gb_spilled_local + gb_spilled_remote > 0.1
+ORDER BY gb_spilled_total DESC

--- a/analyses/performance/partition_pruning_report.sql
+++ b/analyses/performance/partition_pruning_report.sql
@@ -1,0 +1,83 @@
+/*
+  Partition Pruning Report
+
+  Per-model micro-partition pruning stats from Snowflake query history,
+  attributed via the dbt query comment (node_id) appended to every query.
+
+  pct_scanned reads:
+  - low  = predicates/joins hit the source table cluster keys (good pruning)
+  - high = full scan; fine for whole-table builds, a problem when the model
+    selects a small slice (check filters against the source cluster keys,
+    e.g. OLIDS medication tables: bnf_chapter, mapped_concept_code,
+    clinical_effective_date)
+
+  Caveats:
+  - partitions_total counts all tables referenced by the query, so pct is a
+    blended figure, not per-table
+  - small scans (< 100 partitions) are excluded: pruning is irrelevant there
+  - SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY lags up to 45 minutes and needs an
+    elevated role (run with DBT_ADMIN / DATA_PLATFORM_MANAGER)
+
+  Run via: dbt compile then execute target/.../partition_pruning_report.sql,
+  or paste directly into snow sql / a worksheet (plain SQL, no Jinja).
+*/
+
+WITH model_queries AS (
+    SELECT
+        -- dbt appends: /* {"app": "dbt", ..., "node_id": "model.wnl_analytics.<name>", ...} */
+        -- wnl_analytics only: excludes upstream dbt-olids (stable_*) builds
+        REGEXP_SUBSTR(query_text, '"node_id":\\s*"model\\.wnl_analytics\\.([^"]+)"', 1, 1, 'e', 1) AS model_name,
+        query_type,
+        start_time,
+        total_elapsed_time / 1000 AS elapsed_secs,
+        partitions_scanned,
+        partitions_total,
+        bytes_scanned / 1e9 AS gb_scanned
+    FROM snowflake.account_usage.query_history
+    WHERE start_time > DATEADD('day', -7, CURRENT_TIMESTAMP)
+        AND query_type IN ('CREATE_TABLE_AS_SELECT', 'INSERT', 'MERGE')
+        AND partitions_total >= 100
+        AND execution_status = 'SUCCESS'
+),
+
+per_model AS (
+    SELECT
+        model_name,
+        COUNT(*) AS runs_7d,
+        ROUND(AVG(elapsed_secs), 1) AS avg_secs,
+        ROUND(AVG(partitions_scanned), 0) AS avg_partitions_scanned,
+        ROUND(AVG(partitions_total), 0) AS avg_partitions_total,
+        ROUND(AVG(partitions_scanned / partitions_total) * 100, 1) AS avg_pct_scanned,
+        ROUND(AVG(gb_scanned), 2) AS avg_gb_scanned,
+        ROUND(SUM(gb_scanned), 1) AS total_gb_7d
+    FROM model_queries
+    WHERE model_name IS NOT NULL
+    GROUP BY model_name
+)
+
+SELECT
+    model_name,
+    runs_7d,
+    avg_secs,
+    avg_partitions_scanned,
+    avg_partitions_total,
+    avg_pct_scanned,
+    avg_gb_scanned,
+    total_gb_7d,
+    CASE
+        WHEN avg_pct_scanned <= 15 THEN '✅ Excellent'
+        WHEN avg_pct_scanned <= 40 THEN '🟢 Good'
+        WHEN avg_pct_scanned <= 70 THEN '🟡 Partial'
+        ELSE '🔴 Full scan'
+    END AS pruning,
+    CASE
+        WHEN avg_pct_scanned > 70 AND total_gb_7d > 20
+            THEN 'High cost + no pruning - check filters vs source cluster keys'
+        WHEN avg_pct_scanned > 70
+            THEN 'Full scan - fine if whole-table build'
+        WHEN avg_pct_scanned > 40 AND total_gb_7d > 20
+            THEN 'Partial pruning on a heavy scan - review predicates'
+        ELSE 'OK'
+    END AS suggestion
+FROM per_model
+ORDER BY total_gb_7d DESC


### PR DESCRIPTION
Three analyses over `SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY`, attributing each warehouse query to its dbt model via the `node_id` in the dbt query comment. All plain SQL (no Jinja) so they run via `dbt compile` output or pasted into a worksheet; need an elevated role (DBT_ADMIN / DATA_PLATFORM_MANAGER) for ACCOUNT_USAGE. Scoped to `wnl_analytics` models only.

- **partition_pruning_report** - partitions scanned vs total per model over 7 days, flags models where filters miss the source cluster keys. First run showed BNF-filtered medication models prune to 10-13% while date-window-only consumers scan ~100%.
- **model_last_run_timing** - each model's last successful run with elapsed time split into queued / blocked / compile / execution. First run showed 66% of build wall-clock is warehouse queueing, not execution; only 4 models exceed 2 minutes of actual execution.
- **model_spill_report** - models ranked by bytes spilled (local/remote split, spill ratio vs scanned). Six models account for ~100 GB of local spill per build cycle; `int_person_pmi_dataset_sus` spills 9x its input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new performance analysis reports for dbt models: one tracking runtime metrics and timing components, another measuring memory spill data, and a third evaluating partition pruning efficiency.
  * Reports leverage Snowflake query history data from the past 7–30 days and include assessments to identify optimisation opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->