### PR TITLE
fix(myria): resolve inpatient site_name from full org dictionary

### DIFF
--- a/models/modelling/commissioning/encounters/int_sus_apc_encounter.sql
+++ b/models/modelling/commissioning/encounters/int_sus_apc_encounter.sql
@@ -42,7 +42,7 @@ select
     , core.spell_commissioning_service_agreement_provider as organisation_id
     , dict_provider.service_provider_name  as organisation_name
     , core.spell_care_location_site_code_of_treatment as site_id
-    , dict_org.organisation_name as site_name  
+    , dict_site.organisation_name as site_name
     
     /* Time and date */
     , core.spell_admission_date as start_date
@@ -132,8 +132,11 @@ left join gender_codes as gen
 LEFT JOIN {{ ref('stg_dictionary_dbo_serviceprovider') }} as dict_provider 
     ON core.SPELL_COMMISSIONING_SERVICE_AGREEMENT_PROVIDER = dict_provider.service_provider_full_code
 
-LEFT JOIN {{ ref('dict_organisation_nhs_provider') }} as dict_org 
-    ON core.spell_care_location_site_code_of_treatment = dict_org.organisation_code 
+-- site name: site-level treatment code resolves against the full organisation
+-- dictionary (hospital sites are type 42; dict_organisation_nhs_provider is trusts
+-- only, type 41, so it left site_name null). Mirrors int_sus_uec_encounter.
+LEFT JOIN {{ ref('stg_dictionary_dbo_organisation') }} as dict_site
+    ON core.spell_care_location_site_code_of_treatment = dict_site.organisation_code
 
 left join dominant_episode_information as dom_ep_info
     ON core.primarykey_id = dom_ep_info.primarykey_id

--- a/models/modelling/commissioning/projects/myria/int_myria_conditions.sql
+++ b/models/modelling/commissioning/projects/myria/int_myria_conditions.sql
@@ -65,7 +65,7 @@ pds_patient_check as
     CASE -- counts distinct attendance IDs and then flags as 1 if there is at least 1 non-elective attendance at Barnet Hospital in the period
         WHEN COUNT(DISTINCT 
                     CASE 
-                        WHEN provider_site_name = 'Barnet Hospital' 
+                        WHEN provider_site_code = 'RAL26' -- Barnet Hospital
                             AND att_dx.activity_date >= '01-Jan-2025' AND att_dx.activity_date < DATE_TRUNC('month',CURRENT_DATE) -- activity between 1 Jan 2025 and start of current month
                             AND pod IN ('NEL-ZLOS','NEL-LOS+1') 
                         THEN primary_id 
@@ -75,7 +75,7 @@ pds_patient_check as
 
     COUNT(DISTINCT -- counts distinct attendance IDs for non-elective attendances at Barnet Hospital in the period
                     CASE 
-                        WHEN provider_site_name = 'Barnet Hospital' 
+                        WHEN provider_site_code = 'RAL26' -- Barnet Hospital
                             AND att_dx.activity_date >= '01-Jan-2025' AND att_dx.activity_date < DATE_TRUNC('month',CURRENT_DATE)
                             AND pod IN ('NEL-ZLOS','NEL-LOS+1') 
                         THEN primary_id 
@@ -85,7 +85,7 @@ pds_patient_check as
         WHEN COUNT(DISTINCT 
                     CASE 
                         WHEN provider_code IN ('RAL','RAP')
-                            AND provider_site_name <> 'Barnet Hospital'
+                            AND provider_site_code <> 'RAL26' -- exclude Barnet Hospital
                             AND att_dx.activity_date >= '01-Jan-2025' AND att_dx.activity_date < DATE_TRUNC('month',CURRENT_DATE)
                             AND pod IN ('NEL-ZLOS','NEL-LOS+1') 
                         THEN primary_id 
@@ -96,7 +96,7 @@ pds_patient_check as
     COUNT(DISTINCT -- counts distinct attendance IDs for non-elective attendances at non-Barnet Hospital sites in the period
                     CASE 
                         WHEN provider_code IN ('RAL','RAP')
-                            AND provider_site_name <> 'Barnet Hospital' 
+                            AND provider_site_code <> 'RAL26' -- exclude Barnet Hospital 
                             AND att_dx.activity_date >= '01-Jan-2025' AND att_dx.activity_date < DATE_TRUNC('month',CURRENT_DATE)
                             AND pod IN ('NEL-ZLOS','NEL-LOS+1') 
                         THEN primary_id 


### PR DESCRIPTION
## What

Fix `site_name` resolution for inpatient (APC) encounters. `int_sus_apc_encounter` joined the site-level treatment code against `dict_organisation_nhs_provider`, which is filtered to NHS **trusts** (org type 41). Hospital **sites** are type 42, so the join missed and `site_name` was **null for every inpatient spell** — including Barnet Hospital (`RAL26`).

Downstream, `int_myria_conditions` counts Barnet NEL admissions via `provider_site_name = 'Barnet Hospital'`, and `fct_person_myria_high_risk_patients` filters on `barnet_hospital_count >= 1`. With the name null, the count was always 0 — so the monthly RFL high-risk cohort was **empty**.

Two changes:
1. `int_sus_apc_encounter` — repoint the `site_name` join to the full organisation dictionary (`stg_dictionary_dbo_organisation`) on the site code, mirroring `int_sus_uec_encounter` (A&E, which always resolved correctly).
2. `int_myria_conditions` — key the Barnet flags/counts off `provider_site_code = 'RAL26'` instead of the display string, consistent with the model's own `most_recent_bh_admission` CTE. Hardening so the cohort no longer depends on a dictionary display name.

## Why now

Surfaced when the Myria models returned no Barnet activity ahead of an RFL submission. Introduced by the OBT-as-int refactor (#796) wiring APC `site_name` to the trust-only dictionary added in #799 (both landed ~11 Jun).

## Testing — before/after

Before = current prod. After = this branch built in dev (`dbt build --select int_sus_apc_encounter int_myria_attendances_diagnoses+ --exclude tag:myria_eval`, 23/23 success, all tests pass).

| Metric | Before (prod) | After (dev) |
|---|---:|---:|
| APC spells resolving `site_name = 'Barnet Hospital'` | 0 | 602,737 |
| Patients with ≥1 Barnet NEL admission | 0 | 15,253 |
| Σ `barnet_hospital_count` | 0 | 20,328 |
| **High-risk RFL cohort rows** | **0** | **5,933** |
| Control group rows | — | 29,624 |

The high-risk count (5,933) sits in the expected range (eval cohort ~5,710 May / ~6,061 cumulative).

## Risk

Low / strictly additive. `dict_organisation_nhs_provider` is defined as `stg_dictionary_dbo_organisation WHERE type = 41` — a subset of the dictionary the fix joins to. `organisation_code` is unique there (427,802 rows, all distinct), confirmed no fan-out (encounter row count unchanged at 12,001,766). Any site code that resolved before resolves to the same name now; previously-null sites now populate. The ~12 other consumers of `int_sus_apc_encounter` (maternity, respiratory, person-activity, cltcs, obt) can only gain correct site names.
