### PR TITLE
fix(dim_person_care_home): stop misclassifying care home staff as residents

### DIFF
--- a/models/reporting/olids/person_status/dim_person_care_home.sql
+++ b/models/reporting/olids/person_status/dim_person_care_home.sql
@@ -7,26 +7,44 @@
 
 -- Person Care Home Dimension Table
 -- Holds the latest care home/nursing home status for persons
--- Only includes persons who have a recorded care home, nursing home, or temporary care home status
--- Uses CAREHOME_COD, NURSEHOME_COD, and TEMPCARHOME_COD clusters
+-- Only includes persons who have a recorded care home or temporary care home status
+-- Uses CAREHOME_COD and TEMPCARHOME_COD clusters.
+-- NURSEHOME_COD is excluded: its only code is "Employed by nursing home" (a staff
+-- code, not a residency code). A handful of staff codes mixed into CAREHOME_COD
+-- (employed by/matron/residential child or youth care worker) are excluded below
+-- for the same reason - see issue #840.
 
-WITH observation_clusters AS (
+WITH care_home_observations AS (
+    SELECT *
+    FROM (
+        {{ get_observations("'CAREHOME_COD', 'TEMPCARHOME_COD'") }}
+    )
+    WHERE mapped_concept_code NOT IN (
+        '1092561000000107', -- Employed by care home
+        '158944006', -- Matron (old people's home)
+        '158942005', -- Residential child care worker
+        '158943000' -- Residential youth care worker
+    )
+),
+
+observation_clusters AS (
     -- First, collect all cluster IDs and determine residence status for each observation
     SELECT
         o.ID,
         ARRAY_AGG(DISTINCT o.cluster_id) WITHIN GROUP (ORDER BY o.cluster_id) AS cluster_ids,
         -- Pre-calculate residence status based on clusters
+        -- Nursing home is a sub-type of CAREHOME_COD codes (no separate residency
+        -- cluster exists for it), identified by code description
         CASE
+            WHEN ARRAY_CONTAINS('CAREHOME_COD'::VARIANT, ARRAY_AGG(DISTINCT o.cluster_id))
+                AND BOOLOR_AGG(o.code_description ILIKE '%nursing home%') THEN 'Nursing Home'
             WHEN ARRAY_CONTAINS('CAREHOME_COD'::VARIANT, ARRAY_AGG(DISTINCT o.cluster_id)) THEN 'Care Home'
-            WHEN ARRAY_CONTAINS('NURSEHOME_COD'::VARIANT, ARRAY_AGG(DISTINCT o.cluster_id)) THEN 'Nursing Home'
             WHEN ARRAY_CONTAINS('TEMPCARHOME_COD'::VARIANT, ARRAY_AGG(DISTINCT o.cluster_id)) THEN 'Temporary Care Home'
             ELSE NULL
         END AS residence_type,
         -- Determine if temporary
         ARRAY_CONTAINS('TEMPCARHOME_COD'::VARIANT, ARRAY_AGG(DISTINCT o.cluster_id)) AS is_temporary
-    FROM (
-        {{ get_observations("'CAREHOME_COD', 'NURSEHOME_COD', 'TEMPCARHOME_COD'") }}
-    ) o
+    FROM care_home_observations o
     GROUP BY o.ID
 ),
 
@@ -50,9 +68,7 @@ latest_residence_status_per_person AS (
         END AS residence_status,
         oc.cluster_ids AS source_cluster_ids,
         o.ID AS observation_lds_id -- Include for potential tie-breaking
-    FROM (
-        {{ get_observations("'CAREHOME_COD', 'NURSEHOME_COD', 'TEMPCARHOME_COD'") }}
-    ) o
+    FROM care_home_observations o
     JOIN {{ ref('int_patient_person_unique') }} pp
         ON o.patient_id = pp.patient_id
     JOIN observation_clusters oc

--- a/models/reporting/olids/person_status/dim_person_care_home.yml
+++ b/models/reporting/olids/person_status/dim_person_care_home.yml
@@ -1,6 +1,6 @@
 models:
   - name: dim_person_care_home
-    description: Dimension table providing the latest recorded care home/nursing home status for persons who have a recorded residence status. Only includes persons with CAREHOME_COD, NURSEHOME_COD, or TEMPCARHOME_COD records.
+    description: Dimension table providing the latest recorded care home/nursing home status for persons who have a recorded residence status. Only includes persons with CAREHOME_COD or TEMPCARHOME_COD records (excluding staff/employment codes); nursing home is derived as a sub-type of CAREHOME_COD.
     config:
       meta:
         owner:
@@ -8,4 +8,4 @@ models:
     tests:
       - cluster_ids_exist:
           arguments:
-            cluster_ids: CAREHOME_COD, NURSEHOME_COD, TEMPCARHOME_COD
+            cluster_ids: CAREHOME_COD, TEMPCARHOME_COD

--- a/models/reporting/olids/person_status/dim_person_care_home.yml
+++ b/models/reporting/olids/person_status/dim_person_care_home.yml
@@ -9,3 +9,9 @@ models:
       - cluster_ids_exist:
           arguments:
             cluster_ids: CAREHOME_COD, TEMPCARHOME_COD
+    columns:
+      - name: person_id
+        description: Person identifier - one row per person (grain)
+        tests:
+          - unique
+          - not_null


### PR DESCRIPTION
## Problem

\`dim_person_care_home\` used \`NURSEHOME_COD\` to set \`residence_type = 'Nursing Home'\`. Querying the reference codeset shows \`NURSEHOME_COD\`'s only code is \`1092571000000100\` "Employed by nursing home" - a staff code, not a residency code. \`CAREHOME_COD\` also had 4 staff codes mixed in (\`Employed by care home\`, \`Matron (old people's home)\`, \`Residential child care worker\`, \`Residential youth care worker\`).

This meant nursing/care home staff were being counted as residents.

## Fix

- Drop \`NURSEHOME_COD\` from the model entirely - it has no residency codes.
- Exclude the 4 staff codes mixed into \`CAREHOME_COD\` by concept code.
- Since nursing home residency codes (e.g. "Lives in nursing home", "Admission to nursing home") live inside \`CAREHOME_COD\` rather than a separate cluster, \`residence_type = 'Nursing Home'\` is now derived from \`code_description\` matching \`%nursing home%\` within \`CAREHOME_COD\`, preserving the existing \`is_nursing_home_resident\` / \`care_home_type\` distinction used downstream in \`dim_person_status_summary\`.
- Updated the \`cluster_ids_exist\` test and model description accordingly.

\`int_flu_health_social_care_worker\` already used \`NURSEHOME_COD\` correctly as a worker-eligibility code and is unaffected.

Closes #840

## Test plan

- [x] \`dbt build --select dim_person_care_home\` passes (model + \`cluster_ids_exist\` test)
- [x] Spot-checked \`residence_type\` distribution post-fix (Care Home / Nursing Home counts look sane)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved care-home residency classification so “nursing home” records are now identified consistently from care-home observations.
  * Refined which residency records are included, reducing incorrect mixing of staff-role entries with care-home locations.
  * Updated validation rules to match the revised residency categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->