### PR TITLE
fix(sus): resolve outpatient site_name from full org dictionary

### DIFF
--- a/models/modelling/commissioning/encounters/int_sus_op_appointment.sql
+++ b/models/modelling/commissioning/encounters/int_sus_op_appointment.sql
@@ -39,7 +39,7 @@ select
     , core.appointment_commissioning_service_agreement_provider as organisation_id
     , dict_provider.service_provider_name as organisation_name
     , core.appointment_care_location_site_code_of_treatment as site_id
-    , dict_org.organisation_name as site_name
+    , dict_site.organisation_name as site_name
 
      /* Time and date */
     , core.appointment_date as start_date
@@ -134,9 +134,12 @@ LEFT JOIN {{ ref('stg_dictionary_dbo_procedure')}} As dict_proc ON proc.code = d
 -- need to stage procedure dictionary to get description and category
 
 -- organisations
-left join 
-    {{ ref('dict_organisation_nhs_provider') }} as dict_org 
-    on core.appointment_care_location_site_code_of_treatment = dict_org.organisation_code 
+-- site name: site-level treatment code resolves against the full organisation
+-- dictionary (hospital sites are type 42; dict_organisation_nhs_provider is trusts
+-- only, type 41, so it left site_name null). Mirrors int_sus_uec_encounter.
+left join
+    {{ ref('stg_dictionary_dbo_organisation') }} as dict_site
+    on core.appointment_care_location_site_code_of_treatment = dict_site.organisation_code
 
 left join 
     {{ ref('stg_dictionary_dbo_serviceprovider') }} as dict_provider 


### PR DESCRIPTION
## What

Fix `site_name` resolution for outpatient (OP) SUS encounters. `int_sus_op_appointment` joined the site-level treatment code (`appointment_care_location_site_code_of_treatment`) against `dict_organisation_nhs_provider`, which is filtered to NHS **trusts** (org type 41). Hospital **sites** are type 42, so the join missed and `site_name` was **null for every outpatient row** — including Barnet Hospital (`RAL26`).

Repoint the join to the full organisation dictionary (`stg_dictionary_dbo_organisation`) on the site code, mirroring `int_sus_uec_encounter`.

## Context

This is the outpatient twin of the inpatient defect fixed in #812. Same root cause, same one-line fix; OP was missed from that PR (the commit landed after #812 merged). After this, all three SUS encounter models resolve `site_name` correctly and `dict_organisation_nhs_provider` is only used where it should be (UEC's provider-name join, keyed on a trust code).

## Testing — before/after

Built in dev (`dbt build --select int_sus_op_appointment int_sus_op_encounter`, 11/11 success, all tests pass).

| Metric | Before (prod) | After (dev) |
|---|---:|---:|
| OP `site_name` resolved | 0% | 98.49% |
| Barnet OP rows named | 0 | 3,656,352 |

## Risk

Low / strictly additive. `dict_organisation_nhs_provider` is a `type = 41` subset of the dictionary the fix joins to; `organisation_code` is unique there, so previously-null sites populate and nothing that resolved before changes. No fan-out.
