### PR TITLE
feat(tirzepatide): GLP-1 eligibility cohort models

### DIFF
--- a/models/modelling/olids/diagnoses/int_dyslipidaemia_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/int_dyslipidaemia_diagnoses_all.sql
@@ -31,6 +31,6 @@ SELECT
     TRUE AS is_diagnosis_code,
     'Dyslipidaemia Diagnosis' AS dyslipidaemia_observation_type
 
-FROM ({{ get_observations("'DYSLIPIDAEMIA_COD'", source='ECL_CACHE', include_history=true) }}) obs
+FROM ({{ get_observations("'DYSLIPIDAEMIA_COD'", source='ECL_CACHE') }}) obs
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/int_dyslipidaemia_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/int_dyslipidaemia_diagnoses_all.sql
@@ -1,0 +1,36 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All dyslipidaemia diagnosis observations from clinical records.
+Uses the terminology-managed DYSLIPIDAEMIA_COD cluster, defined against the
+SNOMED hierarchy << 48286001 |Disorder of lipoprotein and/or lipid metabolism|
+(broad net: includes hyperlipidaemia and hypercholesterolaemia, which sit under
+48286001 but not under the narrower 370992007 |Dyslipidaemia|).
+
+Clinical Purpose:
+- Dyslipidaemia comorbidity identification (e.g. tirzepatide eligibility)
+- Cardiovascular risk assessment support
+
+Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
+This is OBSERVATION-LEVEL data - one row per diagnosis observation.
+*/
+
+SELECT
+    obs.id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS concept_display,
+    obs.cluster_id AS source_cluster_id,
+    obs.patient_id,
+
+    TRUE AS is_diagnosis_code,
+    'Dyslipidaemia Diagnosis' AS dyslipidaemia_observation_type
+
+FROM ({{ get_observations("'DYSLIPIDAEMIA_COD'", source='ECL_CACHE', include_history=true) }}) obs
+
+ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/int_dyslipidaemia_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_dyslipidaemia_diagnoses_all.yml
@@ -1,0 +1,45 @@
+models:
+  - name: int_dyslipidaemia_diagnoses_all
+    description: 'Dyslipidaemia diagnosis observations for cardiovascular risk and
+      comorbidity identification.
+
+      Key Features:
+
+      • Uses the terminology-managed DYSLIPIDAEMIA_COD cluster (<< 48286001
+      |Disorder of lipoprotein and/or lipid metabolism|)
+
+      • Broad definition captures hyperlipidaemia and hypercholesterolaemia
+
+      • Includes retired SNOMED predecessors via SCT history expansion
+
+      Purpose: Provide observation-level dyslipidaemia diagnosis data for
+      downstream cohort and register models.'
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: id
+    columns:
+      - name: id
+        description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: 'Unique identifier for the person'
+      - name: clinical_effective_date
+        description: 'Date when the dyslipidaemia observation was recorded'
+      - name: concept_code
+        description: 'SNOMED concept code for the dyslipidaemia diagnosis'
+      - name: concept_display
+        description: 'Human-readable description of the dyslipidaemia diagnosis'
+      - name: source_cluster_id
+        description: 'Source cluster identifier, expected to be DYSLIPIDAEMIA_COD'
+      - name: patient_id
+        description: 'Patient identifier from source system'
+      - name: is_diagnosis_code
+        description: 'Boolean flag indicating diagnosis code (always TRUE for these observations)'
+      - name: dyslipidaemia_observation_type
+        description: 'Type of diagnosis observation'

--- a/models/modelling/olids/diagnoses/int_dyslipidaemia_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_dyslipidaemia_diagnoses_all.yml
@@ -10,8 +10,6 @@ models:
 
       • Broad definition captures hyperlipidaemia and hypercholesterolaemia
 
-      • Includes retired SNOMED predecessors via SCT history expansion
-
       Purpose: Provide observation-level dyslipidaemia diagnosis data for
       downstream cohort and register models.'
     config:

--- a/models/modelling/olids/diagnoses/int_obstructive_sleep_apnoea_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/int_obstructive_sleep_apnoea_diagnoses_all.sql
@@ -1,0 +1,34 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id', 'clinical_effective_date'])
+}}
+
+/*
+All obstructive sleep apnoea (OSA) diagnosis observations from clinical records.
+Uses the terminology-managed OBSTRUCTIVE_SLEEP_APNOEA_COD cluster, defined against
+the SNOMED hierarchy << 78275009 |Obstructive sleep apnoea syndrome| (top-level
+concept and all descendants).
+
+Clinical Purpose:
+- OSA comorbidity identification (e.g. tirzepatide eligibility)
+
+Includes ALL persons (active, inactive, deceased) following intermediate layer principles.
+This is OBSERVATION-LEVEL data - one row per diagnosis observation.
+*/
+
+SELECT
+    obs.id,
+    obs.person_id,
+    obs.clinical_effective_date,
+    obs.mapped_concept_code AS concept_code,
+    obs.mapped_concept_display AS concept_display,
+    obs.cluster_id AS source_cluster_id,
+    obs.patient_id,
+
+    TRUE AS is_diagnosis_code,
+    'Obstructive Sleep Apnoea Diagnosis' AS osa_observation_type
+
+FROM ({{ get_observations("'OBSTRUCTIVE_SLEEP_APNOEA_COD'", source='ECL_CACHE', include_history=true) }}) obs
+
+ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/int_obstructive_sleep_apnoea_diagnoses_all.sql
+++ b/models/modelling/olids/diagnoses/int_obstructive_sleep_apnoea_diagnoses_all.sql
@@ -29,6 +29,6 @@ SELECT
     TRUE AS is_diagnosis_code,
     'Obstructive Sleep Apnoea Diagnosis' AS osa_observation_type
 
-FROM ({{ get_observations("'OBSTRUCTIVE_SLEEP_APNOEA_COD'", source='ECL_CACHE', include_history=true) }}) obs
+FROM ({{ get_observations("'OBSTRUCTIVE_SLEEP_APNOEA_COD'", source='ECL_CACHE') }}) obs
 
 ORDER BY person_id, clinical_effective_date, id

--- a/models/modelling/olids/diagnoses/int_obstructive_sleep_apnoea_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_obstructive_sleep_apnoea_diagnoses_all.yml
@@ -1,0 +1,43 @@
+models:
+  - name: int_obstructive_sleep_apnoea_diagnoses_all
+    description: 'Obstructive sleep apnoea (OSA) diagnosis observations for
+      comorbidity identification.
+
+      Key Features:
+
+      • Uses the terminology-managed OBSTRUCTIVE_SLEEP_APNOEA_COD cluster
+      (<< 78275009 |Obstructive sleep apnoea syndrome|)
+
+      • Includes retired SNOMED predecessors via SCT history expansion
+
+      Purpose: Provide observation-level OSA diagnosis data for downstream cohort
+      and register models.'
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: id
+    columns:
+      - name: id
+        description: 'Unique identifier for the clinical observation'
+        tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: 'Unique identifier for the person'
+      - name: clinical_effective_date
+        description: 'Date when the OSA observation was recorded'
+      - name: concept_code
+        description: 'SNOMED concept code for the OSA diagnosis'
+      - name: concept_display
+        description: 'Human-readable description of the OSA diagnosis'
+      - name: source_cluster_id
+        description: 'Source cluster identifier, expected to be OBSTRUCTIVE_SLEEP_APNOEA_COD'
+      - name: patient_id
+        description: 'Patient identifier from source system'
+      - name: is_diagnosis_code
+        description: 'Boolean flag indicating diagnosis code (always TRUE for these observations)'
+      - name: osa_observation_type
+        description: 'Type of diagnosis observation'

--- a/models/modelling/olids/diagnoses/int_obstructive_sleep_apnoea_diagnoses_all.yml
+++ b/models/modelling/olids/diagnoses/int_obstructive_sleep_apnoea_diagnoses_all.yml
@@ -8,8 +8,6 @@ models:
       • Uses the terminology-managed OBSTRUCTIVE_SLEEP_APNOEA_COD cluster
       (<< 78275009 |Obstructive sleep apnoea syndrome|)
 
-      • Includes retired SNOMED predecessors via SCT history expansion
-
       Purpose: Provide observation-level OSA diagnosis data for downstream cohort
       and register models.'
     config:

--- a/models/modelling/olids/programme/tirzepatide/int_tirzepatide_eligible_population.sql
+++ b/models/modelling/olids/programme/tirzepatide/int_tirzepatide_eligible_population.sql
@@ -1,0 +1,181 @@
+{{
+    config(
+        materialized='table',
+        tags=['intermediate', 'programme', 'tirzepatide'],
+        cluster_by=['person_id'])
+}}
+
+/*
+Tirzepatide (GLP-1 for obesity) eligibility population.
+
+Composes the eligibility criteria for the NCL/WNL tirzepatide rollout from
+existing registers, the two new comorbidity clusters, and ethnicity-adjusted BMI.
+
+Eligibility (both cohorts): >= 4 of 5 qualifying comorbidities
+  1. Hypertension                 - fct_person_hypertension_register
+  2. Dyslipidaemia                - int_dyslipidaemia_diagnoses_all (DYSLIPIDAEMIA_COD)
+  3. Obstructive sleep apnoea     - int_obstructive_sleep_apnoea_diagnoses_all (OBSTRUCTIVE_SLEEP_APNOEA_COD)
+  4. Cardiovascular disease       - any of AF / CHD / heart failure / PAD / stroke-TIA registers
+                                    (hypertension is excluded here - it counts separately above
+                                     to avoid double-counting, per the qualifying-comorbidity list)
+  5. Type 2 diabetes mellitus     - fct_person_diabetes_register (diabetes_type = 'Type 2')
+
+BMI band (ethnicity-adjusted via int_bmi_latest, NICE NG246 thresholds):
+  - Cohort 1 (Year 1, 2025/26): BMI >= 40   -> Obese Class III
+  - Cohort 2 (Year 2, 2026/27): BMI 35-39.9 -> Obese Class II
+  The -2.5 adjustment for South Asian, Chinese, other Asian, Middle Eastern,
+  Black African and African-Caribbean groups is already baked into bmi_category.
+
+Spine: currently-registered, living adults whose latest valid BMI is in an
+eligible band (Class II or III). No eligible person can sit below Class II, so
+this narrowing is lossless and keeps the model lean. Comorbidity flags and the
+cohort eligibility flags are layered on top. Filter is_eligible_any downstream.
+*/
+
+WITH base_population AS (
+    -- Currently-registered, living adults (registers don't enforce registration,
+    -- so the spine does)
+    SELECT
+        prac.person_id,
+        age.age
+    FROM {{ ref('dim_person_current_practice') }} AS prac
+    INNER JOIN {{ ref('dim_person_age') }} AS age
+        ON prac.person_id = age.person_id
+    WHERE prac.registration_end_date IS NULL
+      AND COALESCE(age.is_deceased, FALSE) = FALSE
+      AND age.age >= 18
+),
+
+-- BMI gate: latest valid BMI in an eligible band (ethnicity-adjusted)
+bmi AS (
+    SELECT
+        person_id,
+        bmi_value AS latest_bmi_value,
+        clinical_effective_date AS latest_bmi_date,
+        bmi_category,
+        requires_lower_bmi_thresholds,
+        cardiometabolic_risk_ethnicity_group
+    FROM {{ ref('int_bmi_latest') }}
+    WHERE bmi_category IN ('Obese Class II', 'Obese Class III')
+),
+
+-- Qualifying comorbidity 1: hypertension
+hypertension AS (
+    SELECT DISTINCT person_id FROM {{ ref('fct_person_hypertension_register') }}
+),
+
+-- Qualifying comorbidity 2: dyslipidaemia (any diagnosis observation)
+dyslipidaemia AS (
+    SELECT DISTINCT person_id FROM {{ ref('int_dyslipidaemia_diagnoses_all') }}
+),
+
+-- Qualifying comorbidity 3: obstructive sleep apnoea (any diagnosis observation)
+osa AS (
+    SELECT DISTINCT person_id FROM {{ ref('int_obstructive_sleep_apnoea_diagnoses_all') }}
+),
+
+-- Qualifying comorbidity 4: cardiovascular disease (excludes hypertension)
+cvd AS (
+    SELECT person_id FROM {{ ref('fct_person_atrial_fibrillation_register') }}
+    UNION
+    SELECT person_id FROM {{ ref('fct_person_chd_register') }}
+    UNION
+    SELECT person_id FROM {{ ref('fct_person_heart_failure_register') }}
+    UNION
+    SELECT person_id FROM {{ ref('fct_person_pad_register') }}
+    UNION
+    SELECT person_id FROM {{ ref('fct_person_stroke_tia_register') }}
+),
+
+-- Qualifying comorbidity 5: type 2 diabetes
+type2_diabetes AS (
+    SELECT DISTINCT person_id
+    FROM {{ ref('fct_person_diabetes_register') }}
+    WHERE diabetes_type = 'Type 2'
+),
+
+flags AS (
+    SELECT
+        bp.person_id,
+        bp.age,
+        bmi.latest_bmi_value,
+        bmi.latest_bmi_date,
+        bmi.bmi_category,
+        bmi.requires_lower_bmi_thresholds,
+        bmi.cardiometabolic_risk_ethnicity_group,
+
+        (htn.person_id IS NOT NULL) AS has_hypertension,
+        (dys.person_id IS NOT NULL) AS has_dyslipidaemia,
+        (osa.person_id IS NOT NULL) AS has_obstructive_sleep_apnoea,
+        (cvd.person_id IS NOT NULL) AS has_cardiovascular_disease,
+        (t2dm.person_id IS NOT NULL) AS has_type2_diabetes
+    FROM base_population AS bp
+    INNER JOIN bmi ON bp.person_id = bmi.person_id
+    LEFT JOIN hypertension AS htn ON bp.person_id = htn.person_id
+    LEFT JOIN dyslipidaemia AS dys ON bp.person_id = dys.person_id
+    LEFT JOIN osa ON bp.person_id = osa.person_id
+    LEFT JOIN cvd ON bp.person_id = cvd.person_id
+    LEFT JOIN type2_diabetes AS t2dm ON bp.person_id = t2dm.person_id
+)
+
+SELECT
+    person_id,
+    age,
+
+    -- BMI
+    latest_bmi_value,
+    latest_bmi_date,
+    bmi_category,
+    requires_lower_bmi_thresholds,
+    cardiometabolic_risk_ethnicity_group,
+
+    -- Qualifying comorbidities
+    has_hypertension,
+    has_dyslipidaemia,
+    has_obstructive_sleep_apnoea,
+    has_cardiovascular_disease,
+    has_type2_diabetes,
+    (
+        has_hypertension::INT
+        + has_dyslipidaemia::INT
+        + has_obstructive_sleep_apnoea::INT
+        + has_cardiovascular_disease::INT
+        + has_type2_diabetes::INT
+    ) AS qualifying_comorbidity_count,
+
+    -- Cohort BMI bands
+    (bmi_category = 'Obese Class III') AS bmi_meets_cohort_1,
+    (bmi_category = 'Obese Class II') AS bmi_meets_cohort_2,
+
+    -- Eligibility: >= 4 qualifying comorbidities + cohort BMI band
+    (
+        (
+            has_hypertension::INT
+            + has_dyslipidaemia::INT
+            + has_obstructive_sleep_apnoea::INT
+            + has_cardiovascular_disease::INT
+            + has_type2_diabetes::INT
+        ) >= 4
+        AND bmi_category = 'Obese Class III'
+    ) AS is_eligible_cohort_1,
+    (
+        (
+            has_hypertension::INT
+            + has_dyslipidaemia::INT
+            + has_obstructive_sleep_apnoea::INT
+            + has_cardiovascular_disease::INT
+            + has_type2_diabetes::INT
+        ) >= 4
+        AND bmi_category = 'Obese Class II'
+    ) AS is_eligible_cohort_2,
+    (
+        (
+            has_hypertension::INT
+            + has_dyslipidaemia::INT
+            + has_obstructive_sleep_apnoea::INT
+            + has_cardiovascular_disease::INT
+            + has_type2_diabetes::INT
+        ) >= 4
+        AND bmi_category IN ('Obese Class II', 'Obese Class III')
+    ) AS is_eligible_any
+FROM flags

--- a/models/modelling/olids/programme/tirzepatide/int_tirzepatide_eligible_population.yml
+++ b/models/modelling/olids/programme/tirzepatide/int_tirzepatide_eligible_population.yml
@@ -1,0 +1,68 @@
+models:
+  - name: int_tirzepatide_eligible_population
+    description: 'Tirzepatide (GLP-1 for obesity) eligibility population.
+
+      Composes the rollout criteria from existing registers, the two new
+      comorbidity clusters (DYSLIPIDAEMIA_COD, OBSTRUCTIVE_SLEEP_APNOEA_COD) and
+      ethnicity-adjusted BMI.
+
+      Eligibility (both cohorts): >= 4 of 5 qualifying comorbidities
+      (hypertension, dyslipidaemia, obstructive sleep apnoea, cardiovascular
+      disease, type 2 diabetes). CVD excludes hypertension to avoid
+      double-counting. BMI band sets the cohort: Cohort 1 = Obese Class III
+      (>= 40), Cohort 2 = Obese Class II (35-39.9), both ethnicity-adjusted.
+
+      Grain: one row per currently-registered, living adult whose latest valid
+      BMI is in an eligible band (Class II or III). Filter is_eligible_any
+      downstream for the actionable cohort.'
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+    columns:
+      - name: person_id
+        description: 'Unique identifier for the person'
+        tests:
+          - unique
+          - not_null
+      - name: age
+        description: 'Current age in years (>= 18)'
+      - name: latest_bmi_value
+        description: 'Latest valid BMI measurement'
+      - name: latest_bmi_date
+        description: 'Date of the latest valid BMI measurement'
+      - name: bmi_category
+        description: 'Ethnicity-adjusted BMI category (Obese Class II or Obese Class III)'
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['Obese Class II', 'Obese Class III']
+      - name: requires_lower_bmi_thresholds
+        description: 'TRUE where the -2.5 ethnicity BMI adjustment applies'
+      - name: cardiometabolic_risk_ethnicity_group
+        description: 'Ethnicity group used for the BMI threshold adjustment'
+      - name: has_hypertension
+        description: 'On hypertension register'
+      - name: has_dyslipidaemia
+        description: 'Has a dyslipidaemia diagnosis (DYSLIPIDAEMIA_COD)'
+      - name: has_obstructive_sleep_apnoea
+        description: 'Has an OSA diagnosis (OBSTRUCTIVE_SLEEP_APNOEA_COD)'
+      - name: has_cardiovascular_disease
+        description: 'On any of AF / CHD / heart failure / PAD / stroke-TIA registers (hypertension excluded)'
+      - name: has_type2_diabetes
+        description: 'On diabetes register with type 2 classification'
+      - name: qualifying_comorbidity_count
+        description: 'Count of qualifying comorbidities present (0-5)'
+      - name: bmi_meets_cohort_1
+        description: 'BMI in Cohort 1 band (Obese Class III, >= 40 ethnicity-adjusted)'
+      - name: bmi_meets_cohort_2
+        description: 'BMI in Cohort 2 band (Obese Class II, 35-39.9 ethnicity-adjusted)'
+      - name: is_eligible_cohort_1
+        description: '>= 4 qualifying comorbidities and Cohort 1 BMI band'
+      - name: is_eligible_cohort_2
+        description: '>= 4 qualifying comorbidities and Cohort 2 BMI band'
+      - name: is_eligible_any
+        description: 'Eligible for either cohort'

--- a/models/reporting/olids/programme/tirzepatide/fct_tirzepatide_cohort_status.sql
+++ b/models/reporting/olids/programme/tirzepatide/fct_tirzepatide_cohort_status.sql
@@ -1,0 +1,141 @@
+{{ config(
+    materialized='table',
+    tags=['fact', 'programme', 'tirzepatide', 'powerbi'],
+    cluster_by=['person_id', 'practice_code']) }}
+
+/*
+Tirzepatide cohort status fact table (person-level, PowerBI-ready).
+
+Combines the eligibility population (int_tirzepatide_eligible_population) with
+current GLP-1 prescribing (int_glp1_medications_all) and demographic / practice
+context, so practices can identify patients eligible for tirzepatide and see
+whether they are already on a GLP-1 (and for which likely indication).
+
+Grain: one row per currently-registered, living, eligible person
+(is_eligible_any = TRUE in the population model).
+*/
+
+WITH eligible AS (
+    SELECT *
+    FROM {{ ref('int_tirzepatide_eligible_population') }}
+    WHERE is_eligible_any = TRUE
+),
+
+-- Collapse order-level GLP-1 prescribing to one row per person
+glp1_orders AS (
+    SELECT
+        person_id,
+        order_date,
+        glp1_drug,
+        is_dual_gip_glp1,
+        is_diabetes_indication,
+        is_recent_6m,
+        rolling_order_count_12m
+    FROM {{ ref('int_glp1_medications_all') }}
+),
+
+-- Person-level prescribing summary (BOOLOR_AGG: Snowflake MAX rejects booleans)
+glp1_agg AS (
+    SELECT
+        person_id,
+        BOOLOR_AGG(is_dual_gip_glp1) AS ever_on_tirzepatide,
+        MAX(order_date) AS latest_glp1_order_date,
+        BOOLOR_AGG(is_recent_6m) AS is_currently_treated_glp1,
+        MAX(rolling_order_count_12m) AS glp1_orders_12m
+    FROM glp1_orders
+    GROUP BY person_id
+),
+
+-- Attributes of the most recent order (drug, likely indication)
+glp1_latest AS (
+    SELECT
+        person_id,
+        glp1_drug AS latest_glp1_drug,
+        is_dual_gip_glp1 AS latest_order_is_tirzepatide,
+        CASE WHEN is_diabetes_indication THEN 'Diabetes' ELSE 'Obesity' END AS latest_glp1_indication
+    FROM glp1_orders
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY order_date DESC) = 1
+),
+
+glp1_person AS (
+    SELECT
+        a.person_id,
+        TRUE AS ever_on_glp1,
+        a.ever_on_tirzepatide,
+        a.latest_glp1_order_date,
+        a.is_currently_treated_glp1,
+        a.glp1_orders_12m,
+        l.latest_glp1_drug,
+        l.latest_order_is_tirzepatide,
+        l.latest_glp1_indication
+    FROM glp1_agg AS a
+    INNER JOIN glp1_latest AS l ON a.person_id = l.person_id
+)
+
+SELECT
+    -- Core identifiers
+    elig.person_id,
+    demo.sk_patient_id,
+
+    -- Practice context
+    prac.practice_code,
+    prac.practice_name,
+    demo.pcn_code,
+    demo.pcn_name,
+    demo.borough_registered,
+    demo.neighbourhood_registered,
+
+    -- Demographics
+    elig.age,
+    demo.gender,
+    demo.age_band_nhs,
+    demo.ethnicity_category,
+    demo.imd_quintile_19,
+
+    -- Eligibility: cohort assignment
+    elig.is_eligible_cohort_1,
+    elig.is_eligible_cohort_2,
+    CASE
+        WHEN elig.is_eligible_cohort_1 THEN 'Cohort 1 (BMI >= 40)'
+        WHEN elig.is_eligible_cohort_2 THEN 'Cohort 2 (BMI 35-39.9)'
+    END AS cohort,
+
+    -- BMI
+    elig.latest_bmi_value,
+    elig.latest_bmi_date,
+    elig.bmi_category,
+    elig.requires_lower_bmi_thresholds,
+    elig.cardiometabolic_risk_ethnicity_group,
+
+    -- Qualifying comorbidities
+    elig.has_hypertension,
+    elig.has_dyslipidaemia,
+    elig.has_obstructive_sleep_apnoea,
+    elig.has_cardiovascular_disease,
+    elig.has_type2_diabetes,
+    elig.qualifying_comorbidity_count,
+
+    -- GLP-1 prescribing status
+    COALESCE(glp1.ever_on_glp1, FALSE) AS ever_on_glp1,
+    COALESCE(glp1.ever_on_tirzepatide, FALSE) AS ever_on_tirzepatide,
+    COALESCE(glp1.is_currently_treated_glp1, FALSE) AS is_currently_treated_glp1,
+    glp1.latest_glp1_drug,
+    glp1.latest_glp1_indication,
+    glp1.latest_glp1_order_date,
+    glp1.glp1_orders_12m,
+
+    -- Actionable = eligible but not currently on any GLP-1
+    NOT COALESCE(glp1.is_currently_treated_glp1, FALSE) AS is_actionable,
+
+    -- Metadata
+    CURRENT_DATE() AS data_refresh_date
+
+FROM eligible AS elig
+INNER JOIN {{ ref('dim_person_demographics') }} AS demo
+    ON elig.person_id = demo.person_id
+INNER JOIN {{ ref('dim_person_current_practice') }} AS prac
+    ON elig.person_id = prac.person_id
+LEFT JOIN glp1_person AS glp1
+    ON elig.person_id = glp1.person_id
+WHERE prac.registration_end_date IS NULL  -- Current registrations only
+ORDER BY elig.qualifying_comorbidity_count DESC, elig.person_id

--- a/models/reporting/olids/programme/tirzepatide/fct_tirzepatide_cohort_status.yml
+++ b/models/reporting/olids/programme/tirzepatide/fct_tirzepatide_cohort_status.yml
@@ -1,0 +1,97 @@
+models:
+  - name: fct_tirzepatide_cohort_status
+    description: 'Person-level tirzepatide cohort status for the NCL/WNL GLP-1
+      obesity rollout.
+
+      Combines the eligibility population (int_tirzepatide_eligible_population)
+      with current GLP-1 prescribing (int_glp1_medications_all) and demographic /
+      practice context, so practices can identify eligible patients and see
+      whether they are already on a GLP-1 and for which likely indication.
+
+      Grain: one row per currently-registered, living, eligible person. Cohort 1
+      = Obese Class III (BMI >= 40); Cohort 2 = Obese Class II (BMI 35-39.9), both
+      ethnicity-adjusted. is_actionable flags eligible patients not currently on
+      any GLP-1.'
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.at_least_one:
+          column_name: person_id
+    columns:
+      - name: person_id
+        description: 'Unique identifier for the person'
+        tests:
+          - unique
+          - not_null
+      - name: sk_patient_id
+        description: 'Surrogate patient identifier'
+      - name: practice_code
+        description: 'Registered practice ODS code'
+      - name: practice_name
+        description: 'Registered practice name'
+      - name: pcn_code
+        description: 'Primary care network code'
+      - name: pcn_name
+        description: 'Primary care network name'
+      - name: borough_registered
+        description: 'Borough of registered practice'
+      - name: neighbourhood_registered
+        description: 'Neighbourhood of registered practice'
+      - name: age
+        description: 'Current age in years'
+      - name: gender
+        description: 'Gender'
+      - name: age_band_nhs
+        description: 'NHS age band'
+      - name: ethnicity_category
+        description: 'High-level ethnicity category'
+      - name: imd_quintile_19
+        description: 'IMD 2019 deprivation quintile'
+      - name: is_eligible_cohort_1
+        description: '>= 4 qualifying comorbidities and BMI Obese Class III (>= 40)'
+      - name: is_eligible_cohort_2
+        description: '>= 4 qualifying comorbidities and BMI Obese Class II (35-39.9)'
+      - name: cohort
+        description: 'Cohort label (Cohort 1 or Cohort 2)'
+      - name: latest_bmi_value
+        description: 'Latest valid BMI measurement'
+      - name: latest_bmi_date
+        description: 'Date of the latest valid BMI measurement'
+      - name: bmi_category
+        description: 'Ethnicity-adjusted BMI category'
+      - name: requires_lower_bmi_thresholds
+        description: 'TRUE where the -2.5 ethnicity BMI adjustment applies'
+      - name: cardiometabolic_risk_ethnicity_group
+        description: 'Ethnicity group used for the BMI threshold adjustment'
+      - name: has_hypertension
+        description: 'On hypertension register'
+      - name: has_dyslipidaemia
+        description: 'Has a dyslipidaemia diagnosis'
+      - name: has_obstructive_sleep_apnoea
+        description: 'Has an OSA diagnosis'
+      - name: has_cardiovascular_disease
+        description: 'On any of AF / CHD / heart failure / PAD / stroke-TIA registers'
+      - name: has_type2_diabetes
+        description: 'On diabetes register with type 2 classification'
+      - name: qualifying_comorbidity_count
+        description: 'Count of qualifying comorbidities present (4 or 5 for eligible persons)'
+      - name: ever_on_glp1
+        description: 'Has any GLP-1 receptor agonist order on record'
+      - name: ever_on_tirzepatide
+        description: 'Has any tirzepatide (dual GIP/GLP-1) order on record'
+      - name: is_currently_treated_glp1
+        description: 'Has a GLP-1 order in the last 6 months'
+      - name: latest_glp1_drug
+        description: 'Active ingredient of the most recent GLP-1 order'
+      - name: latest_glp1_indication
+        description: 'Likely indication of the most recent GLP-1 order (Diabetes vs Obesity, from BNF)'
+      - name: latest_glp1_order_date
+        description: 'Date of the most recent GLP-1 order'
+      - name: glp1_orders_12m
+        description: 'Rolling count of GLP-1 orders in the last 12 months'
+      - name: is_actionable
+        description: 'Eligible and not currently on any GLP-1 (last 6 months)'
+      - name: data_refresh_date
+        description: 'Build date of this fact table'


### PR DESCRIPTION
## Summary

Adds tirzepatide (GLP-1 for obesity) eligibility cohorts for the NCL/WNL rollout, composed from existing registers, two new SNOMED-hierarchy clusters, and ethnicity-adjusted BMI. Supports identifying patients eligible for Cohort 1/2 and whether they are already on a GLP-1.

Context: request from Simon Landergan / Katie Coleman to give all WNL practices (not just Ardens users) a way to identify GLP-1-eligible patients.

## Models

**New comorbidity diagnosis intermediates** (`diagnoses/`, generic/reusable):
- `int_dyslipidaemia_diagnoses_all` — `DYSLIPIDAEMIA_COD` (290 codes, `<< 48286001 |Disorder of lipoprotein and/or lipid metabolism|` — broad net incl. hyperlipidaemia/hypercholesterolaemia)
- `int_obstructive_sleep_apnoea_diagnoses_all` — `OBSTRUCTIVE_SLEEP_APNOEA_COD` (9 codes, `<< 78275009 |Obstructive sleep apnoea syndrome|`)

**Population intermediate** — `int_tirzepatide_eligible_population`:
- ≥4 of 5 qualifying comorbidities: hypertension, dyslipidaemia, OSA, cardiovascular disease (AF/CHD/HF/PAD/stroke-TIA — **excludes hypertension** to avoid double-counting), type 2 diabetes
- Cohort band from existing ethnicity-adjusted BMI categories: Cohort 1 = Obese Class III (≥40 / ≥37.5 adjusted), Cohort 2 = Obese Class II (35–39.9 / 32.5–37.4 adjusted)
- Spine = currently-registered living adults with latest BMI in Class II/III (lossless narrowing — no eligible person sits below Class II)

**Reporting fact** — `fct_tirzepatide_cohort_status`:
- Cohort + demographics/practice context + current GLP-1/tirzepatide treatment status, likely indication (obesity vs diabetes), and `is_actionable` (eligible, not currently on a GLP-1)

## Validation (DEV)

- 2,083 eligible: **872 Cohort 1**, **1,211 Cohort 2** (mutually exclusive bands, reporting rows match)
- 613 already on a GLP-1 (last 6m), 413 ever on tirzepatide → ~1,470 actionable
- OSA sparsest comorbidity (860/1,836 of the exactly-4 group), consistent with under-coding
- `dbt build` green: 4 models, 13 tests passed

## Decisions to confirm

1. **Type 2 diabetes** restricted to `diabetes_type = 'Type 2'` (excludes "Unknown"-type diabetics) — tightest read of criteria.
2. **Indication split is BNF-derived** — Mounjaro is coded under diabetes (0601) even when prescribed for obesity, so tirzepatide mostly shows as "Diabetes". Labelled "likely indication" in docs.
3. **Folder placement** — generic dyslipidaemia/OSA ints kept in `diagnoses/` (reusable) rather than the programme folder; programme-specific population + reporting models under `programme/tirzepatide/`.
