### PR TITLE
fix(schedule): drop daily tag from raw layer

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -56,7 +56,11 @@ models:
       +materialized: view
       +database: "STAGING"
       +schema: "DBT_RAW"
-      +tags: ["raw", "daily"]
+      # No 'daily' tag: raw views build as ancestors of the staging/daily models
+      # that ref them (+tag:daily pulls them in). Tagging all ~660 raw views
+      # 'daily' fired every view at once, exhausting the connection pool inside
+      # EXECUTE DBT PROJECT (Fusion ignores threads).
+      +tags: ["raw"]
       +post-hook: ["{{ add_model_comment() }}"]
 
     # Staging layer - cleaned and standardised source data

--- a/docs/archive/materialisation-guide.md
+++ b/docs/archive/materialisation-guide.md
@@ -393,9 +393,11 @@ The production build schedule affects how materialisations behave:
 | When | What runs | Effect on materialisations |
 |------|-----------|---------------------------|
 | **Daily** | `dbt snapshot` | All snapshots capture changes |
-| **Daily** | `dbt build -s +tag:daily` | Daily-tagged models and their upstream dependencies build; incremental models process only new data |
-| **Monday** | Full project build | All models rebuild; incremental models process only new data |
-| **1st of month** | Full project build with `--full-refresh` | All tables rebuilt from scratch, including incremental models |
+| **Daily** | `dbt build -s +tag:daily` | Daily-tagged models (staging + daily-tagged downstream tables) and their upstream dependencies build; incremental models process only new data |
+| **Monday** | `dbt build -s +staging+` | Staging, its raw ancestors, and everything downstream rebuild; incremental models process only new data |
+| **1st of month** | `dbt build -s +staging+ --full-refresh` | Same scope, but all tables rebuilt from scratch, including incremental models |
+
+Raw is not tagged `daily`; each schedule rebuilds only the raw views consumed by the staging models in scope (~166 of ~660), not every raw view. Raw views reflect live source on query and otherwise rebuild on deploy when their DDL changes. Models outside the staging lineage (`int_date_spine`, `def_indicator*`) build daily or on deploy, not on the Monday/monthly schedules.
 
 ### What This Means for You
 

--- a/docs/archive/snapshots-guide.md
+++ b/docs/archive/snapshots-guide.md
@@ -211,8 +211,8 @@ Snapshots run as part of the production build schedule:
 |------|-----------|
 | **Daily** | `dbt snapshot` — all snapshots capture changes |
 | **Daily** | `dbt build -s +tag:daily` — daily-tagged models and their upstream dependencies build |
-| **Monday** | Full project build — all models rebuild |
-| **1st of month** | Full project build with `--full-refresh` — all tables rebuilt from scratch |
+| **Monday** | `dbt build -s +staging+` — staging, its raw ancestors, and all downstream rebuild |
+| **1st of month** | `dbt build -s +staging+ --full-refresh` — same scope, all tables rebuilt from scratch |
 
 Snapshots always run before the main model build so that downstream models can reference the latest snapshot data.
 


### PR DESCRIPTION
## Problem

Daily/weekly/monthly builds error in Snowflake because too many models fire at once. `raw` and `staging` were both tagged `daily`, so the daily task (`dbt build -s +tag:daily`) rebuilt **all ~660 raw views** every run. dbt Fusion ignores `--threads` inside `EXECUTE DBT PROJECT`, so the concurrent `CREATE OR REPLACE VIEW` statements exhaust Snowflake's connection pool.

Staging only references **166 of the 660 raw views**; the other ~495 are orphans in the dbt graph (no model refs them). Raw views reflect live source on query and only need rebuilding on DDL change (handled at deploy).

## Change

Remove `daily` from the raw layer tag. `+tag:daily` now pulls in only the raw views needed as ancestors of the daily-tagged staging/downstream models.

Verified with `dbt ls --select +tag:daily`:

| | before | after |
|---|---|---|
| total models | 934 | 440 |
| raw views | 660 | 166 |
| non-raw models dropped | — | 0 |

All daily-refresh downstream tables (demographics, disease registers, `person_month_analysis_base`) are retained.

## Related

The Snowflake `Weekly build` / `Monthly full refresh` tasks were switched to `--select +staging+` (same rationale — avoid firing all 660 raw on the full build). Applied live and committed to `Snowflake-Deployment` separately. Docs schedule tables updated here to match.

## Rollout

Takes effect once merged to `main` and the dbt project gets a new version (the refresh root task runs `ADD VERSION` on SHA change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build schedule guidance to use narrower, staging-focused selections for Monday and monthly runs.
  * Clarified that raw models are no longer part of the daily tagging set, and that rebuilds now follow the staging lineage more selectively.
  * Added notes explaining the expected rebuild behaviour for live-source changes, deploy-time updates, and full-refresh runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->