### PR TITLE
fix(person-demographics): map SNOMED sex grouper to Unknown

### DIFF
--- a/models/reporting/olids/person_demographics/dim_person_demographics.yml
+++ b/models/reporting/olids/person_demographics/dim_person_demographics.yml
@@ -112,7 +112,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['Male', 'Female', 'Unknown', 'Indeterminate sex', 'Finding related to biological sex']
+                values: ['Male', 'Female', 'Indeterminate sex', 'Unknown']
 
       - name: ethnicity_category
         description: 'Ethnicity category from latest recording'

--- a/models/reporting/olids/person_demographics/dim_person_gender.sql
+++ b/models/reporting/olids/person_demographics/dim_person_gender.sql
@@ -49,7 +49,13 @@ SELECT
 FROM (
     SELECT
         ap.person_id,
-        COALESCE(p_best.gender_display, p_curr.gender_display, p_best.gender_source_display, p_curr.gender_source_display, 'Unknown') AS gender,
+        COALESCE(
+            -- "Finding related to biological sex" is the SNOMED parent grouper (429019009)
+            -- mapped to source code 'U'/'Unknown'; non-informative, so fall through to source display
+            NULLIF(p_best.gender_display, 'Finding related to biological sex'),
+            NULLIF(p_curr.gender_display, 'Finding related to biological sex'),
+            p_best.gender_source_display, p_curr.gender_source_display, 'Unknown'
+        ) AS gender,
         ROW_NUMBER() OVER (
             PARTITION BY ap.person_id
             ORDER BY

--- a/models/reporting/olids/person_demographics/dim_person_gender.yml
+++ b/models/reporting/olids/person_demographics/dim_person_gender.yml
@@ -1,12 +1,12 @@
 models:
   - name: dim_person_gender
-    description: 'Gender demographics for all persons with standardised three-category classification.
+    description: 'Gender demographics for all persons with standardised classification.
 
       Key Features:
 
       • One row per person derived from gender_source_concept_id mappings
 
-      • Standardised categories: Male, Female, Unknown
+      • Standardised categories: Male, Female, Indeterminate sex, Unknown
 
       • Patient selection prioritises records with gender data
 
@@ -28,4 +28,4 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['Male', 'Female', 'Unknown', 'Indeterminate sex', 'Finding related to biological sex']
+                values: ['Male', 'Female', 'Indeterminate sex', 'Unknown']

--- a/models/reporting/olids/person_demographics/dim_person_women_child_bearing_age.yml
+++ b/models/reporting/olids/person_demographics/dim_person_women_child_bearing_age.yml
@@ -39,7 +39,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['Female', 'Unknown', 'Indeterminate sex', 'Finding related to biological sex']
+                values: ['Female', 'Unknown', 'Indeterminate sex']
 
       - name: is_child_bearing_age_12_55
         description: 'Flag for standard demographic child-bearing age (12-55 years inclusive)'


### PR DESCRIPTION
`gender_display` resolves source code `U` to the SNOMED parent grouper "Finding related to biological sex" (429019009), which carries no actual sex value but surfaced as a distinct gender (57 patients).

- `NULLIF` the grouper out of the COALESCE in `dim_person_gender` so those rows fall through to the source display (`Unknown`)
- Tighten gender `accepted_values` to `Male / Female / Indeterminate sex / Unknown` across the three demographics models

Verified: model rebuilt, 4 tests pass, output now Female / Male / Unknown / Indeterminate sex only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gender data handling across demographic records to better treat ambiguous classifications as non-informative.

* **Tests**
  * Refined validation rules for gender fields to standardise accepted categories: Male, Female, Indeterminate sex, and Unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->