### PR TITLE
Fix: cohort snapshot ppipeline

### DIFF
--- a/models/published/direct_care/C_LTCS/cltcs_cohort_membership.sql
+++ b/models/published/direct_care/C_LTCS/cltcs_cohort_membership.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+
+/*
+Membership-collapsed view of cltcs_cohort_data for SCD2 snapshotting.
+
+Clinical Purpose:
+- Feed `cltcs_cohort_membership_snapshot` so that we can track when patients
+  enter, exit and re-enter the C-LTCS cohort, plus when their processing
+  area changes. A change in `area_code` represents a change in processing
+  pathway and is treated as the end of one stint and the start of another.
+
+Shape:
+- One row per patient_id (carrying current area_code).
+- The wide attribute set from cltcs_cohort_data is collapsed into a single
+  VARIANT column `attributes_json` so the snapshot stays narrow while still
+  preserving the patient's state at the start of each stint.
+- `OBJECT_CONSTRUCT_KEEP_NULL` is used so null-valued fields are retained
+  in the JSON (distinguishing "null at entry" from "field absent").
+
+Snapshot (see docs/snapshots-guide.md):
+- `strategy: check` with selective `check_cols` on `area_code` only; the
+  patient is identified by `unique_key: patient_id`. Inclusion and removal
+  are tracked when the row appears or disappears from this view
+  (`hard_deletes: invalidate`). `attributes_json` is not in `check_cols`, so
+  it is captured when a new stint opens and does not reopen a stint when
+  only attributes drift.
+- `table_refresh_date` is the project convention for the optional `updated_at`
+  column used alongside the check strategy.
+
+Downstream:
+- `snapshots/cltcs_cohort_membership_snapshot.yml`
+*/
+
+select
+      patient_id
+    , area_code
+    , re_id_key
+    , object_construct_keep_null(
+          * exclude (patient_id, area_code, re_id_key)
+      ) as attributes_json
+    , current_timestamp()::timestamp_ntz as table_refresh_date
+from {{ ref('cltcs_cohort_data') }}

--- a/models/published/direct_care/C_LTCS/cltcs_cohort_membership.yml
+++ b/models/published/direct_care/C_LTCS/cltcs_cohort_membership.yml
@@ -1,0 +1,52 @@
+version: 2
+
+models:
+  - name: cltcs_cohort_membership
+    description: >
+      Membership-collapsed view of `cltcs_cohort_data` that feeds
+      `cltcs_cohort_membership_snapshot`. One row per patient_id with the
+      patient's current area_code and a VARIANT (`attributes_json`) holding
+      the wide cohort attributes via OBJECT_CONSTRUCT_KEEP_NULL. The snapshot
+      uses a check strategy on `area_code` only and invalidates hard deletes;
+      see docs/snapshots-guide.md.
+    config:
+      meta:
+        owner:
+          name: Emily Baldwin
+    columns:
+      - name: patient_id
+        data_type: number
+        description: "Unique patient identifier from commissioning data [sk_patient_id]"
+        data_tests:
+          - unique:
+              config:
+                severity: warn
+                warn_if: ">1"
+          - not_null
+
+      - name: area_code
+        data_type: varchar
+        description: >
+          Area code (Neighbourhood in this context). The only column in the
+          snapshot's `check_cols`: a change ends the current stint and opens a
+          new one. Patient presence in this view is tracked via the snapshot
+          `unique_key` and `hard_deletes: invalidate`.
+
+      - name: re_id_key
+        data_type: varchar
+        description: "Pseudonymised patient identifier (hxflake)."
+
+      - name: attributes_json
+        data_type: variant
+        description: >
+          Wide cohort attributes from `cltcs_cohort_data` collapsed into a
+          single VARIANT via OBJECT_CONSTRUCT_KEEP_NULL, excluding the
+          identifying columns (patient_id, area_code, re_id_key). Null
+          values are preserved. Omitted from the snapshot `check_cols`, so in
+          the snapshot table this VARIANT is frozen at the start of each stint.
+
+      - name: table_refresh_date
+        data_type: timestamp_ntz
+        description: >
+          Build timestamp passed to the snapshot as `updated_at` (project
+          pattern for check-strategy snapshots alongside selective `check_cols`).

--- a/snapshots/cltcs_cohort_membership_snapshot.yml
+++ b/snapshots/cltcs_cohort_membership_snapshot.yml
@@ -1,0 +1,34 @@
+snapshots:
+  - name: cltcs_cohort_membership_snapshot
+    relation: ref('cltcs_cohort_membership')
+    description: >
+      SCD2 history of C-LTCS cohort membership (see docs/snapshots-guide.md).
+      One row per stint per patient: `unique_key` is `patient_id`. A new stint
+      opens when `area_code` changes (`check_cols` is selective — only
+      `area_code`, not metadata that changes every run). Rows removed from
+      `cltcs_cohort_membership` are closed via `hard_deletes: invalidate`
+      (`dbt_valid_to` set). Re-entry after exit opens a new row.
+
+      `dbt_valid_from` / `dbt_valid_to` are the snapshot validity window for
+      each version. `attributes_json` is not in `check_cols`, so it reflects
+      cohort attributes as at the start of that stint (wide fields collapsed
+      in the membership view).
+
+    config:
+      strategy: check
+      unique_key: [patient_id]
+      updated_at: table_refresh_date
+      hard_deletes: invalidate
+      check_cols:
+        - area_code
+
+    columns:
+      - name: patient_id
+        description: "Unique patient identifier; snapshot unique_key."
+        data_tests:
+          - not_null
+
+      - name: dbt_valid_from
+        description: "When this snapshot version became active (SCD2)."
+        data_tests:
+          - not_null


### PR DESCRIPTION
Moving to DBT snapshot for SCD2 of cohort as natively supported and automation pipeline established. All data nested within JSON as is highly volatile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced LTCS cohort membership dataset with automated historical change tracking, capturing membership status updates and area code assignments.

## Tests
* Established comprehensive data quality validation framework including uniqueness tests for patient records, mandatory field constraints, and change detection auditing to ensure data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->