### PR TITLE
feat(cost): patient-level cost + resource-vs-need models (WNL)

### DIFF
--- a/models/modelling/commissioning/cost/int_person_cost_12m.sql
+++ b/models/modelling/commissioning/cost/int_person_cost_12m.sql
@@ -1,0 +1,19 @@
+-- Per-person patient-attributable spend over the latest 12 months, from
+-- fct_person_cost_by_month (is_patient_attributable rows only). Building block
+-- shared by the age-sex cost curve and the person resource-vs-need fact.
+{{ config(materialized = 'table') }}
+
+with bounds as (
+    select max(activity_month) as max_month
+    from {{ ref('fct_person_cost_by_month') }}
+)
+
+select
+    f.sk_patient_id,
+    sum(f.total_cost) as actual_cost_12m
+from {{ ref('fct_person_cost_by_month') }} as f
+cross join bounds as b
+where f.is_patient_attributable
+  and f.sk_patient_id is not null
+  and f.activity_month >= dateadd(month, -11, b.max_month)
+group by 1

--- a/models/modelling/commissioning/cost/int_person_cost_12m.yml
+++ b/models/modelling/commissioning/cost/int_person_cost_12m.yml
@@ -1,0 +1,21 @@
+version: 2
+models:
+  - name: int_person_cost_12m
+    description: >
+      Per-person patient-attributable spend over the latest 12 months (from
+      fct_person_cost_by_month). One row per sk_patient_id with spend in the
+      window. Shared building block for the resource-vs-need models.
+    config:
+      meta:
+        owner:
+          name: Eddie Davison
+    columns:
+      - name: sk_patient_id
+        description: DMIC pseudonymised NHS number (primary key).
+        data_tests:
+          - not_null
+          - unique
+      - name: actual_cost_12m
+        description: Patient-attributable spend over the latest 12 months (GBP).
+        data_tests:
+          - not_null

--- a/models/modelling/commissioning/cost/int_resource_need_age_sex_curve.sql
+++ b/models/modelling/commissioning/cost/int_resource_need_age_sex_curve.sql
@@ -1,0 +1,33 @@
+-- Empirical WNL age-sex cost curve: expected (average) patient-attributable
+-- cost per head by NHS age band and gender, over the registered WNL population
+-- including non-users (cost 0). These are the "need weights" used for indirect
+-- standardisation in fct_person_resource_need - derived from our own spend, so
+-- stable and reproducible (no external / flaky weighted-list-size feed).
+{{ config(materialized = 'table') }}
+
+with population as (
+    select
+        p.sk_patient_id,
+        p.gender,
+        {{ calculate_age_attributes('p.date_of_birth', 'current_date()') }}
+    from {{ ref('dim_person_demographics_basic') }} as p
+    where p.flag_current_registered
+),
+
+pop_cost as (
+    select
+        population.age_band_nhs as age_band,
+        population.gender,
+        coalesce(c.actual_cost_12m, 0) as actual_cost_12m
+    from population
+    left join {{ ref('int_person_cost_12m') }} as c
+        on population.sk_patient_id = c.sk_patient_id
+)
+
+select
+    age_band,
+    gender,
+    count(*)             as population,
+    avg(actual_cost_12m) as expected_cost_per_head
+from pop_cost
+group by 1, 2

--- a/models/modelling/commissioning/cost/int_resource_need_age_sex_curve.yml
+++ b/models/modelling/commissioning/cost/int_resource_need_age_sex_curve.yml
@@ -1,0 +1,29 @@
+version: 2
+models:
+  - name: int_resource_need_age_sex_curve
+    description: >
+      Empirical WNL age-sex cost curve - average patient-attributable cost per
+      head by NHS age band and gender over the registered WNL population
+      (including non-users). The need weights for indirect standardisation in
+      fct_person_resource_need. One row per age band x gender.
+    config:
+      meta:
+        owner:
+          name: Eddie Davison
+    columns:
+      - name: age_band
+        description: NHS age band (0-4, 5-14, ... 85+, Unknown).
+      - name: gender
+        description: Gender.
+      - name: population
+        description: Registered WNL persons in the band.
+      - name: expected_cost_per_head
+        description: Average 12-month patient-attributable cost per head (GBP).
+        data_tests:
+          - not_null
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - age_band
+              - gender

--- a/models/modelling/commissioning/cost/int_slam_activity_cost.sql
+++ b/models/modelling/commissioning/cost/int_slam_activity_cost.sql
@@ -1,0 +1,111 @@
+/*
+Patient-level SLAM activity & actual cost — the spine of the Aligning
+Resource to Need model.
+
+Grain: sk_patient_id x activity_month x commissioner x provider x
+service hierarchy (service_grouping > service > activity_type) x POD x HRG.
+
+Source: stg_lsplcm_latest (latest-submission LSPLCM PLD — actual provider
+cost dv_total_cost, NOT national tariff). Covers the WNL footprint
+(NCL + NWL merged). Rolling most-recent 12 months by financial period.
+
+Cost basis: SLAM actual cost is the agreed spine over SUS tariff — it is
+real commissioned spend (local prices, CQUIN, top-ups), includes high-cost
+drugs/devices that tariff excludes, and is commissioner-attributed.
+
+POD -> service hierarchy via the slam_pod_service_grouping seed (joined on
+upper-cased POD). is_patient_attributable carries through so per-patient /
+need cuts can exclude block/adjustment/transport lines while provider
+totals keep them.
+
+Period: dv_financial_year 'YYYYYY' + dv_financial_month (1=April..12=March)
+converted to the first of the calendar month. Rows with no parsed financial
+period are dropped (period unknown).
+*/
+
+with base as (
+    select
+        s.sk_patient_id
+        , date_from_parts(
+            left(s.dv_financial_year, 4)::int + iff(s.dv_financial_month >= 10, 1, 0)
+            , mod(s.dv_financial_month + 2, 12) + 1
+            , 1
+          )                                             as activity_month
+        , s.commissioner_code
+        , s.dv_provider_code                            as provider_code
+        -- responsibility (not registration) code is the populated practice
+        -- field in current SLAM: gp_practice_code_registration is ~0%,
+        -- gp_practice_responsibility_code ~98%.
+        , s.gp_practice_responsibility_code             as registered_practice_code
+        , upper(trim(s.point_of_delivery_code))         as pod_code
+        , s.tariff_code                                 as hrg_code
+        , s.age_at_activity_date
+        , s.gender_code
+        , s.ethnic_category
+        , s.lsoa
+        , s.dv_total_cost
+        , s.dv_activity_count
+    from {{ ref('stg_lsplcm_latest') }} as s
+    where s.dv_financial_year is not null
+      and s.dv_financial_month between 1 and 12
+)
+
+-- Anchor the rolling window on the latest month with material volume, not
+-- max(activity_month): a handful of mis-stated rows carry future financial
+-- periods (e.g. 2027-03) that would otherwise shrink the window. Months with
+-- a real submission have ~1.7M rows; junk/partial months have <1k.
+, bounds as (
+    select max(activity_month) as end_month
+    from (
+        select activity_month
+        from base
+        group by activity_month
+        having count(*) > 100000
+    )
+)
+
+, recent as (
+    select b.*
+    from base as b
+    cross join bounds
+    where b.activity_month > dateadd('month', -12, bounds.end_month)
+      and b.activity_month <= bounds.end_month
+)
+
+select
+    r.sk_patient_id
+    , r.activity_month
+    , r.commissioner_code
+    , r.provider_code
+    , r.registered_practice_code
+    -- service hierarchy (POD seed); unmatched -> Other / Unmapped
+    , coalesce(m.service_grouping, 'Unmapped')          as service_grouping
+    , coalesce(m.service, 'Unmapped')                   as service
+    , coalesce(m.activity_type, 'Other')                as activity_type
+    , r.pod_code
+    , r.hrg_code
+    , coalesce(m.is_patient_attributable, false)        as is_patient_attributable
+    -- demographics at event (constant within patient-month; any_value safe)
+    , any_value(r.age_at_activity_date)                 as age_at_activity_date
+    , any_value(r.gender_code)                          as gender_code
+    , any_value(r.ethnic_category)                      as ethnic_category
+    , any_value(r.lsoa)                                 as lsoa
+    -- measures
+    , sum(r.dv_total_cost)                              as total_cost
+    , sum(r.dv_activity_count)                          as total_activity
+    , count(*)                                          as line_count
+from recent as r
+left join {{ ref('slam_pod_service_grouping') }} as m
+    on m.pod_code = r.pod_code
+group by
+    r.sk_patient_id
+    , r.activity_month
+    , r.commissioner_code
+    , r.provider_code
+    , r.registered_practice_code
+    , service_grouping
+    , service
+    , activity_type
+    , r.pod_code
+    , r.hrg_code
+    , is_patient_attributable

--- a/models/modelling/commissioning/cost/int_slam_activity_cost.yml
+++ b/models/modelling/commissioning/cost/int_slam_activity_cost.yml
@@ -1,0 +1,46 @@
+version: 2
+models:
+  - name: int_slam_activity_cost
+    description: |
+      Patient-level SLAM activity & actual cost — spine of the Aligning
+      Resource to Need model. Rolling most-recent 12 months from
+      stg_lsplcm_latest (actual provider cost, WNL = NCL+NWL). Grain:
+      patient x month x commissioner x provider x service hierarchy x POD x
+      HRG. Service hierarchy and is_patient_attributable from the
+      slam_pod_service_grouping seed. Cost in £ (dv_total_cost).
+    config:
+      meta:
+        owner:
+          name: Eddie Davison
+    columns:
+      - name: sk_patient_id
+        description: DMIC pseudonymised NHS number (NULL for unidentified activity).
+      - name: activity_month
+        description: First of the calendar month derived from financial year/month.
+        data_tests:
+          - not_null
+      - name: commissioner_code
+        description: Commissioner ODS code (ICB attribution — NCL 93C, NWL W2U3Z, others out-of-sector).
+      - name: provider_code
+        description: Cleaned provider ODS code.
+      - name: service_grouping
+        description: Top-level grouping (Crisis/Community/Planned/Excluded/Unmapped).
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [Crisis, Community, Planned, Excluded, Unmapped]
+      - name: service
+        description: Mid-level service (Ru's labels).
+      - name: activity_type
+        description: Detail activity type.
+      - name: pod_code
+        description: SLAM point-of-delivery code (upper-cased).
+      - name: hrg_code
+        description: HRG / national tariff currency code (from tariff_code).
+      - name: is_patient_attributable
+        description: FALSE for block/adjustment/transport lines — exclude for per-patient/need cuts.
+      - name: total_cost
+        description: Actual SLAM cost for the grain, £.
+      - name: total_activity
+        description: Sum of dv_activity_count for the grain.

--- a/models/modelling/commissioning/prescribing/int_person_prescribing_cost_monthly.sql
+++ b/models/modelling/commissioning/prescribing/int_person_prescribing_cost_monthly.sql
@@ -1,0 +1,27 @@
+/*
+Primary care prescribing cost per patient per month, from EPD.
+
+Grain: one row per sk_patient_id per activity_month (first of the processing
+period month). Latest submission only (the feed restates each period as a full
+reload — see stg_epd_pc_meds.is_latest_submission), so cost is not double
+counted.
+
+Cost: item_actual_cost is the actual reimbursed spend in pence; divided by 100
+to £ to align with the SUS tariff (£) and MH proxy-cost (£) PODs that feed the
+person cost model.
+
+Patients not matched to NCL (sk_patient_id NULL — out-of-area) are dropped, so
+this joins cleanly to the person dimensions like the other POD summaries.
+*/
+
+select
+    sk_patient_id
+    , date_trunc('month', processing_period_date)   as activity_month
+    , round(sum(item_actual_cost) / 100, 2)         as prescribing_cost
+    , sum(item_count)                               as prescribing_items
+from {{ ref('stg_epd_pc_meds') }}
+where is_latest_submission
+    and sk_patient_id is not null
+group by
+    sk_patient_id
+    , date_trunc('month', processing_period_date)

--- a/models/modelling/commissioning/prescribing/int_person_prescribing_cost_monthly.yml
+++ b/models/modelling/commissioning/prescribing/int_person_prescribing_cost_monthly.yml
@@ -1,0 +1,30 @@
+version: 2
+models:
+  - name: int_person_prescribing_cost_monthly
+    description: |
+      Primary care prescribing cost per patient per month, from EPD
+      (stg_epd_pc_meds). Latest submission only (deduped), cost converted
+      from pence to £. Feeds the person cost model as the prescribing POD.
+    config:
+      meta:
+        owner:
+          name: Eddie Davison
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - sk_patient_id
+              - activity_month
+    columns:
+      - name: sk_patient_id
+        description: DMIC pseudonymised NHS number.
+        data_tests:
+          - not_null
+      - name: activity_month
+        description: First day of the prescribing processing-period month.
+        data_tests:
+          - not_null
+      - name: prescribing_cost
+        description: Actual reimbursed prescribing spend for the patient-month, in £.
+      - name: prescribing_items
+        description: Number of prescription items dispensed in the patient-month.

--- a/models/reporting/commissioning/cost/fct_cost_by_org_month.sql
+++ b/models/reporting/commissioning/cost/fct_cost_by_org_month.sql
@@ -1,0 +1,46 @@
+/*
+SLAM commissioned cost by organisation and month — reporting aggregate for
+the Aligning Resource to Need work.
+
+Grain: activity_month x icb_group x commissioner_code x provider_code x
+service_grouping x service. Built from int_slam_activity_cost (SLAM actual
+cost spine, rolling 12 months).
+
+icb_group splits WNL-commissioned (resident) spend from out-of-sector
+pass-through (other ICBs' residents treated at WNL providers). Use
+in_patch = true for the resource-to-need numerator.
+
+Measures: total_cost / total_activity, plus *_attributable variants
+(is_patient_attributable lines only) so per-patient and need cuts exclude
+block/adjustment/transport.
+
+Prescribing (EPD) is patient-level NCL only with no commissioner/provider —
+it is not included here; see fct_person_cost_by_month for the patient-level
+SLAM+EPD union.
+*/
+
+select
+    activity_month
+    , case
+        when commissioner_code in ('W2U3Z', '93C', 'Z9B2Z') then 'WNL in-patch'
+        else 'Out-of-sector'
+      end                                               as icb_group
+    , commissioner_code in ('W2U3Z', '93C', 'Z9B2Z')    as in_patch
+    , commissioner_code
+    , provider_code
+    , service_grouping
+    , service
+    , sum(total_cost)                                   as total_cost
+    , sum(total_activity)                               as total_activity
+    , sum(iff(is_patient_attributable, total_cost, 0))  as attributable_cost
+    , sum(iff(is_patient_attributable, total_activity, 0)) as attributable_activity
+    , count(distinct sk_patient_id)                     as patients
+from {{ ref('int_slam_activity_cost') }}
+group by
+    activity_month
+    , icb_group
+    , in_patch
+    , commissioner_code
+    , provider_code
+    , service_grouping
+    , service

--- a/models/reporting/commissioning/cost/fct_cost_by_org_month.yml
+++ b/models/reporting/commissioning/cost/fct_cost_by_org_month.yml
@@ -1,0 +1,50 @@
+version: 2
+models:
+  - name: fct_cost_by_org_month
+    description: |
+      SLAM commissioned cost by organisation and month — ICB / sub-ICB /
+      provider totals over time for the Aligning Resource to Need work.
+      Grain: activity_month x icb_group x commissioner_code x provider_code
+      x service_grouping x service. icb_group separates WNL-commissioned
+      (resident) spend from out-of-sector pass-through. SLAM only; see
+      fct_person_cost_by_month for the patient-level SLAM+EPD union.
+    config:
+      meta:
+        owner:
+          name: Eddie Davison
+    columns:
+      - name: activity_month
+        data_tests: [not_null]
+        description: First of the calendar month.
+      - name: icb_group
+        description: WNL in-patch vs Out-of-sector.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['WNL in-patch', 'Out-of-sector']
+      - name: in_patch
+        description: TRUE for WNL-commissioned (resident) spend — the resource-to-need numerator.
+      - name: commissioner_code
+        description: Commissioner ODS code.
+      - name: provider_code
+        description: Provider ODS code.
+      - name: service_grouping
+        description: Crisis / Community / Planned / Excluded / Unmapped.
+      - name: service
+        description: Mid-level service.
+      - name: total_cost
+        description: Actual SLAM cost, £.
+      - name: attributable_cost
+        description: Cost on patient-attributable lines only (excludes block/adjustment/transport).
+      - name: patients
+        description: Distinct patients in the grain (null-patient lines excluded from the count).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - activity_month
+              - commissioner_code
+              - provider_code
+              - service_grouping
+              - service

--- a/models/reporting/commissioning/cost/fct_person_cost_by_month.sql
+++ b/models/reporting/commissioning/cost/fct_person_cost_by_month.sql
@@ -1,0 +1,85 @@
+/*
+Patient-level spend by month and service grouping — headline fact for the
+Aligning Resource to Need analysis.
+
+Grain: sk_patient_id x activity_month x service_grouping x service x
+activity_type x cost_source.
+
+Unions the two cost spines built so far:
+  * SLAM (int_slam_activity_cost) — acute / community actual cost, WNL
+    (NCL + NWL). The agreed spine over SUS tariff.
+  * EPD prescribing (int_person_prescribing_cost_monthly) — GP prescriptions
+    (Community), NCL patients only.
+
+Prescribing is restricted to the SLAM rolling-12-month window so both
+sources cover the same period.
+
+Still to union (sources identified, build pending): GP appointments (OLIDS),
+MH inpatient + contacts (MHSDS — needs the discharge-forward dedup fix),
+community contacts (CSDS), high-cost drugs/devices PLD (LSDrPLCM/LSDePLCM).
+
+is_patient_attributable carries through from the POD mapping — filter it for
+per-patient / spend-vs-need cuts (excludes SLAM block/adjustment lines);
+keep all rows for provider/system totals.
+*/
+
+with slam as (
+    select
+        sk_patient_id
+        , activity_month
+        , service_grouping
+        , service
+        , activity_type
+        , is_patient_attributable
+        , 'SLAM' as cost_source
+        , total_cost
+        , total_activity
+    from {{ ref('int_slam_activity_cost') }}
+)
+
+, window_bounds as (
+    select min(activity_month) as min_month, max(activity_month) as max_month
+    from slam
+)
+
+, rx as (
+    select
+        p.sk_patient_id
+        , p.activity_month
+        , 'Community'        as service_grouping
+        , 'GP Prescriptions' as service
+        , 'Prescribing'      as activity_type
+        , true               as is_patient_attributable
+        , 'EPD'              as cost_source
+        , p.prescribing_cost as total_cost
+        , p.prescribing_items as total_activity
+    from {{ ref('int_person_prescribing_cost_monthly') }} as p
+    cross join window_bounds as w
+    where p.activity_month between w.min_month and w.max_month
+)
+
+, combined as (
+    select * from slam
+    union all
+    select * from rx
+)
+
+select
+    sk_patient_id
+    , activity_month
+    , service_grouping
+    , service
+    , activity_type
+    , is_patient_attributable
+    , cost_source
+    , sum(total_cost)       as total_cost
+    , sum(total_activity)   as total_activity
+from combined
+group by
+    sk_patient_id
+    , activity_month
+    , service_grouping
+    , service
+    , activity_type
+    , is_patient_attributable
+    , cost_source

--- a/models/reporting/commissioning/cost/fct_person_cost_by_month.yml
+++ b/models/reporting/commissioning/cost/fct_person_cost_by_month.yml
@@ -1,0 +1,56 @@
+version: 2
+models:
+  - name: fct_person_cost_by_month
+    description: |
+      Patient-level spend by month and service grouping — headline fact for
+      the Aligning Resource to Need analysis. Unions the SLAM actual-cost
+      spine (int_slam_activity_cost, WNL = NCL+NWL) with EPD prescribing
+      (int_person_prescribing_cost_monthly, NCL), over the SLAM rolling
+      12-month window. Grain: patient x month x service_grouping x service x
+      activity_type x cost_source.
+
+      Pending unions (sources identified): GP appointments (OLIDS), MH
+      inpatient + contacts (MHSDS, post discharge-forward fix), community
+      contacts (CSDS), high-cost drugs/devices PLD.
+
+      Compare against need via stg_reference_gp_weighted_list_size
+      (practice-level NHS weighted population). Filter is_patient_attributable
+      for per-patient cuts.
+    config:
+      meta:
+        owner:
+          name: Eddie Davison
+    columns:
+      - name: sk_patient_id
+        description: DMIC pseudonymised NHS number (NULL for unidentified SLAM activity).
+      - name: activity_month
+        description: First of the calendar month.
+        data_tests:
+          - not_null
+      - name: service_grouping
+        description: Crisis / Community / Planned / Excluded / Unmapped.
+        data_tests:
+          - not_null
+      - name: service
+        description: Mid-level service (A&E, Emergency Admissions, GP Prescriptions, etc.).
+      - name: activity_type
+        description: Detail activity type.
+      - name: is_patient_attributable
+        description: FALSE for SLAM block/adjustment/transport lines.
+      - name: cost_source
+        description: SLAM or EPD — provenance of the cost.
+      - name: total_cost
+        description: Spend for the grain, £.
+      - name: total_activity
+        description: Activity count / prescription items for the grain.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - sk_patient_id
+              - activity_month
+              - service_grouping
+              - service
+              - activity_type
+              - is_patient_attributable
+              - cost_source

--- a/models/reporting/commissioning/cost/fct_person_resource_need.sql
+++ b/models/reporting/commissioning/cost/fct_person_resource_need.sql
@@ -26,6 +26,9 @@ with population as (
         p.registered_sub_icb_code,
         p.registered_sub_icb_name,
         p.residence_imd_decile,
+        p.residence_borough,
+        p.residence_ward_2025_name,
+        p.residence_lsoa_2021_code,
         {{ calculate_age_attributes('p.date_of_birth', 'current_date()') }}
     from {{ ref('dim_person_demographics_basic') }} as p
     where p.flag_current_registered
@@ -43,6 +46,9 @@ select
     pop.registered_sub_icb_code,
     pop.registered_sub_icb_name,
     pop.residence_imd_decile,
+    pop.residence_borough,
+    pop.residence_ward_2025_name,
+    pop.residence_lsoa_2021_code,
     coalesce(cost.actual_cost_12m, 0) as actual_cost_12m,
     curve.expected_cost_per_head      as expected_cost_12m
 from population as pop

--- a/models/reporting/commissioning/cost/fct_person_resource_need.sql
+++ b/models/reporting/commissioning/cost/fct_person_resource_need.sql
@@ -1,0 +1,53 @@
+/*
+Resource vs need at person level — indirect age-sex standardisation.
+
+Assembles, one row per current registered WNL patient:
+  * actual_cost_12m   - patient-attributable spend over the latest 12 months
+    (int_person_cost_12m)
+  * expected_cost_12m - the WNL average cost per head for the patient's age-sex
+    band (int_resource_need_age_sex_curve)
+
+resource_to_need = sum(actual) / sum(expected) for any cut (borough,
+neighbourhood, practice, sub-ICB, age band, sex, ethnicity, IMD). Index > 1 =
+spend above what the age-sex profile predicts at WNL-average rates; < 1 = below.
+Deprivation / morbidity are exposed as cut dimensions, not folded into the weight.
+*/
+
+{{ config(materialized = 'table', tags = ['daily']) }}
+
+with population as (
+    select
+        p.sk_patient_id,
+        p.gender,
+        p.ethnicity,
+        p.practice_code,
+        p.registered_borough,
+        p.registered_neighbourhood_name,
+        p.registered_sub_icb_code,
+        p.registered_sub_icb_name,
+        p.residence_imd_decile,
+        {{ calculate_age_attributes('p.date_of_birth', 'current_date()') }}
+    from {{ ref('dim_person_demographics_basic') }} as p
+    where p.flag_current_registered
+)
+
+select
+    pop.sk_patient_id,
+    pop.gender,
+    pop.age,
+    pop.age_band_nhs as age_band,
+    pop.ethnicity,
+    pop.practice_code,
+    pop.registered_borough,
+    pop.registered_neighbourhood_name,
+    pop.registered_sub_icb_code,
+    pop.registered_sub_icb_name,
+    pop.residence_imd_decile,
+    coalesce(cost.actual_cost_12m, 0) as actual_cost_12m,
+    curve.expected_cost_per_head      as expected_cost_12m
+from population as pop
+left join {{ ref('int_person_cost_12m') }} as cost
+    on pop.sk_patient_id = cost.sk_patient_id
+left join {{ ref('int_resource_need_age_sex_curve') }} as curve
+    on pop.age_band_nhs = curve.age_band
+    and pop.gender = curve.gender

--- a/models/reporting/commissioning/cost/fct_person_resource_need.yml
+++ b/models/reporting/commissioning/cost/fct_person_resource_need.yml
@@ -1,0 +1,33 @@
+version: 2
+models:
+  - name: fct_person_resource_need
+    description: >
+      Resource vs need at person level for the registered WNL population
+      (indirect age-sex standardisation). One row per registered patient with
+      actual 12-month patient-attributable spend and the expected cost (WNL
+      average for their age-sex band, derived empirically from the same
+      population). resource_to_need = sum(actual) / sum(expected) for any cut.
+    config:
+      meta:
+        owner:
+          name: Eddie Davison
+    columns:
+      - name: sk_patient_id
+        description: DMIC pseudonymised NHS number (primary key).
+        data_tests:
+          - not_null
+          - unique
+      - name: gender
+        description: Gender (used with age_band for the cost curve).
+      - name: age
+        description: Age in completed years.
+      - name: age_band
+        description: NHS age band (0-4, 5-14, ... 85+), used for the cost curve.
+      - name: registered_sub_icb_code
+        description: Registered sub-ICB (QMJ = NCL, QRV = NWL).
+      - name: actual_cost_12m
+        description: Patient-attributable spend over the latest 12 months (GBP).
+        data_tests:
+          - not_null
+      - name: expected_cost_12m
+        description: WNL average cost per head for the patient's age-sex band (GBP).

--- a/models/reporting/commissioning/cost/fct_resource_need_by_area.sql
+++ b/models/reporting/commissioning/cost/fct_resource_need_by_area.sql
@@ -1,0 +1,20 @@
+-- Resource vs need summarised by registered geography (sub-ICB x borough x
+-- neighbourhood) for the registered WNL population. Convenience aggregate for
+-- the Aligning Resource to Need pack and dashboards: maps and borough tables.
+-- Roll up to borough / sub-ICB by summing actual + expected (never average the
+-- index - it is sum(actual) / sum(expected)).
+{{ config(materialized = 'table') }}
+
+select
+    registered_sub_icb_code,
+    registered_sub_icb_name,
+    registered_borough,
+    registered_neighbourhood_name,
+    count(*)                              as population,
+    sum(actual_cost_12m)                  as actual_cost_12m,
+    sum(expected_cost_12m)                as expected_cost_12m,
+    div0(sum(actual_cost_12m), sum(expected_cost_12m)) as resource_to_need_index,
+    sum(actual_cost_12m)   / count(*)     as cost_per_head,
+    sum(expected_cost_12m) / count(*)     as expected_per_head
+from {{ ref('fct_person_resource_need') }}
+group by 1, 2, 3, 4

--- a/models/reporting/commissioning/cost/fct_resource_need_by_area.yml
+++ b/models/reporting/commissioning/cost/fct_resource_need_by_area.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: fct_resource_need_by_area
+    description: >
+      Resource vs need by registered geography (sub-ICB x borough x
+      neighbourhood) for the registered WNL population. Convenience aggregate
+      for the Aligning Resource to Need pack and dashboards. Roll up to borough
+      or sub-ICB by summing actual + expected; the index is
+      sum(actual) / sum(expected), never an average of indices.
+    config:
+      meta:
+        owner:
+          name: Eddie Davison
+    columns:
+      - name: registered_sub_icb_code
+        description: Registered sub-ICB (QMJ = NCL, QRV = NWL).
+      - name: registered_borough
+        description: Registered borough (ODS organisation relationships).
+      - name: registered_neighbourhood_name
+        description: Registered neighbourhood.
+      - name: population
+        description: Registered WNL persons in the area.
+        data_tests:
+          - not_null
+      - name: actual_cost_12m
+        description: Patient-attributable spend over the latest 12 months (GBP).
+      - name: expected_cost_12m
+        description: Expected spend from the WNL age-sex cost curve (GBP).
+      - name: resource_to_need_index
+        description: actual / expected. >1 = above age-sex-expected spend.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - registered_sub_icb_code
+              - registered_borough
+              - registered_neighbourhood_name

--- a/models/reporting/commissioning/cost/fct_resource_need_by_ward.sql
+++ b/models/reporting/commissioning/cost/fct_resource_need_by_ward.sql
@@ -1,0 +1,37 @@
+-- Resource vs need by residence ward (2025) for the registered WNL population.
+-- Drives the ward choropleths in the Aligning Resource to Need pack.
+--   weighted_population      = age-sex-weighted population (expected / WNL mean)
+--   spend_per_weighted_head  = actual / weighted population = index x WNL mean,
+--                              i.e. spend per age-weighted head
+--   resource_to_need_index   = actual / expected
+{{ config(materialized = 'table') }}
+
+with base as (
+    select
+        residence_borough,
+        residence_ward_2025_name as ward,
+        count(*)               as population,
+        sum(actual_cost_12m)   as actual_cost_12m,
+        sum(expected_cost_12m) as expected_cost_12m
+    from {{ ref('fct_person_resource_need') }}
+    where residence_ward_2025_name is not null
+    group by 1, 2
+),
+
+overall as (
+    select sum(actual_cost_12m) / sum(population) as mean_cost_per_head
+    from base
+)
+
+select
+    b.residence_borough,
+    b.ward,
+    b.population,
+    b.actual_cost_12m,
+    b.expected_cost_12m,
+    div0(b.actual_cost_12m, b.population)       as cost_per_head,
+    div0(b.expected_cost_12m, o.mean_cost_per_head) as weighted_population,
+    div0(b.actual_cost_12m, b.expected_cost_12m) as resource_to_need_index,
+    o.mean_cost_per_head * div0(b.actual_cost_12m, b.expected_cost_12m) as spend_per_weighted_head
+from base as b
+cross join overall as o

--- a/models/reporting/commissioning/cost/fct_resource_need_by_ward.yml
+++ b/models/reporting/commissioning/cost/fct_resource_need_by_ward.yml
@@ -1,0 +1,29 @@
+version: 2
+models:
+  - name: fct_resource_need_by_ward
+    description: >
+      Resource vs need by residence ward (2025) for the registered WNL
+      population. Drives the ward choropleths in the Aligning Resource to Need
+      pack: cost per head, age-weighted population, spend per weighted head, and
+      the resource-to-need index (actual / expected).
+    config:
+      meta:
+        owner:
+          name: Eddie Davison
+    columns:
+      - name: ward
+        description: Residence ward 2025 name.
+        data_tests:
+          - not_null
+      - name: residence_borough
+        description: Residence local authority / borough.
+      - name: population
+        description: Registered WNL persons resident in the ward.
+      - name: weighted_population
+        description: Age-sex-weighted population (expected cost / WNL mean per head).
+      - name: cost_per_head
+        description: Actual 12-month attributable spend per head (GBP).
+      - name: spend_per_weighted_head
+        description: Spend per age-weighted head (GBP) = index x WNL mean per head.
+      - name: resource_to_need_index
+        description: actual / expected. >1 = above age-sex-expected spend.

--- a/seeds/slam_pod_service_grouping.csv
+++ b/seeds/slam_pod_service_grouping.csv
@@ -1,0 +1,140 @@
+pod_code,activity_type,service,service_grouping,is_patient_attributable,review_note
+AE,A&E,A&E,Crisis,true,
+AANDE,A&E,A&E,Crisis,true,free-text variant of AE
+AANDETYPE3,A&E,A&E,Crisis,true,free-text variant of AE
+AE TYPE1,A&E,A&E,Crisis,true,free-text variant of AE
+AE TYPE3,A&E,A&E,Crisis,true,free-text variant of AE
+NEL,Non-Elective,Emergency Admissions,Crisis,true,
+NELST,Non-Elective,Emergency Admissions,Crisis,true,non-elective short stay
+NELXBD,Non-Elective Excess Bed Days,Emergency Admissions,Crisis,true,
+NELOBD,Non-Elective Bed Days,Emergency Admissions,Crisis,true,
+IPSPECIAL,Non-Elective,Emergency Admissions,Crisis,true,
+NCBPS01T,Non-Elective,Emergency Admissions,Crisis,true,
+AMBSTR,Ambulatory Emergency Care,Emergency Admissions,Crisis,true,
+AMBUE,Ambulatory Emergency Care,Emergency Admissions,Crisis,true,
+AMBOTHER,Ambulatory Emergency Care,Emergency Admissions,Crisis,true,desc unreliable - review
+UNBACC,Critical Care,Critical Care,Crisis,true,critical care follows admission - default Crisis; Ru to confirm
+UNBNCC,Critical Care,Critical Care,Crisis,true,critical care - default Crisis; Ru to confirm
+UNBPCC,Critical Care,Critical Care,Crisis,true,critical care - default Crisis; Ru to confirm
+NCBPSNIC,Critical Care,Critical Care,Crisis,true,neonatal critical care
+CCTRANS,Critical Care,Critical Care,Crisis,true,critical care transfer
+NIC,Critical Care,Critical Care,Crisis,true,
+PIC,Critical Care,Critical Care,Crisis,true,
+ACC,Critical Care,Critical Care,Crisis,true,
+NELNE,Maternity,Maternity,Planned,true,maternity deliveries - Ru to confirm grouping (Crisis vs Planned)
+NELNEXBD,Maternity,Maternity,Planned,true,maternity excess bed days - Ru to confirm grouping
+NELNEXB,Maternity,Maternity,Planned,true,maternity excess bed days - Ru to confirm grouping
+NELNEOBD,Maternity,Maternity,Planned,true,maternity bed days - Ru to confirm grouping
+NCBPS04G,Maternity,Maternity,Planned,true,maternity deliveries - Ru to confirm grouping
+MATPATHAN,Maternity,Maternity,Planned,true,antenatal pathway - Ru to confirm grouping
+MATPATHPN,Maternity,Maternity,Planned,true,postnatal pathway - Ru to confirm grouping
+MATPATH,Maternity,Maternity,Planned,true,maternity pathway - Ru to confirm grouping
+EL,Elective,Acute Elective,Planned,true,
+DC,Day Case,Acute Elective,Planned,true,
+ELXBD,Elective Excess Bed Days,Acute Elective,Planned,true,
+ELOBD,Elective Bed Days,Acute Elective,Planned,true,
+RADAY,Regular Attender,Acute Elective,Planned,true,
+RANIGHT,Regular Attender,Acute Elective,Planned,true,
+DCRE,Regular Attender,Acute Elective,Planned,true,
+IPOBD,Elective Bed Days,Acute Elective,Planned,true,
+IPUNB,Unbundled,Acute Elective,Planned,true,
+WAFA,Ward Attender,Acute Elective,Planned,true,
+WAFUP,Ward Attender,Acute Elective,Planned,true,
+WA,Ward Attender,Acute Elective,Planned,true,
+REHAB,Rehabilitation,Acute Elective,Planned,true,
+UNBREHAB,Rehabilitation,Acute Elective,Planned,true,
+UNBREHA,Rehabilitation,Acute Elective,Planned,true,
+NCBPS38S,Day Case,Acute Elective,Planned,true,
+NCBPS38T,Day Case,Acute Elective,Planned,true,
+NCBPS34A,Day Case,Acute Elective,Planned,true,
+NCBPS37Z,Day Case,Acute Elective,Planned,true,
+NCBPSXXX,Day Case,Acute Elective,Planned,true,
+NCBPS23F,Day Case,Acute Elective,Planned,true,
+OPFASPCL,Outpatient First,Outpatients,Planned,true,
+OPFAMPCL,Outpatient First,Outpatients,Planned,true,
+OPFASPNCL,Outpatient First,Outpatients,Planned,true,
+OPFAMPNCL,Outpatient First,Outpatients,Planned,true,
+OPFASPC,Outpatient First,Outpatients,Planned,true,
+OPFAMPC,Outpatient First,Outpatients,Planned,true,
+OPFA,Outpatient First,Outpatients,Planned,true,
+OPFAHOME,Outpatient First,Outpatients,Planned,true,
+OPFAPREOP,Outpatient First,Outpatients,Planned,true,
+OPFUPSPCL,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUPMPCL,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUPSPNCL,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUPMPNCL,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUPSP,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUPMP,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUPSPNC,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUP,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUPHOME,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUPPREOP,Outpatient Follow-up,Outpatients,Planned,true,
+NCBPS01Y,Outpatient Follow-up,Outpatients,Planned,true,
+NCBPS16Y,Outpatient Follow-up,Outpatients,Planned,true,
+OPPROC,Outpatient Procedure,Outpatients,Planned,true,
+OPPROCFA,Outpatient Procedure,Outpatients,Planned,true,
+OPPROCFUP,Outpatient Procedure,Outpatients,Planned,true,
+OPPROCF,Outpatient Procedure,Outpatients,Planned,true,
+NF2FFA,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+NF2FFUP,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+NF2FFUPNCL,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+NF2FPREOP,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+NCBPS23A,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+TELOPFA,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+TELOPFUP,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+PREOP,Outpatient,Outpatients,Planned,true,
+OP,Outpatient,Outpatients,Planned,true,
+AUDIO,Outpatient,Outpatients,Planned,true,
+EYECAS,Outpatient,Outpatients,Planned,true,
+PHYSIO,Outpatient,Outpatients,Planned,true,
+THERAPIES,Outpatient,Outpatients,Planned,true,
+MDT,Outpatient (MDT),Outpatients,Planned,true,
+AANDG,Advice & Guidance,Outpatients,Planned,true,
+ADVICEGUID,Advice & Guidance,Outpatients,Planned,true,
+UNBRAD,Diagnostics,Diagnostics,Planned,true,
+DALAB,Diagnostics,Diagnostics,Planned,true,
+DAIMG,Diagnostics,Diagnostics,Planned,true,
+DAOTHER,Diagnostics,Diagnostics,Planned,true,
+DA,Diagnostics,Diagnostics,Planned,true,
+DIRACC,Diagnostics,Diagnostics,Planned,true,
+OPUNBRAD,Diagnostics,Diagnostics,Planned,true,
+OPDIAG,Diagnostics,Diagnostics,Planned,true,
+TEST,Diagnostics,Diagnostics,Planned,true,
+SCREEN,Screening,Diagnostics,Planned,true,screening - Community/Diagnostics? Ru to confirm
+BLOCK,High Cost Drugs,High-Cost Drugs & Devices,Planned,false,block contract - not patient-attributable
+DRUG,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,
+DRUGS,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,
+POC,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,
+YOC,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,programme drugs
+DEVICE,Devices,High-Cost Drugs & Devices,Planned,true,
+UNBCHEMO,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
+CHEMOOP,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
+CHEMOIP,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
+UNBCHEM,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
+NCBPS01C,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
+UNBRTHPY,Radiotherapy,High-Cost Drugs & Devices,Planned,true,
+UNBRTHP,Radiotherapy,High-Cost Drugs & Devices,Planned,true,
+UNBPALL,Palliative Care,High-Cost Drugs & Devices,Planned,true,palliative - Community? Ru to confirm grouping
+UNBOTHER,Unbundled Other,High-Cost Drugs & Devices,Planned,true,
+ARD,Renal Dialysis,Renal Dialysis,Planned,true,
+IVF,Specialist,Other Planned,Planned,true,assisted conception
+MAINT,Other,Other Planned,Planned,true,AQP maintenance - review
+COMM,Community,Community Services,Community,true,
+COMMSUB,Community,Community Services,Community,true,
+COMMINIT,Community,Community Services,Community,true,
+OTHER,Patient Transport,Patient Transport,Excluded,false,desc unreliable - likely transport/other; review
+PTSTRANS,Patient Transport,Patient Transport,Excluded,false,
+PTSTRAN,Patient Transport,Patient Transport,Excluded,false,
+HTCS,Patient Transport,Patient Transport,Excluded,false,travel cost scheme
+ADJUSTMENT,Adjustment,Contract Adjustment,Excluded,false,below-the-line contract adjustment
+ADJUSTMEN,Adjustment,Contract Adjustment,Excluded,false,contract adjustment
+ADJUSTM,Adjustment,Contract Adjustment,Excluded,false,contract adjustment
+NAOTHER,Adjustment,Contract Adjustment,Excluded,false,bottom-line adjustment
+CQUIN,CQUIN,Contract Adjustment,Excluded,false,
+AAG,Non-Chargeable,Contract Adjustment,Excluded,false,
+VV,Adjustment,Contract Adjustment,Excluded,false,value variable
+PATIENT,Other,Unmapped,Unmapped,false,unclear code - review
+LAC,Other,Unmapped,Unmapped,false,unclear code - review
+CDC,Other,Unmapped,Unmapped,false,unclear code - review
+CPC,Other,Unmapped,Unmapped,false,unclear code - review
+DIVERTPATH,Other,Unmapped,Unmapped,false,unclear code - review

--- a/seeds/slam_pod_service_grouping.csv
+++ b/seeds/slam_pod_service_grouping.csv
@@ -1,140 +1,144 @@
 pod_code,activity_type,service,service_grouping,is_patient_attributable,review_note
-AE,A&E,A&E,Crisis,true,
+COMM,Community,Community Services,Community,true,ACM: Other / Community / Non-specific contact type
+COMMINIT,Community,Community Services,Community,true,ACM: Other / Community / Initial
+COMMSUB,Community,Community Services,Community,true,ACM: Other / Community / Subsequent
+LAC,Looked After Children,LAC Health Assessments,Community,true,unclear code - review | corrected per ACM | ACM: Other / Looked After Children Health Assessments
+SCREEN,Public Health Screening,Public Health Screening,Community,true,screening - Community/Diagnostics? Ru to confirm | corrected per ACM | ACM: Other / Public Health Screening
 AANDE,A&E,A&E,Crisis,true,free-text variant of AE
 AANDETYPE3,A&E,A&E,Crisis,true,free-text variant of AE
+ACC,Critical Care,Critical Care,Crisis,true,
+AE,A&E,A&E,Crisis,true,ACM: A&E
 AE TYPE1,A&E,A&E,Crisis,true,free-text variant of AE
 AE TYPE3,A&E,A&E,Crisis,true,free-text variant of AE
-NEL,Non-Elective,Emergency Admissions,Crisis,true,
-NELST,Non-Elective,Emergency Admissions,Crisis,true,non-elective short stay
-NELXBD,Non-Elective Excess Bed Days,Emergency Admissions,Crisis,true,
-NELOBD,Non-Elective Bed Days,Emergency Admissions,Crisis,true,
-IPSPECIAL,Non-Elective,Emergency Admissions,Crisis,true,
+AMBHTR,Ambulance Services,Ambulance,Crisis,true,ACM: Other / Ambulance Services / Hear and treat/refer | added from ACM map
+AMBOTHER,Ambulatory Emergency Care,Emergency Admissions,Crisis,true,desc unreliable - review | ACM: Other / Ambulance Services
+AMBSTC,Ambulance Services,Ambulance,Crisis,true,"ACM: Other / Ambulance Services / See, treat and convey | added from ACM map"
+AMBSTR,Ambulance Services,Ambulance,Crisis,true,corrected per ACM | ACM: Other / Ambulance Services / See and treat/refer
+AMBUE,Ambulatory Emergency Care,Emergency Admissions,Crisis,true,ACM: Other / Ambulance Services / Urgent and emergency care
+CCTRANS,Critical Care,Critical Care,Crisis,true,"critical care transfer | ACM: Other / Critical Care Transport (HRG XA06Z, XB08Z)"
+IPSPECIAL,Non-Elective,Emergency Admissions,Crisis,true,ACM: Admitted Patient Care / Generic
 NCBPS01T,Non-Elective,Emergency Admissions,Crisis,true,
-AMBSTR,Ambulatory Emergency Care,Emergency Admissions,Crisis,true,
-AMBUE,Ambulatory Emergency Care,Emergency Admissions,Crisis,true,
-AMBOTHER,Ambulatory Emergency Care,Emergency Admissions,Crisis,true,desc unreliable - review
-UNBACC,Critical Care,Critical Care,Crisis,true,critical care follows admission - default Crisis; Ru to confirm
-UNBNCC,Critical Care,Critical Care,Crisis,true,critical care - default Crisis; Ru to confirm
-UNBPCC,Critical Care,Critical Care,Crisis,true,critical care - default Crisis; Ru to confirm
 NCBPSNIC,Critical Care,Critical Care,Crisis,true,neonatal critical care
-CCTRANS,Critical Care,Critical Care,Crisis,true,critical care transfer
+NEL,Non-Elective,Emergency Admissions,Crisis,true,"ACM: Admitted Patient Care / Non-elective / Emergency (admission method 21-25,28, 2A-2D)"
+NELOBD,Non-Elective Bed Days,Emergency Admissions,Crisis,true,"ACM: Admitted Patient Care / Non-elective / Emergency (admission method 21-25,28, 2A-2D)"
+NELST,Non-Elective,Emergency Admissions,Crisis,true,"non-elective short stay | ACM: Admitted Patient Care / Non-elective / Emergency (admission method 21-25,28, 2A-2D)"
+NELXBD,Non-Elective Excess Bed Days,Emergency Admissions,Crisis,true,"ACM: Admitted Patient Care / Non-elective / Emergency (admission method 21-25,28, 2A-2D)"
 NIC,Critical Care,Critical Care,Crisis,true,
 PIC,Critical Care,Critical Care,Crisis,true,
-ACC,Critical Care,Critical Care,Crisis,true,
-NELNE,Maternity,Maternity,Planned,true,maternity deliveries - Ru to confirm grouping (Crisis vs Planned)
-NELNEXBD,Maternity,Maternity,Planned,true,maternity excess bed days - Ru to confirm grouping
-NELNEXB,Maternity,Maternity,Planned,true,maternity excess bed days - Ru to confirm grouping
-NELNEOBD,Maternity,Maternity,Planned,true,maternity bed days - Ru to confirm grouping
-NCBPS04G,Maternity,Maternity,Planned,true,maternity deliveries - Ru to confirm grouping
-MATPATHAN,Maternity,Maternity,Planned,true,antenatal pathway - Ru to confirm grouping
-MATPATHPN,Maternity,Maternity,Planned,true,postnatal pathway - Ru to confirm grouping
-MATPATH,Maternity,Maternity,Planned,true,maternity pathway - Ru to confirm grouping
-EL,Elective,Acute Elective,Planned,true,
-DC,Day Case,Acute Elective,Planned,true,
-ELXBD,Elective Excess Bed Days,Acute Elective,Planned,true,
-ELOBD,Elective Bed Days,Acute Elective,Planned,true,
-RADAY,Regular Attender,Acute Elective,Planned,true,
-RANIGHT,Regular Attender,Acute Elective,Planned,true,
-DCRE,Regular Attender,Acute Elective,Planned,true,
-IPOBD,Elective Bed Days,Acute Elective,Planned,true,
-IPUNB,Unbundled,Acute Elective,Planned,true,
-WAFA,Ward Attender,Acute Elective,Planned,true,
-WAFUP,Ward Attender,Acute Elective,Planned,true,
-WA,Ward Attender,Acute Elective,Planned,true,
-REHAB,Rehabilitation,Acute Elective,Planned,true,
-UNBREHAB,Rehabilitation,Acute Elective,Planned,true,
-UNBREHA,Rehabilitation,Acute Elective,Planned,true,
-NCBPS38S,Day Case,Acute Elective,Planned,true,
-NCBPS38T,Day Case,Acute Elective,Planned,true,
-NCBPS34A,Day Case,Acute Elective,Planned,true,
-NCBPS37Z,Day Case,Acute Elective,Planned,true,
-NCBPSXXX,Day Case,Acute Elective,Planned,true,
-NCBPS23F,Day Case,Acute Elective,Planned,true,
-OPFASPCL,Outpatient First,Outpatients,Planned,true,
-OPFAMPCL,Outpatient First,Outpatients,Planned,true,
-OPFASPNCL,Outpatient First,Outpatients,Planned,true,
-OPFAMPNCL,Outpatient First,Outpatients,Planned,true,
-OPFASPC,Outpatient First,Outpatients,Planned,true,
-OPFAMPC,Outpatient First,Outpatients,Planned,true,
-OPFA,Outpatient First,Outpatients,Planned,true,
-OPFAHOME,Outpatient First,Outpatients,Planned,true,
-OPFAPREOP,Outpatient First,Outpatients,Planned,true,
-OPFUPSPCL,Outpatient Follow-up,Outpatients,Planned,true,
-OPFUPMPCL,Outpatient Follow-up,Outpatients,Planned,true,
-OPFUPSPNCL,Outpatient Follow-up,Outpatients,Planned,true,
-OPFUPMPNCL,Outpatient Follow-up,Outpatients,Planned,true,
-OPFUPSP,Outpatient Follow-up,Outpatients,Planned,true,
-OPFUPMP,Outpatient Follow-up,Outpatients,Planned,true,
-OPFUPSPNC,Outpatient Follow-up,Outpatients,Planned,true,
-OPFUP,Outpatient Follow-up,Outpatients,Planned,true,
-OPFUPHOME,Outpatient Follow-up,Outpatients,Planned,true,
-OPFUPPREOP,Outpatient Follow-up,Outpatients,Planned,true,
-NCBPS01Y,Outpatient Follow-up,Outpatients,Planned,true,
-NCBPS16Y,Outpatient Follow-up,Outpatients,Planned,true,
-OPPROC,Outpatient Procedure,Outpatients,Planned,true,
-OPPROCFA,Outpatient Procedure,Outpatients,Planned,true,
-OPPROCFUP,Outpatient Procedure,Outpatients,Planned,true,
-OPPROCF,Outpatient Procedure,Outpatients,Planned,true,
-NF2FFA,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
-NF2FFUP,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
-NF2FFUPNCL,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
-NF2FPREOP,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
-NCBPS23A,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
-TELOPFA,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
-TELOPFUP,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
-PREOP,Outpatient,Outpatients,Planned,true,
-OP,Outpatient,Outpatients,Planned,true,
-AUDIO,Outpatient,Outpatients,Planned,true,
-EYECAS,Outpatient,Outpatients,Planned,true,
-PHYSIO,Outpatient,Outpatients,Planned,true,
-THERAPIES,Outpatient,Outpatients,Planned,true,
-MDT,Outpatient (MDT),Outpatients,Planned,true,
+UNBACC,Critical Care,Critical Care,Crisis,true,critical care follows admission - default Crisis; Ru to confirm | ACM: Other / Unbundled Activities / Adult Critical Care (HRG beginning XC)
+UNBNCC,Critical Care,Critical Care,Crisis,true,"critical care - default Crisis; Ru to confirm | ACM: Other / Unbundled Activities / Neonatal Critical Care (HRG beginning XA, except XA06Z)"
+UNBPCC,Critical Care,Critical Care,Crisis,true,"critical care - default Crisis; Ru to confirm | ACM: Other / Unbundled Activities / Paediatric Critical Care (HRG beginning XB, except XB08Z)"
+ADJUSTM,Adjustment,Contract Adjustment,Excluded,false,contract adjustment
+ADJUSTMEN,Adjustment,Contract Adjustment,Excluded,false,contract adjustment
+ADJUSTMENT,Adjustment,Contract Adjustment,Excluded,false,below-the-line contract adjustment | ACM: Non-Activity / Adjustment
+BLOCK,Block,Block,Excluded,false,block contract - not patient-attributable | corrected per ACM | ACM: Non-Activity / Block
+CQUIN,CQUIN,Contract Adjustment,Excluded,false,ACM: Non-Activity / CQUIN
+HTCS,Patient Transport,Patient Transport,Excluded,false,travel cost scheme
+NAOTHER,Adjustment,Contract Adjustment,Excluded,false,bottom-line adjustment | ACM: Non-Activity / Other
+OTHER,Patient Transport,Patient Transport,Excluded,false,desc unreliable - likely transport/other; review | ACM: Other
+PTSTRAN,Patient Transport,Patient Transport,Excluded,false,
+PTSTRANS,Patient Transport,Patient Transport,Excluded,false,ACM: Other / Patient Transport Services
+VV,Adjustment,Contract Adjustment,Excluded,false,value variable
+AAG,Advice and Guidance,Advice and Guidance,Planned,true,corrected per ACM | ACM: Other / Advice And Guidance
 AANDG,Advice & Guidance,Outpatients,Planned,true,
 ADVICEGUID,Advice & Guidance,Outpatients,Planned,true,
-UNBRAD,Diagnostics,Diagnostics,Planned,true,
-DALAB,Diagnostics,Diagnostics,Planned,true,
-DAIMG,Diagnostics,Diagnostics,Planned,true,
-DAOTHER,Diagnostics,Diagnostics,Planned,true,
-DA,Diagnostics,Diagnostics,Planned,true,
-DIRACC,Diagnostics,Diagnostics,Planned,true,
-OPUNBRAD,Diagnostics,Diagnostics,Planned,true,
-OPDIAG,Diagnostics,Diagnostics,Planned,true,
-TEST,Diagnostics,Diagnostics,Planned,true,
-SCREEN,Screening,Diagnostics,Planned,true,screening - Community/Diagnostics? Ru to confirm
-BLOCK,High Cost Drugs,High-Cost Drugs & Devices,Planned,false,block contract - not patient-attributable
-DRUG,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,
-DRUGS,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,
-POC,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,
-YOC,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,programme drugs
-DEVICE,Devices,High-Cost Drugs & Devices,Planned,true,
-UNBCHEMO,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
-CHEMOOP,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
+ARD,Renal Dialysis,Renal Dialysis,Planned,true,ACM: Other / Dialysis (HRG beginning LD) / Adult
+AUDIO,Outpatient,Outpatients,Planned,true,
 CHEMOIP,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
-UNBCHEM,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
+CHEMOOP,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
+CRD,Dialysis,Renal Dialysis,Planned,true,ACM: Other / Dialysis (HRG beginning LD) / Child | added from ACM map
+DA,Diagnostics,Diagnostics,Planned,true,
+DAIMG,Diagnostics,Diagnostics,Planned,true,ACM: Direct Access / Imaging
+DALAB,Diagnostics,Diagnostics,Planned,true,ACM: Direct Access / Lab Testing
+DAOTHER,Diagnostics,Diagnostics,Planned,true,ACM: Direct Access / Other
+DC,Day Case,Acute Elective,Planned,true,ACM: Admitted Patient Care / Elective (admission method 11-13)
+DCRE,Regular Attender,Acute Elective,Planned,true,ACM: Other / Day Care
+DEVICE,Devices,High-Cost Drugs & Devices,Planned,true,ACM: High Cost National Tariff-excluded Devices
+DIRACC,Diagnostics,Diagnostics,Planned,true,
+DRUG,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,ACM: High Cost National Tariff-excluded Drugs
+DRUGS,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,
+EL,Elective,Acute Elective,Planned,true,ACM: Admitted Patient Care / Elective (admission method 11-13)
+ELOBD,Elective Bed Days,Acute Elective,Planned,true,ACM: Admitted Patient Care / Elective (admission method 11-13)
+ELXBD,Elective Excess Bed Days,Acute Elective,Planned,true,ACM: Admitted Patient Care / Elective (admission method 11-13)
+EYECAS,Outpatient,Outpatients,Planned,true,
+IPFCE,Admitted Patient Care,Inpatient (generic),Planned,true,ACM: Admitted Patient Care / Generic | added from ACM map
+IPOBD,Elective Bed Days,Acute Elective,Planned,true,ACM: Admitted Patient Care / Generic
+IPUNB,Unbundled,Acute Elective,Planned,true,
+IVF,Specialist,Other Planned,Planned,true,assisted conception | ACM: Other / IVF Treatment
+MAINT,Other,Other Planned,Planned,true,AQP maintenance - review | ACM: Other / Device Maintenance
+MATPATH,Maternity,Maternity,Planned,true,maternity pathway - Ru to confirm grouping
+MATPATHAN,Maternity,Maternity,Planned,true,antenatal pathway - Ru to confirm grouping | ACM: Other / Maternity Pathway / Ante-natal
+MATPATHPN,Maternity,Maternity,Planned,true,postnatal pathway - Ru to confirm grouping | ACM: Other / Maternity Pathway / Post-natal
+MDT,Outpatient (MDT),Outpatients,Planned,true,ACM: Other / MDT Review
 NCBPS01C,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
-UNBRTHPY,Radiotherapy,High-Cost Drugs & Devices,Planned,true,
+NCBPS01Y,Outpatient Follow-up,Outpatients,Planned,true,
+NCBPS04G,Maternity,Maternity,Planned,true,maternity deliveries - Ru to confirm grouping
+NCBPS16Y,Outpatient Follow-up,Outpatients,Planned,true,
+NCBPS23A,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+NCBPS23F,Day Case,Acute Elective,Planned,true,
+NCBPS34A,Day Case,Acute Elective,Planned,true,
+NCBPS37Z,Day Case,Acute Elective,Planned,true,
+NCBPS38S,Day Case,Acute Elective,Planned,true,
+NCBPS38T,Day Case,Acute Elective,Planned,true,
+NCBPSXXX,Day Case,Acute Elective,Planned,true,
+NELNE,Maternity,Maternity,Planned,true,"maternity deliveries - Ru to confirm grouping (Crisis vs Planned) | ACM: Admitted Patient Care / Non-elective / Non-emergency (admission method 31-32, 81-83)"
+NELNEOBD,Maternity,Maternity,Planned,true,"maternity bed days - Ru to confirm grouping | ACM: Admitted Patient Care / Non-elective / Non-emergency (admission method 31-32, 81-83)"
+NELNEXB,Maternity,Maternity,Planned,true,maternity excess bed days - Ru to confirm grouping
+NELNEXBD,Maternity,Maternity,Planned,true,"maternity excess bed days - Ru to confirm grouping | ACM: Admitted Patient Care / Non-elective / Non-emergency (admission method 31-32, 81-83)"
+NF2FFA,Outpatient Non-Face-to-Face,Outpatients,Planned,true,ACM: Outpatient / Attendance / First
+NF2FFUP,Outpatient Non-Face-to-Face,Outpatients,Planned,true,ACM: Outpatient / Attendance / Follow-up
+NF2FFUPNCL,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+NF2FPREOP,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+OP,Outpatient,Outpatients,Planned,true,
+OPDIAG,Diagnostics,Diagnostics,Planned,true,
+OPFA,Outpatient First,Outpatients,Planned,true,ACM: Outpatient / Attendance / First
+OPFAHOME,Outpatient First,Outpatients,Planned,true,ACM: Outpatient / Attendance / First
+OPFAMPC,Outpatient First,Outpatients,Planned,true,
+OPFAMPCL,Outpatient First,Outpatients,Planned,true,ACM: Outpatient / Attendance / First
+OPFAMPNCL,Outpatient First,Outpatients,Planned,true,ACM: Outpatient / Attendance / First
+OPFAPREOP,Outpatient First,Outpatients,Planned,true,ACM: Outpatient / Attendance / First
+OPFASPC,Outpatient First,Outpatients,Planned,true,
+OPFASPCL,Outpatient First,Outpatients,Planned,true,ACM: Outpatient / Attendance / First
+OPFASPNCL,Outpatient First,Outpatients,Planned,true,ACM: Outpatient / Attendance / First
+OPFUP,Outpatient Follow-up,Outpatients,Planned,true,ACM: Outpatient / Attendance / Follow-up
+OPFUPHOME,Outpatient Follow-up,Outpatients,Planned,true,ACM: Outpatient / Attendance / Follow-up
+OPFUPMP,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUPMPCL,Outpatient Follow-up,Outpatients,Planned,true,ACM: Outpatient / Attendance / Follow-up
+OPFUPMPNCL,Outpatient Follow-up,Outpatients,Planned,true,ACM: Outpatient / Attendance / Follow-up
+OPFUPPREOP,Outpatient Follow-up,Outpatients,Planned,true,ACM: Outpatient / Attendance / Follow-up
+OPFUPSP,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUPSPCL,Outpatient Follow-up,Outpatients,Planned,true,ACM: Outpatient / Attendance / Follow-up
+OPFUPSPNC,Outpatient Follow-up,Outpatients,Planned,true,
+OPFUPSPNCL,Outpatient Follow-up,Outpatients,Planned,true,ACM: Outpatient / Attendance / Follow-up
+OPPROC,Outpatient Procedure,Outpatients,Planned,true,ACM: Outpatient / Procedure / Non-specific attendance type
+OPPROCF,Outpatient Procedure,Outpatients,Planned,true,
+OPPROCFA,Outpatient Procedure,Outpatients,Planned,true,ACM: Outpatient / Procedure / First
+OPPROCFUP,Outpatient Procedure,Outpatients,Planned,true,ACM: Outpatient / Procedure / Follow-up
+OPUNBRAD,Diagnostics,Diagnostics,Planned,true,
+PHYSIO,Outpatient,Outpatients,Planned,true,
+POC,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,ACM: Other / Package of Care
+PREOP,Outpatient,Outpatients,Planned,true,
+RADAY,Regular Attender,Acute Elective,Planned,true,ACM: Admitted Patient Care / Elective (admission method 11-13)
+RANIGHT,Regular Attender,Acute Elective,Planned,true,ACM: Admitted Patient Care / Elective (admission method 11-13)
+REHAB,Rehabilitation,Acute Elective,Planned,true,
+TELOPFA,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+TELOPFUP,Outpatient Non-Face-to-Face,Outpatients,Planned,true,
+TEST,Diagnostics,Diagnostics,Planned,true,ACM: Other / Tests
+THERAPIES,Outpatient,Outpatients,Planned,true,
+UNBCHEM,Chemotherapy,High-Cost Drugs & Devices,Planned,true,
+UNBCHEMO,Chemotherapy,High-Cost Drugs & Devices,Planned,true,ACM: Other / Unbundled Activities / Chemotherapy (unbundled HRGs beginning SB)
+UNBOTHER,Unbundled Other,High-Cost Drugs & Devices,Planned,true,ACM: Other / Unbundled Activities / Other Unbundled Activities
+UNBPALL,Palliative Care,High-Cost Drugs & Devices,Planned,true,palliative - Community? Ru to confirm grouping | ACM: Other / Unbundled Activities / Palliative Care (HRGs beginning SD)
+UNBRAD,Diagnostics,Diagnostics,Planned,true,ACM: Other / Unbundled Activities / Radiology (HRGs beginning RD or RN - previously beginning RA)
+UNBREHA,Rehabilitation,Acute Elective,Planned,true,
+UNBREHAB,Rehabilitation,Acute Elective,Planned,true,ACM: Other / Unbundled Activities / Rehabilitation (HRGs beginning VC)
 UNBRTHP,Radiotherapy,High-Cost Drugs & Devices,Planned,true,
-UNBPALL,Palliative Care,High-Cost Drugs & Devices,Planned,true,palliative - Community? Ru to confirm grouping
-UNBOTHER,Unbundled Other,High-Cost Drugs & Devices,Planned,true,
-ARD,Renal Dialysis,Renal Dialysis,Planned,true,
-IVF,Specialist,Other Planned,Planned,true,assisted conception
-MAINT,Other,Other Planned,Planned,true,AQP maintenance - review
-COMM,Community,Community Services,Community,true,
-COMMSUB,Community,Community Services,Community,true,
-COMMINIT,Community,Community Services,Community,true,
-OTHER,Patient Transport,Patient Transport,Excluded,false,desc unreliable - likely transport/other; review
-PTSTRANS,Patient Transport,Patient Transport,Excluded,false,
-PTSTRAN,Patient Transport,Patient Transport,Excluded,false,
-HTCS,Patient Transport,Patient Transport,Excluded,false,travel cost scheme
-ADJUSTMENT,Adjustment,Contract Adjustment,Excluded,false,below-the-line contract adjustment
-ADJUSTMEN,Adjustment,Contract Adjustment,Excluded,false,contract adjustment
-ADJUSTM,Adjustment,Contract Adjustment,Excluded,false,contract adjustment
-NAOTHER,Adjustment,Contract Adjustment,Excluded,false,bottom-line adjustment
-CQUIN,CQUIN,Contract Adjustment,Excluded,false,
-AAG,Non-Chargeable,Contract Adjustment,Excluded,false,
-VV,Adjustment,Contract Adjustment,Excluded,false,value variable
-PATIENT,Other,Unmapped,Unmapped,false,unclear code - review
-LAC,Other,Unmapped,Unmapped,false,unclear code - review
+UNBRTHPY,Radiotherapy,High-Cost Drugs & Devices,Planned,true,ACM: Other / Unbundled Activities / Radiotherapy (unbundled HRGs beginning SC)
+WA,Ward Attender,Acute Elective,Planned,true,
+WAFA,Ward Attender,Acute Elective,Planned,true,ACM: Outpatient / Attendance / First
+WAFUP,Ward Attender,Acute Elective,Planned,true,ACM: Outpatient / Attendance / Follow-up
+YOC,High Cost Drugs,High-Cost Drugs & Devices,Planned,true,programme drugs | ACM: Other / Year of Care
 CDC,Other,Unmapped,Unmapped,false,unclear code - review
 CPC,Other,Unmapped,Unmapped,false,unclear code - review
 DIVERTPATH,Other,Unmapped,Unmapped,false,unclear code - review
+PATIENT,Other,Unmapped,Unmapped,false,unclear code - review | ACM: Other / Patients

--- a/seeds/slam_pod_service_grouping.yml
+++ b/seeds/slam_pod_service_grouping.yml
@@ -1,0 +1,77 @@
+version: 2
+seeds:
+  - name: slam_pod_service_grouping
+    description: |
+      Maps SLAM point-of-delivery (POD) codes to a 3-level activity
+      hierarchy: service_grouping (Crisis / Community / Planned) >
+      service (Ru's named services, e.g. A&E, Emergency Admissions,
+      Outpatients, Diagnostics) > activity_type (detail). HRG, surfaced
+      separately from the feed, is the finest subcategory below this.
+      One row per POD code.
+
+      Note: the top level is labelled Community (not Ru's original
+      "Neighbourhood") to avoid colliding with the geographic
+      Borough/Neighbourhood dimension in the same analysis. Relabel for Ru
+      sign-off if he prefers "Neighbourhood".
+
+      Keyed on the upper-cased POD code: consumers join on
+      UPPER(TRIM(point_of_delivery_code)). Codes not present here default to
+      activity_type='Other', service_grouping='Unmapped' downstream.
+
+      First-cut mapping from the last-12-months LSPLCM POD profile (top ~30
+      codes carry ~95% of cost; the rest is a long free-text tail). POD
+      descriptions in the feed are unreliable (one random example per code),
+      so mapping is by POD code, not description.
+
+      is_patient_attributable = FALSE flags lines that are real provider
+      spend but not genuine patient-level activity (block contracts,
+      below-the-line adjustments, CQUIN, transport). Filter
+      is_patient_attributable for per-patient / need analysis; keep all rows
+      for provider-total reconciliation.
+
+      review_note flags the judgment calls for sign-off — notably maternity
+      (Crisis vs own line), critical care (follows admission), and the
+      block/adjustment handling.
+    config:
+      meta:
+        owner:
+          name: Eddie Davison
+      column_types:
+        pod_code: varchar
+        activity_type: varchar
+        service: varchar
+        service_grouping: varchar
+        is_patient_attributable: boolean
+        review_note: varchar
+    columns:
+      - name: pod_code
+        description: Upper-cased SLAM POD code. Primary key.
+        data_tests:
+          - not_null
+          - unique
+      - name: activity_type
+        description: Detail level — canonical activity type (A&E, Non-Elective, Elective, Day Case, Outpatient First/Follow-up/Procedure, Diagnostics, Critical Care, High Cost Drugs, etc.).
+        data_tests:
+          - not_null
+      - name: service
+        description: Mid level — Ru's named service (A&E, Emergency Admissions, Critical Care, Maternity, Acute Elective, Outpatients, Diagnostics, High-Cost Drugs & Devices, Renal Dialysis, Community Services, etc.). Nests within service_grouping.
+        data_tests:
+          - not_null
+      - name: service_grouping
+        description: Top level — Aligning-Resource-to-Need category.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Crisis
+                  - Community
+                  - Planned
+                  - Excluded
+                  - Unmapped
+      - name: is_patient_attributable
+        description: FALSE for block/adjustment/transport lines that are real spend but not patient-level activity.
+        data_tests:
+          - not_null
+      - name: review_note
+        description: Free-text flag for judgment calls needing sign-off. Blank when the mapping is unambiguous.


### PR DESCRIPTION
The models for Ru's **Aligning Resource to Need** analysis (NCL + NWL), built on the WNL person spine.

> ⚠️ **Stacked on #834** (the WNL person spine). Base is `feat/wnl-person-spine`; retarget to `main` once #834 merges. Review #834 first.

## Resource (cost)
- `slam_pod_service_grouping` seed — POD → Crisis / Community / Planned.
- `int_slam_activity_cost` — patient-level SLAM actual cost (latest submission), WNL in-patch vs out-of-sector.
- `int_person_prescribing_cost_monthly` — EPD prescribing cost per patient-month (WNL).
- `fct_person_cost_by_month` — person × month × service spend.
- `fct_cost_by_org_month` — org × month spend by service grouping.

## Need + comparison (indirect age-sex standardisation)
- `int_person_cost_12m` — per-person latest-12m attributable spend (shared block).
- `int_resource_need_age_sex_curve` — **empirical WNL age-sex cost curve** (expected cost per head). The "need weights", derived from our own spend — **no external or flaky weighted-list-size feed** (those are all broken/NCL-only upstream).
- `fct_person_resource_need` — actual vs expected per registered patient. `resource_to_need = sum(actual)/sum(expected)`, cuttable by **borough / neighbourhood / practice / sub-ICB / age / sex / ethnicity / IMD**.

## Why an empirical curve, not weighted list size
The published/internal weighted-list-size feeds are unusable: `GP_WEIGHTED_LIST_SIZE` is NCL-only, and every WNL-combined weighted view is broken (the missing `VERSION_2` object — same family #830 removed). The own-data age-sex curve is stable, reproducible, and the right method when you already hold actual spend. Deprivation/morbidity stay as **cut dimensions**, not folded into the weight. A durable published weighted-registration source is a tracked follow-up.

## Validation
`fct_person_resource_need` index by sub-ICB: **NCL 1.05 / NWL 0.97** — both near 1, confirming the cost base is WNL-symmetric (no coverage skew). All models build green with paired ymls (descriptions + key/uniqueness tests).

## Not in this PR
- **LTC-count** cut (OLIDS = NCL + separate governance — deferred, like ethnicity backfill).
- The **pack** (report + WNL choropleths) — separate visual deliverable.
