### PR TITLE
feat(slam): recover LSACM DLP/Local layouts + commissioner-grain latest

### DIFF
--- a/macros/transformations/parse_slam.sql
+++ b/macros/transformations/parse_slam.sql
@@ -5,19 +5,6 @@
    models. Models supply only feed-specific columns; aliases are fixed:
    `s` = source table, `sl` = submission_slices_ranked. #}
 
-{# Maps SDL WNL source table names to their raw-layer passthrough models. #}
-{% macro sdl_wnl_raw_model(table_name) -%}
-{%- set models = {
-    'LSACM': 'raw_sdl_wnl_lsacm',
-    'LSPLCM': 'raw_sdl_wnl_lsplcm',
-    'LSDRPLCM': 'raw_sdl_wnl_lsdrplcm',
-    'LSDEPLCM': 'raw_sdl_wnl_lsdeplcm',
-    'COMOPL': 'raw_sdl_wnl_comopl',
-    'REF': 'raw_sdl_wnl_ref',
-} -%}
-{{- models[table_name] -}}
-{%- endmacro %}
-
 {# Money/activity string -> NUMBER(38,6).
    Handles thousands commas, currency symbols (incl. mojibake bytes), spaces,
    and accounting-style "(1,234.56)" negatives. 'TBC' and other non-numeric
@@ -69,9 +56,17 @@
 
 {# Financial year string -> canonical 'YYYYYY' (e.g. '202526'), validated so the
    second year follows the first. Accepts '202526', '2025/26', '2025-26',
-   '2025 26', '2025-2026'. Bare calendar years ('2020') are ambiguous -> NULL.
-   Garbage ('215551', specialty names on misaligned rows) -> NULL. #}
-{% macro parse_slam_financial_year(col) %}
+   '2025 26', '2025-2026'. Garbage ('215551', specialty names on misaligned
+   rows) -> NULL.
+
+   Bare calendar years ('2020') are ambiguous across feeds (could be either FY
+   end) -> NULL by default. allow_bare_year=true reads a bare 4-digit '20YY'
+   (2015-2030) as the FY START year ('2020' -> '202021'); used only for LSACM,
+   whose DLP/Local layouts carry the FY start year in dlp_FinancialYear with no
+   YYYYYY column. Safe there because, after the AcuteAGG summaries are
+   quarantined, a bare year in LSACM.financial_year is reliably a real FY start;
+   the PLD feeds keep returning NULL so their activity-date fallback wins. #}
+{% macro parse_slam_financial_year(col, allow_bare_year=false) %}
     case
         when regexp_replace({{ col }}, '[^0-9]', '') rlike '^20[0-9]{4}$'
              and try_to_number(substr(regexp_replace({{ col }}, '[^0-9]', ''), 5, 2))
@@ -82,6 +77,12 @@
                  = try_to_number(substr(regexp_replace({{ col }}, '[^0-9]', ''), 1, 4)) + 1
             then substr(regexp_replace({{ col }}, '[^0-9]', ''), 1, 4)
                  || substr(regexp_replace({{ col }}, '[^0-9]', ''), 7, 2)
+{% if allow_bare_year %}
+        when regexp_replace({{ col }}, '[^0-9]', '') rlike '^20[0-9]{2}$'
+             and try_to_number(regexp_replace({{ col }}, '[^0-9]', '')) between 2015 and 2030
+            then regexp_replace({{ col }}, '[^0-9]', '')
+                 || lpad(to_varchar(mod(try_to_number(regexp_replace({{ col }}, '[^0-9]', '')) + 1, 100)), 2, '0')
+{% endif %}
     end
 {% endmacro %}
 
@@ -152,6 +153,8 @@
    `table_name` is the source table; `feed` is the registry FEED literal
    (mixed case, e.g. 'LSDrPLCM'). #}
 {% macro slam_submission_slices(table_name, feed) %}
+{# LSACM DLP/Local layouts carry the FY only as a bare start year - allow it. #}
+{%- set allow_bare = (feed == 'LSACM') -%}
 registry as (
     select
         file_id,
@@ -165,7 +168,7 @@ registry as (
                  = mod(try_to_number(substr(regexp_substr(original_file_name, '_(2[0-9][0-9]{2})_InformationStandard', 1, 1, 'e', 1), 1, 2)) + 1, 100)
                 then '20' || regexp_substr(original_file_name, '_(2[0-9][0-9]{2})_InformationStandard', 1, 1, 'e', 1)
         end                                     as financial_year_from_file_name
-    from {{ ref('raw_sdl_wnl_meta_file_registry') }}
+    from {{ source('sdl_wnl', 'META_FILE_REGISTRY') }}
     where feed = '{{ feed }}'
 ),
 
@@ -177,7 +180,7 @@ submission_slices as (
         financial_year,
         financial_month,
         organisation_identifier_code_of_provider as provider_code_raw
-    from {{ ref(sdl_wnl_raw_model(table_name)) }}
+    from {{ source('sdl_wnl', table_name) }}
     group by all
 ),
 
@@ -186,10 +189,10 @@ submission_slices_enriched as (
         s.*,
         r.submission_loaded_at,
         r.submission_file_name,
-        {{ parse_slam_financial_year('s.financial_year') }}
+        {{ parse_slam_financial_year('s.financial_year', allow_bare_year=allow_bare) }}
                                                 as dv_financial_year_stated,
         coalesce(
-            {{ parse_slam_financial_year('s.financial_year') }},
+            {{ parse_slam_financial_year('s.financial_year', allow_bare_year=allow_bare) }},
             r.financial_year_from_file_name
         )                                       as dv_financial_year,
         {{ parse_slam_financial_month('s.financial_month') }}
@@ -214,7 +217,7 @@ submission_slices_enriched as (
 ,
 new_files as (
     select meta_file_id, meta_batch_id
-    from {{ ref(sdl_wnl_raw_model(table_name)) }}
+    from {{ source('sdl_wnl', table_name) }}
     group by all
     minus
     select distinct meta_file_id, meta_batch_id
@@ -237,7 +240,9 @@ where exists (
 
 {# Body of a stg_*_latest view: staging rows restricted to the file holding
    the current provider statement of each (provider, FY, month) slice, via
-   the stg_slam_latest_submission lookup. #}
+   the stg_slam_latest_submission lookup. LSACM adds commissioner to the slice
+   (DLP/Local providers submit per-commissioner files) — the lookup's
+   dv_commissioner is NULL for the other feeds, so they stay provider-grain. #}
 {% macro slam_latest_view(staging_model, feed) %}
 select s.*
 from {{ ref(staging_model) }} as s
@@ -248,6 +253,9 @@ join {{ ref('stg_slam_latest_submission') }} as l
    and equal_null(l.dv_provider_code, s.dv_provider_code)
    and equal_null(l.dv_financial_year, s.dv_financial_year)
    and equal_null(l.dv_financial_month, s.dv_financial_month)
+{% if feed == 'LSACM' %}
+   and equal_null(l.dv_commissioner, s.commissioner_code)
+{% endif %}
 {% endmacro %}
 
 {# Join condition matching a source row to its submission slice. Null-safe on

--- a/models/staging/commissioning/slam/stg_slam_latest_submission.sql
+++ b/models/staging/commissioning/slam/stg_slam_latest_submission.sql
@@ -46,7 +46,7 @@ with registry as (
                  = mod(try_to_number(substr(regexp_substr(original_file_name, '_(2[0-9][0-9]{2})_InformationStandard', 1, 1, 'e', 1), 1, 2)) + 1, 100)
                 then '20' || regexp_substr(original_file_name, '_(2[0-9][0-9]{2})_InformationStandard', 1, 1, 'e', 1)
         end                                     as financial_year_from_file_name
-    from {{ ref('raw_sdl_wnl_meta_file_registry') }}
+    from {{ source('sdl_wnl', 'META_FILE_REGISTRY') }}
     where feed in ('LSACM', 'LSPLCM', 'LSDrPLCM', 'LSDePLCM')
 ),
 
@@ -65,6 +65,7 @@ slices as (
         financial_year,
         financial_month,
         provider_code_raw,
+        dv_commissioner,
         {{ slam_fy_from_date('period_date') }}      as fy_from_date,
         iff(period_date is not null,
             {{ slam_fm_from_date('period_date') }}, null)
@@ -78,6 +79,15 @@ slices as (
             cast(s.financial_year as varchar)           as financial_year,
             cast(s.financial_month as varchar)          as financial_month,
             s.organisation_identifier_code_of_provider  as provider_code_raw,
+            {% if table_name == 'LSACM' %}
+            -- LSACM DLP/Local layouts submit per-commissioner files, so the
+            -- current statement is per (provider, commissioner, FY, month).
+            -- Other feeds submit one comprehensive file per provider (grain
+            -- stays provider-only): dv_commissioner is NULL and drops out.
+            s.organisation_identifier_code_of_commissioner as dv_commissioner,
+            {% else %}
+            cast(null as varchar)                       as dv_commissioner,
+            {% endif %}
             {% if table_name != 'LSACM' %}
             -- evaluated once per row; gated to incomplete-period rows
             case when {{ parse_slam_financial_year('s.financial_year') }} is null
@@ -87,7 +97,7 @@ slices as (
             {% else %}
             null::date                                  as period_date
             {% endif %}
-        from {{ ref(sdl_wnl_raw_model(table_name)) }} as s
+        from {{ source('sdl_wnl', table_name) }} as s
     )
     group by all
     {% if not loop.last %}union all{% endif %}
@@ -99,8 +109,14 @@ enriched as (
         s.feed,
         s.meta_file_id,
         s.meta_batch_id,
+        s.dv_commissioner,
         coalesce(
-            {{ parse_slam_financial_year('s.financial_year') }},
+            -- LSACM DLP/Local layouts carry the FY as a bare start year; other
+            -- feeds keep the strict parse so their activity-date fallback wins.
+            case when s.feed = 'LSACM'
+                then {{ parse_slam_financial_year('s.financial_year', allow_bare_year=true) }}
+                else {{ parse_slam_financial_year('s.financial_year') }}
+            end,
             r.financial_year_from_file_name,
             s.fy_from_date
         )                                       as dv_financial_year,
@@ -123,7 +139,7 @@ ranked as (
     select
         *,
         rank() over (
-            partition by feed, dv_provider_code, dv_financial_year, dv_financial_month
+            partition by feed, dv_provider_code, dv_commissioner, dv_financial_year, dv_financial_month
             order by submission_loaded_at desc nulls last, meta_file_id desc, meta_batch_id desc
         )                                       as submission_rank
     from enriched
@@ -132,6 +148,7 @@ ranked as (
 select distinct
     feed,
     dv_provider_code,
+    dv_commissioner,
     dv_financial_year,
     dv_financial_month,
     meta_file_id,

--- a/models/staging/commissioning/slam/stg_slam_latest_submission.yml
+++ b/models/staging/commissioning/slam/stg_slam_latest_submission.yml
@@ -22,6 +22,7 @@ models:
             combination_of_columns:
               - feed
               - dv_provider_code
+              - dv_commissioner
               - dv_financial_year
               - dv_financial_month
     columns:
@@ -31,6 +32,11 @@ models:
           - not_null
       - name: dv_provider_code
         description: Dictionary-cleaned provider ODS code (slice key).
+      - name: dv_commissioner
+        description: |
+          Commissioner ODS code — part of the slice key for LSACM only (DLP/Local
+          providers submit per-commissioner files). NULL for the other SLAM feeds,
+          which stay provider-grain.
       - name: dv_financial_year
         description: Validated financial year 'YYYYYY' (slice key).
       - name: dv_financial_month


### PR DESCRIPTION
## Why
Several acute providers (RYJ, RAL, RQX, R1H, …) submit contract monitoring in bespoke "DLP/Local" layouts. The SLAM period logic didn't resolve them, so **~44M rows across 12 providers (FY2019/20–2025/26)** landed in `LSACM` with **no financial period and no usable activity/price**. Reported as a reconciliation gap (4 M12-freeze files for RYJ/RAL/RQX/R1H were missing).

Paired upstream change in `Snowflake-Deployment` maps these layouts' source columns to canonical (period + activity/price); this PR is the dbt side.

## What
- **`parse_slam_financial_year(allow_bare_year=false)`** — opt-in branch reads a bare 4-digit start year (`'2020'` → `'202021'`). Scoped to LSACM, whose DLP layouts carry the FY only as `dlp_FinancialYear` with no `YYYYYY` column. PLD feeds keep returning NULL so their activity-date fallback still wins.
- **`stg_slam_latest_submission`** — adds commissioner to the slice grain **for LSACM only**. These providers submit **per-commissioner files**, so the provider-grain latest view kept one file and dropped the other commissioners (RYJ showed 8 of 59). Other feeds stay provider-grain (`dv_commissioner` NULL).
- **`slam_latest_view`** — joins on commissioner for LSACM; uniqueness test updated to the new grain.

## Checked (prod)
- All four originally-missing files now resolve `dv_financial_year=202021`, 12 months, full activity/price.
- `STG_LSACM_LATEST` now keeps **all** commissioners per provider (RYJ 8→59, RAL 38→52; R1H/RQX unchanged) with **no double-counting** (uniqueness tests pass).
- LSACM now **99.9%** period-resolved (603M rows). PLD feeds unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * LSACM submissions now tracked by individual commissioner for more granular submission identification
  * Enhanced financial year parsing for LSACM with improved handling of calendar year formats
  * Streamlined data sourcing architecture for improved system efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->