### PR TITLE
feat(ltc-lcs): monthly roll-up and movement tracking for rs and cf cohorts

### DIFF
--- a/models/modelling/olids/programme/ltc_lcs/cf/int_ltc_lcs_cf_monthly_membership.sql
+++ b/models/modelling/olids/programme/ltc_lcs/cf/int_ltc_lcs_cf_monthly_membership.sql
@@ -1,0 +1,70 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['month_end_date']
+    )
+}}
+
+{% set indicators = [
+    ('AF', 'af_61'), ('AF', 'af_62'),
+    ('HF', 'hf_61'),
+    ('CKD', 'ckd_61'), ('CKD', 'ckd_62'), ('CKD', 'ckd_63'), ('CKD', 'ckd_64'),
+    ('CVD', 'cvd_61'), ('CVD', 'cvd_62'), ('CVD', 'cvd_63'), ('CVD', 'cvd_64'), ('CVD', 'cvd_65'), ('CVD', 'cvd_66'),
+    ('DM', 'dm_61'), ('DM', 'dm_62'), ('DM', 'dm_63'), ('DM', 'dm_64'), ('DM', 'dm_65'), ('DM', 'dm_66'),
+    ('HTN', 'htn_61'), ('HTN', 'htn_62'), ('HTN', 'htn_63'), ('HTN', 'htn_65'), ('HTN', 'htn_66'),
+    ('CYP Asthma', 'cyp_ast_61')
+] %}
+
+-- LTC LCS: case-finding indicator membership at each month end, long format.
+-- One row per person per month per case-finding indicator they were in, derived
+-- from the SCD2 snapshot. Feeds the monthly cf summary and movement models.
+--
+-- Table (not incremental): see int_ltc_lcs_rs_monthly_position.sql for rationale
+-- (snapshot uses hard_deletes and sits downstream of frequently-corrected logic).
+
+with snapshot as (
+    select * from {{ ref('fct_person_ltc_lcs_case_finding_snapshot') }}
+),
+
+date_spine as (
+    -- Completed months only; the current in-progress month is excluded.
+    select * from {{ ref('int_date_spine') }}
+    where month_end_date < date_trunc('month', current_date)
+),
+
+position as (
+    select
+        snapshot.*,
+        date_spine.month_end_date,
+        date_spine.year_number,
+        date_spine.month_number,
+        date_spine.quarter_number,
+        date_spine.month_year_label,
+        date_spine.financial_year_label as financial_year,
+        date_spine.financial_quarter_label as financial_quarter
+    from snapshot
+    inner join date_spine
+        -- dbt_valid_from/to are timestamps; compare against the instant after
+        -- month_end_date's day so a change on month-end day still counts.
+        on snapshot.dbt_valid_from < dateadd(day, 1, date_spine.month_end_date)
+        and (snapshot.dbt_valid_to is null or snapshot.dbt_valid_to >= dateadd(day, 1, date_spine.month_end_date))
+)
+
+{%- for condition, indicator in indicators %}
+select
+    person_id,
+    month_end_date,
+    year_number,
+    month_number,
+    quarter_number,
+    month_year_label,
+    financial_year,
+    financial_quarter,
+    '{{ condition }}' as condition,
+    '{{ indicator }}' as indicator_code
+from position
+where in_{{ indicator }}
+{%- if not loop.last %}
+union all
+{%- endif %}
+{%- endfor %}

--- a/models/modelling/olids/programme/ltc_lcs/cf/int_ltc_lcs_cf_monthly_membership.yml
+++ b/models/modelling/olids/programme/ltc_lcs/cf/int_ltc_lcs_cf_monthly_membership.yml
@@ -1,0 +1,39 @@
+version: 2
+models:
+  - name: int_ltc_lcs_cf_monthly_membership
+    description: |
+      LTC LCS case-finding indicator membership at each month end, long format.
+      One row per person per month per case-finding indicator they were in,
+      derived from the SCD2 snapshot (fct_person_ltc_lcs_case_finding_snapshot).
+      Feeds fct_ltc_lcs_cf_monthly_summary and fct_ltc_lcs_cf_monthly_movement.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [person_id, month_end_date, indicator_code]
+    columns:
+      - name: person_id
+        description: Unique person identifier
+        data_tests:
+          - not_null
+      - name: month_end_date
+        description: Last day of the month this membership applies to
+        data_tests:
+          - not_null
+      - name: condition
+        description: Case-finding condition the indicator belongs to
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['AF', 'HF', 'CKD', 'CVD', 'DM', 'HTN', 'CYP Asthma']
+      - name: indicator_code
+        description: Case-finding indicator the person was in as of month end
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['af_61', 'af_62', 'hf_61', 'ckd_61', 'ckd_62', 'ckd_63', 'ckd_64', 'cvd_61', 'cvd_62', 'cvd_63', 'cvd_64', 'cvd_65', 'cvd_66', 'dm_61', 'dm_62', 'dm_63', 'dm_64', 'dm_65', 'dm_66', 'htn_61', 'htn_62', 'htn_63', 'htn_65', 'htn_66', 'cyp_ast_61']

--- a/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_monthly_position.sql
+++ b/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_monthly_position.sql
@@ -1,0 +1,57 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['month_end_date']
+    )
+}}
+
+-- LTC LCS: person-level risk stratification position at each month end.
+-- One row per person per month_end_date they were on the LTC LCS MOC base
+-- population, using the SCD2 snapshot to answer "what was their risk group
+-- as of this month end". Feeds the monthly roll-up and movement models.
+--
+-- Table (not incremental): the snapshot has hard_deletes='invalidate' and sits
+-- downstream of risk-stratification logic that gets corrected often, so a closed
+-- month's answer can legitimately shift between runs. Revisit once snapshot
+-- history is long enough that a full rebuild is no longer cheap.
+
+with snapshot as (
+    select * from {{ ref('fct_person_ltc_lcs_risk_summary_snapshot') }}
+),
+
+date_spine as (
+    -- Completed months only; the current in-progress month is excluded.
+    select * from {{ ref('int_date_spine') }}
+    where month_end_date < date_trunc('month', current_date)
+)
+
+select
+    snapshot.person_id,
+    date_spine.month_end_date,
+    date_spine.year_number,
+    date_spine.month_number,
+    date_spine.quarter_number,
+    date_spine.month_year_label,
+    date_spine.financial_year_label as financial_year,
+    date_spine.financial_quarter_label as financial_quarter,
+    snapshot.af_risk_group,
+    snapshot.asthma_adult_risk_group,
+    snapshot.asthma_cyp_risk_group,
+    snapshot.chd_risk_group,
+    snapshot.ckd_risk_group,
+    snapshot.copd_risk_group,
+    snapshot.diabetes_risk_group,
+    snapshot.hf_risk_group,
+    snapshot.hypertension_risk_group,
+    snapshot.nafld_risk_group,
+    snapshot.pad_risk_group,
+    snapshot.stroke_tia_risk_group,
+    snapshot.overall_risk_group,
+    snapshot.overall_risk_rank,
+    snapshot.in_any_risk_group
+from snapshot
+inner join date_spine
+    -- dbt_valid_from/to are timestamps; compare against the instant after month_end_date's
+    -- day (not midnight at its start) so a change recorded later on month-end day still counts.
+    on snapshot.dbt_valid_from < dateadd(day, 1, date_spine.month_end_date)
+    and (snapshot.dbt_valid_to is null or snapshot.dbt_valid_to >= dateadd(day, 1, date_spine.month_end_date))

--- a/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_monthly_position.yml
+++ b/models/modelling/olids/programme/ltc_lcs/rs/int_ltc_lcs_rs_monthly_position.yml
@@ -1,0 +1,113 @@
+version: 2
+models:
+  - name: int_ltc_lcs_rs_monthly_position
+    description: |
+      Person-level LTC LCS risk stratification position at each month end, derived
+      from the SCD2 snapshot (fct_person_ltc_lcs_risk_summary_snapshot). One row per
+      person per month they were on the LTC LCS MOC base population. Feeds the
+      monthly roll-up (fct_ltc_lcs_rs_monthly_summary) and movement
+      (fct_ltc_lcs_rs_monthly_movement) reporting models.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [person_id, month_end_date]
+    columns:
+      - name: person_id
+        description: Unique person identifier
+        data_tests:
+          - not_null
+      - name: month_end_date
+        description: Last day of the month this position applies to
+        data_tests:
+          - not_null
+      - name: af_risk_group
+        description: Highest AF risk group as of month end (HR/MR); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['HR', 'MR']
+      - name: asthma_adult_risk_group
+        description: Highest Asthma Adult risk group as of month end (HRC/HR/MR/LR); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['HRC', 'HR', 'MR', 'LR']
+      - name: asthma_cyp_risk_group
+        description: Highest Asthma CYP risk group as of month end (HR/LR); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['HR', 'LR']
+      - name: chd_risk_group
+        description: Highest CHD risk group as of month end (HRC/HR/MR); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['HRC', 'HR', 'MR']
+      - name: ckd_risk_group
+        description: Highest CKD risk group as of month end (HRC/HR/MR); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['HRC', 'HR', 'MR']
+      - name: copd_risk_group
+        description: Highest COPD risk group as of month end (HRC/HR/MR); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['HRC', 'HR', 'MR']
+      - name: diabetes_risk_group
+        description: Highest Diabetes risk group as of month end (HRC/HR/MR/MRa/MRb/LR); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['HRC', 'HR', 'MR', 'MRa', 'MRb', 'LR']
+      - name: hf_risk_group
+        description: Highest Heart Failure risk group as of month end (HR/MR); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['HR', 'MR']
+      - name: hypertension_risk_group
+        description: Highest Hypertension risk group as of month end (HRC/HR/MRa/MRb/LR); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['HRC', 'HR', 'MRa', 'MRb', 'LR']
+      - name: nafld_risk_group
+        description: Highest NAFLD risk group as of month end (MR only); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['MR']
+      - name: pad_risk_group
+        description: Highest PAD risk group as of month end (HRC/HR/MR); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['HRC', 'HR', 'MR']
+      - name: stroke_tia_risk_group
+        description: Highest Stroke/TIA risk group as of month end (HRC/HR/MR); null if not stratified
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['HRC', 'HR', 'MR']
+      - name: overall_risk_group
+        description: Highest risk group across all conditions as of month end (HRC/HR/MR/LR); MRa/MRb collapse to MR
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['HRC', 'HR', 'MR', 'LR']
+      - name: overall_risk_rank
+        description: Numeric rank of overall_risk_group as of month end (1=HRC highest, 5=LR lowest)
+        data_tests:
+          - not_null
+      - name: in_any_risk_group
+        description: True if person was in any condition risk group as of month end
+        data_tests:
+          - not_null

--- a/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_cf_monthly_movement.sql
+++ b/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_cf_monthly_movement.sql
@@ -1,0 +1,74 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['to_month_end_date']
+    )
+}}
+
+-- LTC LCS: month-to-month movement into and out of each case-finding indicator.
+-- One row per person per indicator per to_month_end_date, comparing membership at
+-- to_month_end_date against the immediately prior populated month:
+--   Entered  - member this month, not the prior populated month (or first month)
+--   Retained - member both this month and the prior populated month
+--   Exited   - member the prior populated month, not this month
+-- Populated months come from the membership grain, so a one-month gap is handled
+-- correctly rather than assuming contiguous calendar months.
+--
+-- Table (not incremental): see int_ltc_lcs_cf_monthly_membership.sql for rationale.
+
+with membership as (
+    select person_id, month_end_date, condition, indicator_code
+    from {{ ref('int_ltc_lcs_cf_monthly_membership') }}
+),
+
+populated_months as (
+    select
+        month_end_date,
+        lag(month_end_date) over (order by month_end_date) as prior_month_end_date,
+        lead(month_end_date) over (order by month_end_date) as next_month_end_date
+    from (select distinct month_end_date from membership)
+),
+
+-- Members this month: Retained if also a member the prior populated month, else Entered.
+entered_retained as (
+    select
+        m.person_id,
+        m.condition,
+        m.indicator_code,
+        m.month_end_date as to_month_end_date,
+        case
+            when pm.prior_month_end_date is null then 'Entered'
+            when prior.person_id is not null then 'Retained'
+            else 'Entered'
+        end as movement_type
+    from membership m
+    inner join populated_months pm on m.month_end_date = pm.month_end_date
+    left join membership prior
+        on prior.person_id = m.person_id
+        and prior.indicator_code = m.indicator_code
+        and prior.month_end_date = pm.prior_month_end_date
+),
+
+-- Members a given month who are not members the next populated month: Exited at that next month.
+exited as (
+    select
+        m.person_id,
+        m.condition,
+        m.indicator_code,
+        pm.next_month_end_date as to_month_end_date,
+        'Exited' as movement_type
+    from membership m
+    inner join populated_months pm on m.month_end_date = pm.month_end_date
+    left join membership nxt
+        on nxt.person_id = m.person_id
+        and nxt.indicator_code = m.indicator_code
+        and nxt.month_end_date = pm.next_month_end_date
+    where pm.next_month_end_date is not null
+      and nxt.person_id is null
+)
+
+select person_id, condition, indicator_code, to_month_end_date, movement_type
+from entered_retained
+union all
+select person_id, condition, indicator_code, to_month_end_date, movement_type
+from exited

--- a/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_cf_monthly_movement.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_cf_monthly_movement.yml
@@ -1,0 +1,42 @@
+version: 2
+models:
+  - name: fct_ltc_lcs_cf_monthly_movement
+    description: |
+      Month-to-month movement into and out of each LTC LCS case-finding indicator.
+      One row per person per indicator per to_month_end_date, comparing membership
+      at to_month_end_date against the immediately prior populated month.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [person_id, indicator_code, to_month_end_date]
+    columns:
+      - name: person_id
+        description: Unique person identifier
+        data_tests:
+          - not_null
+      - name: indicator_code
+        description: Case-finding indicator this movement record is for
+        data_tests:
+          - not_null
+      - name: condition
+        description: Case-finding condition the indicator belongs to
+        data_tests:
+          - not_null
+      - name: to_month_end_date
+        description: Month end this movement record is reporting into
+        data_tests:
+          - not_null
+      - name: movement_type
+        description: |
+          Change in indicator membership vs the prior populated month. 'Entered'
+          (member this month, not prior / first month), 'Retained' (member both),
+          'Exited' (member prior month, not this month).
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['Entered', 'Retained', 'Exited']

--- a/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_cf_monthly_summary.sql
+++ b/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_cf_monthly_summary.sql
@@ -1,0 +1,27 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['month_end_date']
+    )
+}}
+
+-- LTC LCS: monthly case-finding population counts per indicator, grouped by
+-- condition, for dashboard trend charts. One row per month_end_date x condition
+-- x indicator. A person in multiple indicators is counted once per indicator.
+
+select
+    month_end_date,
+    month_year_label,
+    financial_year,
+    financial_quarter,
+    condition,
+    indicator_code,
+    count(distinct person_id) as person_count
+from {{ ref('int_ltc_lcs_cf_monthly_membership') }}
+group by
+    month_end_date,
+    month_year_label,
+    financial_year,
+    financial_quarter,
+    condition,
+    indicator_code

--- a/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_cf_monthly_summary.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/fct_ltc_lcs_cf_monthly_summary.yml
@@ -1,0 +1,39 @@
+version: 2
+models:
+  - name: fct_ltc_lcs_cf_monthly_summary
+    description: |
+      Monthly LTC LCS case-finding population counts per indicator, grouped by
+      condition, for dashboard trend charts. One row per month_end_date x
+      condition x indicator. A person in multiple indicators is counted once per
+      indicator, so counts are not additive across rows within a month.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [month_end_date, condition, indicator_code]
+    columns:
+      - name: month_end_date
+        description: Last day of the month this count applies to
+        data_tests:
+          - not_null
+      - name: month_year_label
+        description: Display label for the month, e.g. 'JUN 2026'
+      - name: financial_year
+        description: UK financial year label (April-March), e.g. '2026/27'
+      - name: financial_quarter
+        description: UK financial quarter label, e.g. 'Q1'
+      - name: condition
+        description: Case-finding condition the indicator belongs to
+        data_tests:
+          - not_null
+      - name: indicator_code
+        description: Case-finding indicator
+        data_tests:
+          - not_null
+      - name: person_count
+        description: Distinct count of persons in this indicator as of month end
+        data_tests:
+          - not_null

--- a/models/reporting/olids/programme/ltc_lcs/cf/fct_person_ltc_lcs_case_finding.sql
+++ b/models/reporting/olids/programme/ltc_lcs/cf/fct_person_ltc_lcs_case_finding.sql
@@ -1,0 +1,44 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['person_id']
+    )
+}}
+
+-- LTC LCS case-finding cohort membership, one row per person currently in any
+-- case-finding indicator. Lean person-level fact used as the snapshot source for
+-- monthly cohort tracking; excludes the in_any_case_finding=false base population
+-- carried by dim_ltc_lcs_cf_summary.
+
+select
+    person_id,
+    in_af_61,
+    in_af_62,
+    in_hf_61,
+    in_ckd_61,
+    in_ckd_62,
+    in_ckd_63,
+    in_ckd_64,
+    in_cvd_61,
+    in_cvd_62,
+    in_cvd_63,
+    in_cvd_64,
+    in_cvd_65,
+    in_cvd_66,
+    in_dm_61,
+    in_dm_62,
+    in_dm_63,
+    in_dm_64,
+    in_dm_65,
+    in_dm_66,
+    in_htn_61,
+    in_htn_62,
+    in_htn_63,
+    in_htn_65,
+    in_htn_66,
+    in_cyp_ast_61,
+    in_any_case_finding,
+    case_finding_count,
+    current_timestamp()::timestamp_ntz as table_refresh_date
+from {{ ref('dim_ltc_lcs_cf_summary') }}
+where in_any_case_finding = true

--- a/models/reporting/olids/programme/ltc_lcs/cf/fct_person_ltc_lcs_case_finding.yml
+++ b/models/reporting/olids/programme/ltc_lcs/cf/fct_person_ltc_lcs_case_finding.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: fct_person_ltc_lcs_case_finding
+    description: |
+      LTC LCS case-finding cohort membership. One row per person currently in any
+      case-finding indicator (in_any_case_finding = true). Each in_* column flags
+      membership of a specific case-finding indicator. Snapshot source for the
+      monthly cohort-tracking models.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.at_least_one:
+          arguments:
+            column_name: person_id
+    columns:
+      - name: person_id
+        description: Unique person identifier
+        data_tests:
+          - not_null
+          - unique
+      - name: in_any_case_finding
+        description: Always true in this model (cohort is filtered to case-finding members)
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true]
+      - name: case_finding_count
+        description: Count of case-finding indicators the person is in
+        data_tests:
+          - not_null
+      - name: table_refresh_date
+        description: Timestamp when the row was built
+        data_tests:
+          - not_null

--- a/models/reporting/olids/programme/ltc_lcs/rs/fct_ltc_lcs_rs_monthly_movement.sql
+++ b/models/reporting/olids/programme/ltc_lcs/rs/fct_ltc_lcs_rs_monthly_movement.sql
@@ -1,0 +1,98 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['to_month_end_date']
+    )
+}}
+
+-- LTC LCS: person-level month-to-month movement between overall risk groups.
+-- One row per person per to_month_end_date, comparing their risk group at
+-- to_month_end_date against their risk group at their immediately prior
+-- *populated* month (not necessarily the prior calendar month, since gaps are
+-- possible if a person's snapshot row was invalidated and later reopened).
+--
+-- Table (not incremental): see int_ltc_lcs_rs_monthly_position.sql for why. Person
+-- x month volume is currently small; revisit once it compounds across more months.
+
+with positions as (
+    select * from {{ ref('int_ltc_lcs_rs_monthly_position') }}
+),
+
+distinct_months as (
+    select distinct month_end_date from positions
+),
+
+populated_months as (
+    select
+        month_end_date,
+        lead(month_end_date) over (order by month_end_date) as next_month_end_date
+    from distinct_months
+),
+
+person_month_with_lag as (
+    select
+        person_id,
+        month_end_date,
+        overall_risk_group,
+        overall_risk_rank,
+        lag(month_end_date) over (partition by person_id order by month_end_date) as prior_month_end_date,
+        lag(overall_risk_group) over (partition by person_id order by month_end_date) as prior_risk_group,
+        lag(overall_risk_rank) over (partition by person_id order by month_end_date) as prior_risk_rank,
+        row_number() over (partition by person_id order by month_end_date desc) as recency_rank
+    from positions
+),
+
+-- Every month a person actually appears in: their risk group vs. wherever they
+-- were the last time they appeared (null from_* fields means new entrant).
+entrants_and_continuers as (
+    select
+        person_id,
+        month_end_date as to_month_end_date,
+        prior_month_end_date as from_month_end_date,
+        prior_risk_group as from_risk_group,
+        prior_risk_rank as from_risk_rank,
+        overall_risk_group as to_risk_group,
+        overall_risk_rank as to_risk_rank
+    from person_month_with_lag
+),
+
+-- The month after a person's last appearance, if that later month has actually
+-- happened (next_month_end_date is not null) — confirms they dropped off rather
+-- than just not having reached a future month yet.
+leavers as (
+    select
+        pm.person_id,
+        pop.next_month_end_date as to_month_end_date,
+        pm.month_end_date as from_month_end_date,
+        pm.overall_risk_group as from_risk_group,
+        pm.overall_risk_rank as from_risk_rank,
+        cast(null as varchar) as to_risk_group,
+        cast(null as number) as to_risk_rank
+    from person_month_with_lag pm
+    inner join populated_months pop on pm.month_end_date = pop.month_end_date
+    where pm.recency_rank = 1
+      and pop.next_month_end_date is not null
+),
+
+combined as (
+    select * from entrants_and_continuers
+    union all
+    select * from leavers
+)
+
+select
+    person_id,
+    to_month_end_date,
+    from_month_end_date,
+    from_risk_group,
+    from_risk_rank,
+    to_risk_group,
+    to_risk_rank,
+    case
+        when from_month_end_date is null then 'New entrant'
+        when to_risk_group is null then 'Left register'
+        when to_risk_rank > from_risk_rank then 'Improved'
+        when to_risk_rank < from_risk_rank then 'Worsened'
+        else 'No change'
+    end as movement_type
+from combined

--- a/models/reporting/olids/programme/ltc_lcs/rs/fct_ltc_lcs_rs_monthly_movement.yml
+++ b/models/reporting/olids/programme/ltc_lcs/rs/fct_ltc_lcs_rs_monthly_movement.yml
@@ -1,0 +1,46 @@
+version: 2
+models:
+  - name: fct_ltc_lcs_rs_monthly_movement
+    description: |
+      Person-level month-to-month movement between LTC LCS overall risk groups.
+      One row per person per to_month_end_date, comparing their risk group at
+      to_month_end_date against their risk group at their immediately prior
+      populated month.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [person_id, to_month_end_date]
+    columns:
+      - name: person_id
+        description: Unique person identifier
+        data_tests:
+          - not_null
+      - name: to_month_end_date
+        description: Month end this movement record is reporting into
+        data_tests:
+          - not_null
+      - name: from_month_end_date
+        description: Month end of the person's immediately prior populated month; null for new entrants
+      - name: from_risk_group
+        description: Overall risk group at from_month_end_date; null for new entrants
+      - name: from_risk_rank
+        description: Overall risk rank at from_month_end_date (1=HRC highest, 5=LR lowest); null for new entrants
+      - name: to_risk_group
+        description: Overall risk group at to_month_end_date; null if the person left the register this month
+      - name: to_risk_rank
+        description: Overall risk rank at to_month_end_date; null if the person left the register this month
+      - name: movement_type
+        description: |
+          Classification of the change between from_risk_group and to_risk_group.
+          'New entrant' (no prior month), 'Left register' (no current month, present
+          prior month), 'Improved' (rank increased = lower risk), 'Worsened' (rank
+          decreased = higher risk), 'No change' (same rank).
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['New entrant', 'Left register', 'Improved', 'Worsened', 'No change']

--- a/models/reporting/olids/programme/ltc_lcs/rs/fct_ltc_lcs_rs_monthly_summary.sql
+++ b/models/reporting/olids/programme/ltc_lcs/rs/fct_ltc_lcs_rs_monthly_summary.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['month_end_date']
+    )
+}}
+
+-- LTC LCS: monthly population counts by overall risk group, for dashboard trend
+-- charts. One row per month_end_date x overall_risk_group.
+
+select
+    month_end_date,
+    month_year_label,
+    financial_year,
+    financial_quarter,
+    overall_risk_group,
+    count(distinct person_id) as person_count
+from {{ ref('int_ltc_lcs_rs_monthly_position') }}
+group by
+    month_end_date,
+    month_year_label,
+    financial_year,
+    financial_quarter,
+    overall_risk_group

--- a/models/reporting/olids/programme/ltc_lcs/rs/fct_ltc_lcs_rs_monthly_summary.yml
+++ b/models/reporting/olids/programme/ltc_lcs/rs/fct_ltc_lcs_rs_monthly_summary.yml
@@ -1,0 +1,36 @@
+version: 2
+models:
+  - name: fct_ltc_lcs_rs_monthly_summary
+    description: |
+      Monthly LTC LCS population counts by overall risk group, for dashboard trend
+      charts. One row per month_end_date x overall_risk_group.
+    config:
+      meta:
+        owner:
+          name: EddieDavison92
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [month_end_date, overall_risk_group]
+    columns:
+      - name: month_end_date
+        description: Last day of the month this count applies to
+        data_tests:
+          - not_null
+      - name: month_year_label
+        description: Display label for the month, e.g. 'JUN 2026'
+      - name: financial_year
+        description: UK financial year label (April-March), e.g. '2026/27'
+      - name: financial_quarter
+        description: UK financial quarter label, e.g. 'Q1'
+      - name: overall_risk_group
+        description: Highest risk group across all conditions (HRC/HR/MR/LR)
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['HRC', 'HR', 'MR', 'LR']
+      - name: person_count
+        description: Distinct count of persons in this risk group as of month end
+        data_tests:
+          - not_null

--- a/snapshots/fct_person_ltc_lcs_case_finding_snapshot.yml
+++ b/snapshots/fct_person_ltc_lcs_case_finding_snapshot.yml
@@ -1,0 +1,50 @@
+snapshots:
+  - name: fct_person_ltc_lcs_case_finding_snapshot
+    relation: ref('fct_person_ltc_lcs_case_finding')
+    description: >
+      Historical snapshot of LTC LCS case-finding cohort membership per person so
+      movement into and out of each case-finding indicator can be tracked over time.
+      A new row opens when any indicator flag changes; people who drop out of all
+      case-finding indicators are closed via hard_deletes: invalidate. Tracks the
+      indicator flags only; in_any_case_finding and case_finding_count are derived
+      from them and captured as at the start of each stint.
+    config:
+      strategy: check
+      unique_key: [person_id]
+      updated_at: table_refresh_date
+      hard_deletes: invalidate
+      check_cols:
+        - in_af_61
+        - in_af_62
+        - in_hf_61
+        - in_ckd_61
+        - in_ckd_62
+        - in_ckd_63
+        - in_ckd_64
+        - in_cvd_61
+        - in_cvd_62
+        - in_cvd_63
+        - in_cvd_64
+        - in_cvd_65
+        - in_cvd_66
+        - in_dm_61
+        - in_dm_62
+        - in_dm_63
+        - in_dm_64
+        - in_dm_65
+        - in_dm_66
+        - in_htn_61
+        - in_htn_62
+        - in_htn_63
+        - in_htn_65
+        - in_htn_66
+        - in_cyp_ast_61
+    columns:
+      - name: person_id
+        description: "Unique person identifier; snapshot unique_key."
+        data_tests:
+          - not_null
+      - name: dbt_valid_from
+        description: "When this snapshot version became active (SCD2)."
+        data_tests:
+          - not_null


### PR DESCRIPTION
Closes #810.

Turns the LTC LCS risk-stratification (rs) and case-finding (cf) snapshots into monthly point-in-time roll-ups and month-over-month movement tracking, per #810 ("track the population moving between groups" + "monthly roll-up view for dashboard").

## Risk stratification (rs)
Built on the existing `fct_person_ltc_lcs_risk_summary_snapshot`:
- `int_ltc_lcs_rs_monthly_position` — person × month risk position (point-in-time off the SCD2 snapshot)
- `fct_ltc_lcs_rs_monthly_summary` — month × overall risk group counts (dashboard trend)
- `fct_ltc_lcs_rs_monthly_movement` — per-person Improved / Worsened / No change / New entrant / Left register

## Case finding (cf)
cf had no snapshot, so this adds the daily SCD2 half plus the monthly models:
- `fct_person_ltc_lcs_case_finding` — lean person cohort (filters `dim_ltc_lcs_cf_summary` to `in_any_case_finding`; leaves the dashboard dim untouched); snapshot source
- `fct_person_ltc_lcs_case_finding_snapshot` — daily SCD2, `check` on the 25 indicator flags, `hard_deletes: invalidate`
- `int_ltc_lcs_cf_monthly_membership` — person × month × condition × indicator (long)
- `fct_ltc_lcs_cf_monthly_summary` — month × condition × indicator person counts
- `fct_ltc_lcs_cf_monthly_movement` — per-indicator Entered / Retained / Exited

cf movement is per-indicator entry/exit (indicators are independent booleans, unlike rs's ordinal risk group), and the summary is per indicator grouped by condition.

## Design notes
- Monthly models cap at the last **completed** month (`< date_trunc('month', current_date)`), so an in-progress month never shows as a data point.
- Materialised as `table` (not incremental): the snapshots use `hard_deletes: invalidate` and sit downstream of frequently-corrected logic, so a closed month's point-in-time answer can legitimately shift. Cheap to rebuild at current volume; revisit once history is deep.

## Verification
- `dbt build` green; **55 tests pass** across both pipelines.
- rs verified on 3 months of real snapshot history (Apr–Jun 2026); a traced person's MR→HR shows correctly as "Worsened"; no movement fan-out.
- cf snapshot seeded (470,339 people / 609,164 indicator memberships); unpivot + point-in-time logic verified via ad-hoc as-of query. cf monthly models will populate as the new snapshot accrues history (the snapshot yml is auto-picked-up by the existing `dbt snapshot` run).

## Caveat
rs movement is only continuous from late May 2026 onward: an upstream OLIDS `person_id` rotation on 2026-05-27 (a one-off, advised as resolved) means April IDs don't carry into May in the snapshot. Models report the snapshot faithfully; this affects the earliest rs history only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monthly reporting for LTC LCS case-finding and risk stratification, including population counts and month-to-month movement views.
  * Introduced person-level monthly views that show indicator membership, risk position, and changes over time.
  * Added a refreshed person-level case-finding dataset for current membership tracking.

* **Bug Fixes**
  * Improved monthly calculations to use completed months only, avoiding partial current-month results.
  * Added data checks to help keep monthly summaries, movements, and membership counts consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->